### PR TITLE
[FEAT] #30 - 앞면,뒷면에 따라 움직이는 바 구현

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreation.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreation.storyboard
@@ -36,29 +36,6 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="KAZ-zy-W47">
-                                <rect key="frame" x="28" y="114" width="114" height="2"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="2" id="5a5-lK-ETW"/>
-                                </constraints>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="sfi-BS-fFq">
-                                    <size key="itemSize" width="128" height="128"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="aAV-62-4sK">
-                                        <rect key="frame" x="-7" y="0.0" width="128" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="SGD-1f-teK">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
-                            </collectionView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nZD-YQ-z5l">
                                 <rect key="frame" x="319" y="66" width="67" height="31"/>
                                 <state key="normal" title="Button"/>
@@ -123,27 +100,34 @@
                                     <action selector="pushToCardCompletionView:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="VWF-RT-J7D"/>
                                 </connections>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gBB-hQ-SyS">
+                                <rect key="frame" x="33" y="114" width="32" height="2"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="2" id="Hm8-0C-mLG"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="9qw-H6-IIh" secondAttribute="trailing" constant="28" id="2E8-4e-xYZ"/>
                             <constraint firstAttribute="bottom" secondItem="9qw-H6-IIh" secondAttribute="bottom" constant="34" id="3yV-Y5-mgf"/>
-                            <constraint firstItem="SCY-6J-7gG" firstAttribute="top" secondItem="KAZ-zy-W47" secondAttribute="bottom" constant="18" id="4vF-oG-vQt"/>
                             <constraint firstItem="nZD-YQ-z5l" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="22" id="4ws-5t-Weg"/>
                             <constraint firstItem="q7k-m0-xi2" firstAttribute="top" secondItem="tbX-yg-azh" secondAttribute="bottom" constant="23" id="6Aa-rV-V5M"/>
                             <constraint firstItem="tbX-yg-azh" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="23" id="7U3-Fg-7iD"/>
                             <constraint firstItem="q7k-m0-xi2" firstAttribute="leading" secondItem="tbX-yg-azh" secondAttribute="leading" id="7jD-u0-Xt5"/>
                             <constraint firstItem="SCY-6J-7gG" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="8ME-sT-obO"/>
+                            <constraint firstItem="gBB-hQ-SyS" firstAttribute="leading" secondItem="q7k-m0-xi2" secondAttribute="leading" constant="5" id="DHT-gt-rBw"/>
                             <constraint firstItem="yP6-6Y-BPF" firstAttribute="leading" secondItem="q7k-m0-xi2" secondAttribute="trailing" constant="30" id="GED-As-RPG"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="nZD-YQ-z5l" secondAttribute="trailing" constant="28" id="LS9-Ox-DcH"/>
                             <constraint firstItem="9qw-H6-IIh" firstAttribute="top" secondItem="SCY-6J-7gG" secondAttribute="bottom" constant="28" id="OXo-Pk-oAs"/>
-                            <constraint firstItem="KAZ-zy-W47" firstAttribute="leading" secondItem="q7k-m0-xi2" secondAttribute="leading" id="YyP-Qy-yTD"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="SCY-6J-7gG" secondAttribute="trailing" id="aGQ-yr-mMG"/>
                             <constraint firstItem="tbX-yg-azh" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="28" id="cvz-4j-mTX"/>
-                            <constraint firstItem="KAZ-zy-W47" firstAttribute="trailing" secondItem="yP6-6Y-BPF" secondAttribute="trailing" id="d8b-Vk-bCG"/>
+                            <constraint firstItem="SCY-6J-7gG" firstAttribute="top" secondItem="gBB-hQ-SyS" secondAttribute="bottom" constant="18" id="ljP-7j-j3g"/>
                             <constraint firstItem="yP6-6Y-BPF" firstAttribute="centerY" secondItem="q7k-m0-xi2" secondAttribute="centerY" id="nzF-Df-pZK"/>
-                            <constraint firstItem="KAZ-zy-W47" firstAttribute="top" secondItem="q7k-m0-xi2" secondAttribute="bottom" constant="3" id="tTa-kQ-SWn"/>
+                            <constraint firstItem="gBB-hQ-SyS" firstAttribute="trailing" secondItem="q7k-m0-xi2" secondAttribute="trailing" constant="-5" id="oCK-mc-g4U"/>
+                            <constraint firstItem="gBB-hQ-SyS" firstAttribute="top" secondItem="q7k-m0-xi2" secondAttribute="bottom" constant="3" id="s9h-ZW-dSo"/>
                             <constraint firstItem="9qw-H6-IIh" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="28" id="wtH-NH-2Nj"/>
                         </constraints>
                     </view>
@@ -154,7 +138,7 @@
                         <outlet property="completeButton" destination="9qw-H6-IIh" id="5sg-Bu-nnt"/>
                         <outlet property="creationTextLabel" destination="tbX-yg-azh" id="yEi-1t-EcY"/>
                         <outlet property="frontTextLabel" destination="q7k-m0-xi2" id="F41-zp-Pzb"/>
-                        <outlet property="textStatusCollectionView" destination="KAZ-zy-W47" id="HUX-cF-ptL"/>
+                        <outlet property="statusMovedView" destination="gBB-hQ-SyS" id="M3E-Ph-HP4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
@@ -69,7 +69,7 @@ extension BackCardCreationCollectionViewCell {
             $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
             $0.backgroundColor = Colors.inputBlack.color
             $0.textColor = Colors.white.color
-            $0.layer.cornerRadius = 10
+            $0.layer.cornerRadius = 5
         }
     }
     private func initUITextFieldList() {

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -90,13 +90,13 @@ extension FrontCardCreationCollectionViewCell {
             $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
             $0.backgroundColor = Colors.inputBlack.color
             $0.textColor = Colors.white.color
-            $0.layer.cornerRadius = 10
+            $0.layer.cornerRadius = 5
         }
         _ = optionalInfoList.map {
             $0.font = UIFont(name: "AppleSDGothicNeo-Medium", size: 16)
             $0.backgroundColor = Colors.inputBlack.color
             $0.textColor = Colors.white.color
-            $0.layer.cornerRadius = 10
+            $0.layer.cornerRadius = 5
         }
     }
     private func initUITextFieldList() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
@@ -15,12 +15,14 @@ class CardCreationViewController: UIViewController {
     private var frontCardIsEmpty = true
     private var backCardIsEmpty = true
     private var restoreFrameYValue = 0.0
+    private var currentIndex = 0
     
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var creationTextLabel: UILabel!
     @IBOutlet weak var frontTextLabel: UILabel!
     @IBOutlet weak var backTextLabel: UILabel!
-    @IBOutlet weak var textStatusCollectionView: UICollectionView!
+
+    @IBOutlet weak var statusMovedView: UIView!
     @IBOutlet weak var cardCreationCollectionView: UICollectionView!
     @IBOutlet weak var closeButton: UIButton!
     @IBOutlet weak var completeButton: UIButton!
@@ -34,6 +36,7 @@ class CardCreationViewController: UIViewController {
         setNotification()
         touchViewToDownKeyboard()
         initRestoreFrameYValue()
+        setTextLabelGesture()
     }
     
     // MARK: - @IBAction Properties
@@ -50,21 +53,22 @@ class CardCreationViewController: UIViewController {
 
 extension CardCreationViewController {
     private func setUI() {
-        view.backgroundColor = .black
-        cardCreationCollectionView.backgroundColor = .black
+        view.backgroundColor = Colors.black.color
+        statusMovedView.backgroundColor = Colors.white.color
+        cardCreationCollectionView.backgroundColor = Colors.black.color
         cardCreationCollectionView.isPagingEnabled = true
         
         creationTextLabel.text = "명함 생성"
         creationTextLabel.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 26)
-        creationTextLabel.textColor = .white
+        creationTextLabel.textColor = Colors.white.color
         
         frontTextLabel.text = "앞면"
         frontTextLabel.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 20)
-        frontTextLabel.textColor = .white
+        frontTextLabel.textColor = Colors.white.color
         
         backTextLabel.text = "뒷면"
         backTextLabel.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 20)
-        backTextLabel.textColor = .white
+        backTextLabel.textColor = Colors.hint.color
         
         closeButton.setImage(UIImage(named: "closeBlack24Dp"), for: .normal)
         closeButton.setTitle("", for: .normal)
@@ -83,11 +87,6 @@ extension CardCreationViewController {
         cardCreationCollectionView.showsVerticalScrollIndicator = false
     }
     private func registerCell() {
-//        let textStatusCollectionViewlayout = textStatusCollectionView.collectionViewLayout as? UICollectionViewFlowLayout
-//        textStatusCollectionViewlayout?.scrollDirection = .horizontal
-//        textStatusCollectionView.delegate = self
-//        textStatusCollectionView.dataSource = self
-        
         cardCreationCollectionView.delegate = self
         cardCreationCollectionView.dataSource = self
 
@@ -106,6 +105,14 @@ extension CardCreationViewController {
     }
     private func initRestoreFrameYValue() {
         restoreFrameYValue = self.view.frame.origin.y
+    }
+    private func setTextLabelGesture() {
+        let tapFrontTextLabelGesture = UITapGestureRecognizer(target: self, action: #selector(dragToFront))
+        frontTextLabel.addGestureRecognizer(tapFrontTextLabelGesture)
+        frontTextLabel.isUserInteractionEnabled = true
+        let tapBackTextLabelGesture = UITapGestureRecognizer(target: self, action: #selector(dragToBack))
+        backTextLabel.addGestureRecognizer(tapBackTextLabelGesture)
+        backTextLabel.isUserInteractionEnabled = true
     }
     @objc
     private func setFrontCardIsEmpty(_ notification: Notification) {
@@ -148,11 +155,56 @@ extension CardCreationViewController {
             }
         }
     }
+    @objc
+    private func dragToBack() {
+        let indexPath = IndexPath(item: 1, section: 0)
+        cardCreationCollectionView.scrollToItem(at: indexPath, at: .left, animated: true)
+        if currentIndex == 0 {
+            UIView.animate(withDuration: 0.2) {
+                self.statusMovedView.transform = CGAffineTransform(translationX: self.backTextLabel.frame.origin.x - self.statusMovedView.frame.origin.x + 5, y: 0)
+            }
+            currentIndex = 1
+            self.frontTextLabel.textColor = Colors.hint.color
+            self.backTextLabel.textColor = Colors.white.color
+        }
+    }
+    @objc
+    private func dragToFront() {
+        if currentIndex == 1 {
+            let indexPath = IndexPath(item: 0, section: 0)
+            cardCreationCollectionView.scrollToItem(at: indexPath, at: .left, animated: true)
+            UIView.animate(withDuration: 0.2) {
+                self.statusMovedView.transform = .identity
+            }
+            currentIndex = 0
+            self.frontTextLabel.textColor = Colors.white.color
+            self.backTextLabel.textColor = Colors.hint.color
+        }
+    }
 }
 
 // MARK: - UICollectionViewDelegate
 
-extension CardCreationViewController: UICollectionViewDelegate { }
+extension CardCreationViewController: UICollectionViewDelegate {
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        let targetIndex = targetContentOffset.pointee.x / scrollView.frame.size.width
+        if targetIndex == 1 && currentIndex == 0 {
+            UIView.animate(withDuration: 0.2) {
+                self.statusMovedView.transform = CGAffineTransform(translationX: self.backTextLabel.frame.origin.x - self.statusMovedView.frame.origin.x + 5, y: 0)
+            }
+            currentIndex = 1
+            self.frontTextLabel.textColor = Colors.hint.color
+            self.backTextLabel.textColor = Colors.white.color
+        } else if targetIndex == 0 && currentIndex == 1 {
+            UIView.animate(withDuration: 0.2) {
+                self.statusMovedView.transform = .identity
+            }
+            currentIndex = 0
+            self.frontTextLabel.textColor = Colors.white.color
+            self.backTextLabel.textColor = Colors.hint.color
+        }
+    }
+}
 
 // MARK: - UICollectionViewDataSource
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#30

🌱 작업한 내용
- collection view 의 index(앞면,뒷면) 에 따라서 움직이는 view 구현
- 앞면, 뒷면 라벨에 collection view 이동 이벤트 추가

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|상단바 이동|<img src ="https://user-images.githubusercontent.com/69136340/136216244-f5708273-2b54-4a09-89fc-94edef92d294.mp4" width ="250">|




## 📮 관련 이슈
- Resolved: #30
