### PR TITLE
[FEAT] #47 - 리스트뷰 세부 기능 수정과 추가 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
 - trailing_whitespace
 - nesting
 - function_parameter_count
+- function_body_length
 excluded:
 - Pods
 - NADA-iOS-forRelease/Sources/AppDelegate.swift

--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -10,4 +10,6 @@ import Foundation
 extension Notification.Name {
     static let frontCardtextFieldIsEmpty = Notification.Name("frontCardtextFieldIsEmpty")
     static let backCardtextFieldIsEmpty = Notification.Name("backCardtextFieldIsEmpty")
+    static let deleteTabBar = NSNotification.Name("deleteTabBar")
+    static let expressTabBar = NSNotification.Name("expressTabBar")
 }

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardList.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardList.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,22 +37,32 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="T3m-AC-fcX">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="T3m-AC-fcX">
                                 <rect key="frame" x="0.0" y="126" width="375" height="652"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="separatorColor" red="0.1764705882352941" green="0.1764705882352941" blue="0.1764705882352941" alpha="1" colorSpace="calibratedRGB"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <color key="sectionIndexBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9r1-kP-Lgu">
+                                <rect key="frame" x="0.0" y="125" width="375" height="1"/>
+                                <color key="backgroundColor" name="black5"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="Nns-gn-uHB"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="WSB-Wx-Jzl" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="23" id="0hJ-g2-MU9"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="9r1-kP-Lgu" secondAttribute="trailing" id="4fU-0h-0EB"/>
+                            <constraint firstItem="9r1-kP-Lgu" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="B19-Hv-G1e"/>
                             <constraint firstItem="lgy-Hk-Rnf" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="28" id="B8X-eH-xhw"/>
                             <constraint firstItem="lgy-Hk-Rnf" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="25" id="C0T-wZ-eqo"/>
                             <constraint firstItem="T3m-AC-fcX" firstAttribute="top" secondItem="WSB-Wx-Jzl" secondAttribute="bottom" constant="27" id="CyX-fp-vib"/>
                             <constraint firstItem="T3m-AC-fcX" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="E4W-Ke-YqM"/>
+                            <constraint firstItem="T3m-AC-fcX" firstAttribute="top" secondItem="9r1-kP-Lgu" secondAttribute="bottom" id="UlC-ol-x58"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="T3m-AC-fcX" secondAttribute="trailing" id="dlD-OW-QE5"/>
                             <constraint firstItem="WSB-Wx-Jzl" firstAttribute="leading" secondItem="lgy-Hk-Rnf" secondAttribute="trailing" constant="20" id="egP-Mf-usK"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="T3m-AC-fcX" secondAttribute="bottom" id="pk7-m1-pre"/>
@@ -63,10 +74,13 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="45" y="84"/>
+            <point key="canvasLocation" x="44" y="83.497536945812811"/>
         </scene>
     </scenes>
     <resources>
         <image name="arrowBackWhite" width="24" height="24"/>
+        <namedColor name="black5">
+            <color red="0.054901960784313725" green="0.054901960784313725" blue="0.054901960784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardList.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardList.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CustomTabBar.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CustomTabBar.storyboard
@@ -11,7 +11,7 @@
         <!--Custom Tab Bar Controller-->
         <scene sceneID="oiP-4J-oIi">
             <objects>
-                <tabBarController storyboardIdentifier="CustomTabBarController" automaticallyAdjustsScrollViewInsets="NO" id="eRZ-8q-um0" customClass="CustomTabBarController" customModule="NADA_iOS_forRelease" customModuleProvider="target" sceneMemberID="viewController">
+                <tabBarController storyboardIdentifier="CustomTabBarController" automaticallyAdjustsScrollViewInsets="NO" hidesBottomBarWhenPushed="YES" id="eRZ-8q-um0" customClass="CustomTabBarController" customModule="NADA_iOS_forRelease" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="IDI-Fs-Cpv">
                         <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CustomTabBar.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CustomTabBar.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eRZ-8q-um0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eRZ-8q-um0">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/Main/Front.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/Main/Front.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HRL-Ko-Eah">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HRL-Ko-Eah">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.swift
@@ -34,8 +34,10 @@ class CardListTableViewCell: UITableViewCell {
         
         if pinButton.currentImage == pinImage {
             pinButton.setImage(UIImage(named: "pushPinBlack"), for: UIControl.State.normal)
+            self.contentView.backgroundColor = UIColor.black1
         } else {
             pinButton.setImage(UIImage(named: "pushPinBlackFilled"), for: UIControl.State.normal)
+            self.contentView.backgroundColor = UIColor.listSelectedBlack3
         }
     }
     

--- a/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.swift
@@ -41,6 +41,10 @@ class CardListTableViewCell: UITableViewCell {
         }
     }
     
+    @IBAction func reorderButtonClicked(_ sender: Any) {
+        
+    }
+    
     func initData(title: String,
                   date: String) {
         titleLabel.text = title

--- a/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.xib
@@ -12,14 +12,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" restorationIdentifier="CardListTableViewCell" selectionStyle="default" indentationWidth="10" reuseIdentifier="CardListTableViewCell" id="KGk-i7-Jjw" customClass="CardListTableViewCell" customModule="NADA_iOS_forRelease" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="75"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="76"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="75"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="76"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yIn-ze-IzC">
-                        <rect key="frame" x="20" y="23" width="29" height="29"/>
+                        <rect key="frame" x="20" y="23.5" width="29" height="29"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="29" id="NcB-Mp-NdW"/>
                             <constraint firstAttribute="width" secondItem="yIn-ze-IzC" secondAttribute="height" multiplier="1:1" id="n51-UO-1hE"/>
@@ -32,16 +32,16 @@
                         </connections>
                     </button>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="fxb-f5-q8B">
-                        <rect key="frame" x="74" y="18" width="112.5" height="39"/>
+                        <rect key="frame" x="74" y="18" width="112.5" height="40"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="SOPT 28기 명함" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WhY-hv-bQn">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SOPT 28기 명함" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WhY-hv-bQn">
                                 <rect key="frame" x="0.0" y="0.0" width="112.5" height="19.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="2021/08/29" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zzG-S2-u68">
-                                <rect key="frame" x="0.0" y="25.5" width="64" height="13.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2021/08/29" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zzG-S2-u68">
+                                <rect key="frame" x="0.0" y="25.5" width="64" height="14.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="12"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -49,19 +49,29 @@
                         </subviews>
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aro-Pe-dpu">
-                        <rect key="frame" x="331" y="25.5" width="24" height="24"/>
+                        <rect key="frame" x="331" y="26" width="24" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="aro-Pe-dpu" secondAttribute="height" multiplier="1:1" id="Nbg-qg-3DP"/>
                         </constraints>
                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                         <state key="normal" image="reorderBlack"/>
                     </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gqs-4Z-ROz">
+                        <rect key="frame" x="0.0" y="75" width="375" height="1"/>
+                        <color key="backgroundColor" name="black5"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="1" id="YPk-j1-87L"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <color key="backgroundColor" name="black1"/>
                 <constraints>
+                    <constraint firstAttribute="bottom" secondItem="Gqs-4Z-ROz" secondAttribute="bottom" id="G5h-lf-K8n"/>
                     <constraint firstItem="fxb-f5-q8B" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="18" id="Pzw-9u-c1n"/>
+                    <constraint firstAttribute="trailing" secondItem="Gqs-4Z-ROz" secondAttribute="trailing" id="Ybc-qm-H5k"/>
                     <constraint firstAttribute="trailing" secondItem="aro-Pe-dpu" secondAttribute="trailing" constant="20" id="g04-zC-1b5"/>
                     <constraint firstItem="fxb-f5-q8B" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="h7g-Gp-EUo"/>
+                    <constraint firstItem="Gqs-4Z-ROz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="mQV-9z-bMe"/>
                     <constraint firstItem="aro-Pe-dpu" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="oEj-EE-E7s"/>
                     <constraint firstItem="fxb-f5-q8B" firstAttribute="leading" secondItem="yIn-ze-IzC" secondAttribute="trailing" constant="25" id="oPT-fp-v3P"/>
                     <constraint firstItem="yIn-ze-IzC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="pkP-1K-YTF"/>
@@ -74,7 +84,7 @@
                 <outlet property="pinButton" destination="yIn-ze-IzC" id="SA9-Pv-lPP"/>
                 <outlet property="titleLabel" destination="WhY-hv-bQn" id="qs9-h3-TQD"/>
             </connections>
-            <point key="canvasLocation" x="132" y="80"/>
+            <point key="canvasLocation" x="131.15942028985509" y="79.6875"/>
         </tableViewCell>
     </objects>
     <resources>
@@ -83,6 +93,9 @@
         <image name="reorderBlack" width="24" height="24"/>
         <namedColor name="black1">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="black5">
+            <color red="0.054901960784313725" green="0.054901960784313725" blue="0.054901960784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -56,7 +57,7 @@
                         <state key="normal" image="reorderBlack"/>
                     </button>
                 </subviews>
-                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <color key="backgroundColor" name="black1"/>
                 <constraints>
                     <constraint firstItem="fxb-f5-q8B" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="18" id="Pzw-9u-c1n"/>
                     <constraint firstAttribute="trailing" secondItem="aro-Pe-dpu" secondAttribute="trailing" constant="20" id="g04-zC-1b5"/>
@@ -80,5 +81,8 @@
         <image name="pushPinBlack" width="28.5" height="28.5"/>
         <image name="pushPinBlackFilled" width="28.5" height="28.5"/>
         <image name="reorderBlack" width="24" height="24"/>
+        <namedColor name="black1">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardList/CardListTableViewCell.xib
@@ -55,6 +55,9 @@
                         </constraints>
                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                         <state key="normal" image="reorderBlack"/>
+                        <connections>
+                            <action selector="reorderButtonClicked:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="7av-2F-TNo"/>
+                        </connections>
                     </button>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gqs-4Z-ROz">
                         <rect key="frame" x="0.0" y="75" width="375" height="1"/>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
@@ -20,12 +20,15 @@ class CardListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationBackSwipeMotion()
+        
         setCardList()
         
         cardListTableView.register(CardListTableViewCell.nib(), forCellReuseIdentifier: "CardListTableViewCell")
         
         cardListTableView.delegate = self
         cardListTableView.dataSource = self
+        
     }
     
     // MARK: - IBAction Properties
@@ -44,6 +47,10 @@ class CardListViewController: UIViewController {
             CardListDataModel(title: "SOPT 28기 명함", date: "2021/08/29"),
             CardListDataModel(title: "SOPT 28기 명함", date: "2021/08/29")
         ])
+    }
+    
+    func navigationBackSwipeMotion() {
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = nil
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
@@ -24,16 +24,12 @@ class CardListViewController: UIViewController {
         navigationBackSwipeMotion()
         
         setCardList()
+        setLongPressGesture()
         
         cardListTableView.register(CardListTableViewCell.nib(), forCellReuseIdentifier: "CardListTableViewCell")
         
         cardListTableView.delegate = self
         cardListTableView.dataSource = self
-        
-        self.cardListTableView.allowsSelection = false
-        
-        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(longPressCalled(gestureRecognizer:)))
-        cardListTableView.addGestureRecognizer(longPressGesture)
 
     }
     
@@ -59,6 +55,13 @@ class CardListViewController: UIViewController {
             CardListDataModel(title: "SOPT 28기 명함", date: "2021/08/29"),
             CardListDataModel(title: "SOPT 28기 명함", date: "2021/08/29")
         ])
+    }
+    
+    func setLongPressGesture() {
+        self.cardListTableView.allowsSelection = false
+        
+        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(longPressCalled(gestureRecognizer:)))
+        cardListTableView.addGestureRecognizer(longPressGesture)
     }
     
     func navigationBackSwipeMotion() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
@@ -57,7 +57,7 @@ class CardListViewController: UIViewController {
 // MARK: - UITableViewDelegate
 extension CardListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 75
+        return 76   
     }
     
     // Swipe Action

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CustomTabBar/CustomTabBarController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CustomTabBar/CustomTabBarController.swift
@@ -65,7 +65,7 @@ class CustomTabBarController: UITabBarController {
     }
     
     // MARK: - Functions
-    public func setTabBarHidden(_ isHidden: Bool, animated: Bool) {
+    private func setTabBarHidden(_ isHidden: Bool, animated: Bool) {
         let block = {
             self.customTabBar.alpha = isHidden ? 0 : 1
             self.additionalSafeAreaInsets = isHidden ? .zero : UIEdgeInsets(top: 0, left: 0, bottom: self.tabBarHeight + self.bottomSpacing, right: 0)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CustomTabBar/CustomTabBarController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CustomTabBar/CustomTabBarController.swift
@@ -62,6 +62,15 @@ class CustomTabBarController: UITabBarController {
         customTabBar.setGradient(color1: UIColor(red: 1, green: 1, blue: 1, alpha: 0.35),
                                  color2: UIColor(red: 1, green: 1, blue: 1, alpha: 0.15))
         customTabBar.setBlur()
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(nextClickRecieved),
+                                               name: NSNotification.Name("deleteTabBar"),
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(prviousClickRecieved),
+                                               name: NSNotification.Name("expressTabBar"),
+                                               object: nil)
     }
     
     // MARK: - Functions
@@ -113,6 +122,7 @@ class CustomTabBarController: UITabBarController {
         customTabBar.tintColor = tintColor
     }
 }
+
 // MARK: - CardTabBarDelegate
 extension CustomTabBarController: CardTabBarDelegate {
     func cardTabBar(_ sender: CustomTabBar, didSelectItemAt index: Int) {
@@ -120,7 +130,19 @@ extension CustomTabBarController: CardTabBarDelegate {
     }
 }
 
-// MARK: - Extensions
+// MARK: - CustomTabBarController Extensions
+extension CustomTabBarController {
+    // 탭바의 hidden 상태처리 함수
+    @objc func nextClickRecieved() {
+        setTabBarHidden(true, animated: false)
+    }
+    
+    @objc func prviousClickRecieved() {
+        setTabBarHidden(false, animated: false)
+    }
+}
+
+// MARK: - CustomTabBar Extensions
 extension CustomTabBar {
     // 그라데이션 효과 적용
     func setGradient(color1: UIColor, color2: UIColor) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CustomTabBar/CustomTabBarController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CustomTabBar/CustomTabBarController.swift
@@ -65,11 +65,11 @@ class CustomTabBarController: UITabBarController {
         
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(nextClickRecieved),
-                                               name: NSNotification.Name("deleteTabBar"),
+                                               name: .deleteTabBar,
                                                object: nil)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(prviousClickRecieved),
-                                               name: NSNotification.Name("expressTabBar"),
+                                               name: .expressTabBar,
                                                object: nil)
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -63,6 +63,7 @@ class FrontViewController: UIViewController {
     // 명함 리스트 뷰로 화면 전환
     @IBAction func pushToCardListView(_ sender: Any) {
         let nextVC = UIStoryboard(name: Const.Storyboard.Name.cardList, bundle: nil).instantiateViewController(identifier: Const.ViewController.Identifier.cardListViewController)
+        
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -59,10 +59,18 @@ class FrontViewController: UIViewController {
         
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NotificationCenter.default.post(name: NSNotification.Name("expressTabBar"), object: nil)
+        
+    }
+    
     // MARK: - @IBAction Properties
     // 명함 리스트 뷰로 화면 전환
     @IBAction func pushToCardListView(_ sender: Any) {
         let nextVC = UIStoryboard(name: Const.Storyboard.Name.cardList, bundle: nil).instantiateViewController(identifier: Const.ViewController.Identifier.cardListViewController)
+    
+        NotificationCenter.default.post(name: NSNotification.Name("deleteTabBar"), object: nil)
         
         self.navigationController?.pushViewController(nextVC, animated: true)
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#47

🌱 작업한 내용
- 리스트뷰에서는 탭바가 보이지 않도록 수정 -> 일단 지금은 필요없긴 한데 이미 만들어 놓은거니깐..
- 백 스와이프 제스처로 pop하는 기능 구현 
- Drag & Drop으로 cell을 정렬하는 기능 구현 -> 가장 중요한 부분!
- 테이블뷰 셀 구분선 수정
- 핀 고정시 해당 셀의 배경색이 같이 변하도록 수정

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![Simulator Screen Recording - iPhone 12 mini - 2021-10-31 at 00 11 23](https://user-images.githubusercontent.com/69389288/139538874-4cbd5af7-3605-4f48-912a-7e6a1778d233.gif) |


## 📮 관련 이슈
- Resolved: #47 
