### PR TITLE
[FIX] #89 - 카드 셀 뒷면 수정 & bottomSheet 수정

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Assets/Colors.xcassets/quaternary.colorset/Contents.json
+++ b/NADA-iOS-forRelease/Resouces/Assets/Colors.xcassets/quaternary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x76",
-          "green" : "0x6C",
-          "red" : "0x66"
+          "blue" : "118",
+          "green" : "108",
+          "red" : "102"
         }
       },
       "idiom" : "universal"

--- a/NADA-iOS-forRelease/Resouces/Assets/Colors.xcassets/secondary.colorset/Contents.json
+++ b/NADA-iOS-forRelease/Resouces/Assets/Colors.xcassets/secondary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF5",
-          "green" : "0xF3",
-          "red" : "0xF1"
+          "blue" : "245",
+          "green" : "243",
+          "red" : "241"
         }
       },
       "idiom" : "universal"

--- a/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
+++ b/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
@@ -119,4 +119,19 @@ extension UIColor {
             return UIColor(white: 1.0, alpha: 1.0)
         }
     }
+    
+    @nonobjc class var bottomDimmedBackground: UIColor {
+        if #available(iOS 13, *) {
+            return UIColor { (traitCollection: UITraitCollection) -> UIColor in
+                if traitCollection.userInterfaceStyle == .light {
+                    return UIColor(white: 0.0, alpha: 0.4)
+                } else {
+                    return UIColor(white: 0.0, alpha: 0.6)
+                }
+            }
+        } else {
+            return UIColor(white: 0.0, alpha: 0.4)
+        }
+    }
+
 }

--- a/NADA-iOS-forRelease/Resouces/Storyboards/Group/GroupEdit.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/Group/GroupEdit.storyboard
@@ -17,7 +17,7 @@
         <!--Group Edit View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController storyboardIdentifier="GroupEditViewController" id="Y6W-OH-hqX" customClass="GroupEditViewController" customModule="NADA_iOS_forRelease" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="GroupEditViewController" hidesBottomBarWhenPushed="YES" id="Y6W-OH-hqX" customClass="GroupEditViewController" customModule="NADA_iOS_forRelease" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/Group/GroupEdit.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/Group/GroupEdit.storyboard
@@ -6,7 +6,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -57,7 +56,7 @@
                                         </connections>
                                     </button>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" name="background"/>
                                 <constraints>
                                     <constraint firstItem="mXl-nw-qPB" firstAttribute="centerY" secondItem="eav-KN-kMH" secondAttribute="centerY" id="4S4-cU-g9Y"/>
                                     <constraint firstAttribute="bottom" secondItem="tEu-WC-9Nx" secondAttribute="bottom" constant="11" id="6C5-Bp-ykI"/>
@@ -73,11 +72,11 @@
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" alwaysBounceVertical="YES" scrollEnabled="NO" bouncesZoom="NO" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="8fV-n9-E62">
                                 <rect key="frame" x="0.0" y="104" width="375" height="674"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" name="background"/>
                             </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="eav-KN-kMH" secondAttribute="trailing" id="a6h-10-vxg"/>
                             <constraint firstItem="8fV-n9-E62" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="ifP-wA-ht6"/>
@@ -100,11 +99,11 @@
     <resources>
         <image name="iconAdd" width="30" height="30"/>
         <image name="iconArrow" width="24" height="24"/>
+        <namedColor name="background">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="secondary">
             <color red="0.16862745098039217" green="0.17647058823529413" blue="0.19215686274509805" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/More/More.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/More/More.storyboard
@@ -41,8 +41,11 @@
                                 </constraints>
                             </view>
                             <tableView autoresizesSubviews="NO" clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" alwaysBounceVertical="YES" scrollEnabled="NO" bouncesZoom="NO" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="WnB-Ge-3qg">
-                                <rect key="frame" x="0.0" y="104" width="375" height="625"/>
+                                <rect key="frame" x="0.0" y="104" width="375" height="466"/>
                                 <color key="backgroundColor" name="textBox"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="466" id="F5a-T6-amW"/>
+                                </constraints>
                             </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
@@ -52,7 +55,6 @@
                             <constraint firstAttribute="trailing" secondItem="wb8-4G-Pj8" secondAttribute="trailing" id="GkL-m8-eem"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="WnB-Ge-3qg" secondAttribute="trailing" id="VnA-Ln-U3x"/>
                             <constraint firstItem="wb8-4G-Pj8" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="aaY-jG-Ypx"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="WnB-Ge-3qg" secondAttribute="bottom" id="cgm-yU-GKk"/>
                             <constraint firstItem="WnB-Ge-3qg" firstAttribute="top" secondItem="wb8-4G-Pj8" secondAttribute="bottom" constant="10" id="fKt-Z9-LvS"/>
                             <constraint firstItem="wb8-4G-Pj8" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="qq9-dH-GCJ"/>
                         </constraints>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -68,46 +68,22 @@ extension BackCardCell {
         if let bgImage = UIImage(named: backgroundImage) {
             self.backgroundImageView.image = bgImage
         }
-        if isMintImage == true {
-            self.mintImageView.image = UIImage(named: "iconTasteOnMincho")
-        } else {
-            self.mintImageView.image = UIImage(named: "iconTasteOffMincho")
-        }
-        if isNoMintImage == true {
-            self.noMintImageView.image = UIImage(named: "iconTasteOnBanmincho")
-        } else {
-            self.noMintImageView.image = UIImage(named: "iconTasteOffBanmincho")
-        }
-        if isSojuImage == true {
-            self.sojuImageView.image = UIImage(named: "iconTasteOnSoju")
-        } else {
-            self.sojuImageView.image = UIImage(named: "iconTasteOffSoju")
-        }
-        if isBeerImage == true {
-            self.beerImageView.image = UIImage(named: "iconTasteOnBeer")
-        } else {
-            self.beerImageView.image = UIImage(named: "iconTasteOffBeer")
-        }
-        if isPourImage == true {
-            self.pourEatImageView.image = UIImage(named: "iconTasteOnBumeok")
-        } else {
-            self.pourEatImageView.image = UIImage(named: "iconTasteOffBumeok")
-        }
-        if isPutSauceImage == true {
-            self.putSauceEatImageView.image = UIImage(named: "iconTasteOnZzik")
-        } else {
-            self.putSauceEatImageView.image = UIImage(named: "iconTasteOffZzik")
-        }
-        if isYangnyumImage == true {
-            self.sauceChickenImageView.image = UIImage(named: "iconTasteOnSeasoned")
-        } else {
-            self.sauceChickenImageView.image = UIImage(named: "iconTasteOffSeasoned")
-        }
-        if isFriedImage == true {
-            self.friedChickenImageView.image = UIImage(named: "iconTasteOnFried")
-        } else {
-            self.friedChickenImageView.image = UIImage(named: "iconTasteOffFried")
-        }
+        self.mintImageView.image = isMintImage == true ?
+        UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")
+        self.noMintImageView.image = isNoMintImage == true ?
+        UIImage(named: "iconTasteOnBanmincho") : UIImage(named: "iconTasteOffBanmincho")
+        self.sojuImageView.image = isSojuImage == true ?
+        UIImage(named: "iconTasteOnSoju") : UIImage(named: "iconTasteOffSoju")
+        self.beerImageView.image = isBeerImage == true ?
+        UIImage(named: "iconTasteOnBeer") : UIImage(named: "iconTasteOffBeer")
+        self.pourEatImageView.image = isPourImage == true ?
+        UIImage(named: "iconTasteOnBumeok") : UIImage(named: "iconTasteOffBumeok")
+        self.putSauceEatImageView.image = isPutSauceImage == true ?
+        UIImage(named: "iconTasteOnZzik") : UIImage(named: "iconTasteOffZzik")
+        self.sauceChickenImageView.image = isYangnyumImage == true ?
+        UIImage(named: "iconTasteOnSeasoned") : UIImage(named: "iconTasteOffSeasoned")
+        self.friedChickenImageView.image = isFriedImage == true ?
+        UIImage(named: "iconTasteOnFried") : UIImage(named: "iconTasteOffFried")
         self.firstTmiLabel.text = firstTmi
         self.secondTmiLabel.text = secondTmi
         self.thirdTmiLabel.text = thirdTmi

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -12,6 +12,7 @@ class BackCardCell: CardCell {
     
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var backgroundImageView: UIImageView!
+    @IBOutlet weak var tasteTitleLabel: UILabel!
     @IBOutlet weak var mintImageView: UIImageView!
     @IBOutlet weak var noMintImageView: UIImageView!
     @IBOutlet weak var sojuImageView: UIImageView!
@@ -20,6 +21,7 @@ class BackCardCell: CardCell {
     @IBOutlet weak var putSauceEatImageView: UIImageView!
     @IBOutlet weak var sauceChickenImageView: UIImageView!
     @IBOutlet weak var friedChickenImageView: UIImageView!
+    @IBOutlet weak var tmiTitleLabel: UILabel!
     @IBOutlet weak var firstTmiLabel: UILabel!
     @IBOutlet weak var secondTmiLabel: UILabel!
     @IBOutlet weak var thirdTmiLabel: UILabel!
@@ -32,56 +34,80 @@ class BackCardCell: CardCell {
     
     // MARK: - Functions
     static func nib() -> UINib {
-        return UINib(nibName: Const.Xib.backCardCell, bundle: nil)
+        return UINib(nibName: Const.Xib.backCardCell, bundle: Bundle(for: BackCardCell.self))
     }
 }
 
 // MARK: - Extensions
 extension BackCardCell {
     private func setUI() {
-        
+        tasteTitleLabel.font = .title02
+        tasteTitleLabel.textColor = .white
+        tmiTitleLabel.font = .title02
+        tmiTitleLabel.textColor = .white
+        firstTmiLabel.font = .textRegular04
+        firstTmiLabel.textColor = .white
+        secondTmiLabel.font = .textRegular04
+        secondTmiLabel.textColor = .white
+        thirdTmiLabel.font = .textRegular04
+        thirdTmiLabel.textColor = .white
     }
     
     func initCell(_ backgroundImage: String,
-                  _ mintImage: String,
-                  _ noMintImage: String,
-                  _ sojuImage: String,
-                  _ beerImage: String,
-                  _ pourImage: String,
-                  _ putSauceImage: String,
-                  _ yangnyumImage: String,
-                  _ friedImage: String,
+                  _ isMintImage: Bool,
+                  _ isNoMintImage: Bool,
+                  _ isSojuImage: Bool,
+                  _ isBeerImage: Bool,
+                  _ isPourImage: Bool,
+                  _ isPutSauceImage: Bool,
+                  _ isYangnyumImage: Bool,
+                  _ isFriedImage: Bool,
                   _ firstTmi: String,
                   _ secondTmi: String,
                   _ thirdTmi: String) {
         if let bgImage = UIImage(named: backgroundImage) {
             self.backgroundImageView.image = bgImage
         }
-        if let mtImage = UIImage(named: mintImage) {
-            self.mintImageView.image = mtImage
+        if isMintImage == true {
+            self.mintImageView.image = UIImage(named: "iconTasteOnMincho")
+        } else {
+            self.mintImageView.image = UIImage(named: "iconTasteOffMincho")
         }
-        if let noMtImage = UIImage(named: noMintImage) {
-            self.noMintImageView.image = noMtImage
+        if isNoMintImage == true {
+            self.noMintImageView.image = UIImage(named: "iconTasteOnBanmincho")
+        } else {
+            self.noMintImageView.image = UIImage(named: "iconTasteOffBanmincho")
         }
-        if let sojuImage = UIImage(named: sojuImage) {
-            self.sojuImageView.image = sojuImage
+        if isSojuImage == true {
+            self.sojuImageView.image = UIImage(named: "iconTasteOnSoju")
+        } else {
+            self.sojuImageView.image = UIImage(named: "iconTasteOffSoju")
         }
-        if let beerImage = UIImage(named: beerImage) {
-            self.beerImageView.image = beerImage
+        if isBeerImage == true {
+            self.beerImageView.image = UIImage(named: "iconTasteOnBeer")
+        } else {
+            self.beerImageView.image = UIImage(named: "iconTasteOffBeer")
         }
-        if let bumukImage = UIImage(named: pourImage) {
-            self.pourEatImageView.image = bumukImage
+        if isPourImage == true {
+            self.pourEatImageView.image = UIImage(named: "iconTasteOnBumeok")
+        } else {
+            self.pourEatImageView.image = UIImage(named: "iconTasteOffBumeok")
         }
-        if let jjikmukImage = UIImage(named: putSauceImage) {
-            self.putSauceEatImageView.image = jjikmukImage
+        if isPutSauceImage == true {
+            self.putSauceEatImageView.image = UIImage(named: "iconTasteOnZzik")
+        } else {
+            self.putSauceEatImageView.image = UIImage(named: "iconTasteOffZzik")
         }
-        if let yangnyumImage = UIImage(named: yangnyumImage) {
-            self.sauceChickenImageView.image = yangnyumImage
+        if isYangnyumImage == true {
+            self.sauceChickenImageView.image = UIImage(named: "iconTasteOnSeasoned")
+        } else {
+            self.sauceChickenImageView.image = UIImage(named: "iconTasteOffSeasoned")
         }
-        if let friedImage = UIImage(named: friedImage) {
-            self.friedChickenImageView.image = friedImage
+        if isFriedImage == true {
+            self.friedChickenImageView.image = UIImage(named: "iconTasteOnFried")
+        } else {
+            self.friedChickenImageView.image = UIImage(named: "iconTasteOffFried")
         }
-
         self.firstTmiLabel.text = firstTmi
         self.secondTmiLabel.text = secondTmi
         self.thirdTmiLabel.text = thirdTmi

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
@@ -7,14 +7,6 @@
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="Spoqa Han Sans Neo Bold.otf">
-            <string>SpoqaHanSansNeo-Bold</string>
-        </array>
-        <array key="Spoqa Han Sans Neo Regular.otf">
-            <string>SpoqaHanSansNeo-Regular</string>
-        </array>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -39,15 +31,15 @@
                         <state key="normal" image="iconShare"/>
                     </button>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="😎 나의 취향" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dHb-jJ-jng">
-                        <rect key="frame" x="24" y="50" width="96.5" height="22"/>
-                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="18"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <rect key="frame" x="24" y="50" width="95.5" height="22"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                        <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🤓 나의 TMI" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XT5-iW-6kG">
-                        <rect key="frame" x="24" y="377" width="96" height="22"/>
-                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="18"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <rect key="frame" x="24" y="377" width="95" height="22"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                        <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qum-Iq-vKj">
@@ -108,20 +100,20 @@
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ch6-5U-VOL">
                         <rect key="frame" x="24" y="415" width="279" height="17"/>
-                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IFb-AS-8IM">
                         <rect key="frame" x="24" y="444" width="279" height="17"/>
-                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9yf-Qs-VBg">
                         <rect key="frame" x="24" y="473" width="279" height="17"/>
-                        <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="14"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
@@ -197,7 +189,9 @@
                 <outlet property="sauceChickenImageView" destination="Nx7-Vx-MTP" id="EBI-QU-BQH"/>
                 <outlet property="secondTmiLabel" destination="IFb-AS-8IM" id="huF-sy-GN1"/>
                 <outlet property="sojuImageView" destination="yJZ-UI-FTC" id="a17-57-8Jd"/>
+                <outlet property="tasteTitleLabel" destination="dHb-jJ-jng" id="s2A-b9-Osl"/>
                 <outlet property="thirdTmiLabel" destination="9yf-Qs-VBg" id="e4s-7p-WmB"/>
+                <outlet property="tmiTitleLabel" destination="XT5-iW-6kG" id="75E-sq-FUS"/>
             </connections>
             <point key="canvasLocation" x="131.15942028985509" y="79.6875"/>
         </collectionViewCell>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -48,9 +48,9 @@ extension FrontCardCell {
         birthLabel.textColor = .white
         mbtiLabel.font = .textRegular02
         mbtiLabel.textColor = .white
-        instagramIDLabel.font = .textRegular02
+        instagramIDLabel.font = .textRegular03
         instagramIDLabel.textColor = .white
-        linkURLLabel.font = .textRegular02
+        linkURLLabel.font = .textRegular04
         linkURLLabel.textColor = .white
     }
     

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
@@ -21,7 +21,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="327" height="540"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                <real key="value" value="10"/>
+                                <real key="value" value="20"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>

--- a/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -36,31 +35,31 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SOPT 명함" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rng-0l-SgL">
                                 <rect key="frame" x="12" y="25" width="43" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="9"/>
-                                <color key="textColor" name="background"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="29기 디자인파트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RM7-A9-SfR">
                                 <rect key="frame" x="12" y="40" width="62.5" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="9"/>
-                                <color key="textColor" name="background"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이채연" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBD-lZ-HlH">
                                 <rect key="frame" x="12" y="147" width="28" height="12"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="10"/>
-                                <color key="textColor" name="background"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1998.01.09 (24)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WCz-jU-GLW">
                                 <rect key="frame" x="12" y="165" width="66" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="9"/>
-                                <color key="textColor" name="background"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENFP" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wwx-y2-tN3">
                                 <rect key="frame" x="12" y="181" width="23" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="9"/>
-                                <color key="textColor" name="background"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconInstagram" translatesAutoresizingMaskIntoConstraints="NO" id="XFs-Sv-f0r">
@@ -73,7 +72,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="chaens_" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R2H-kH-GqM">
                                 <rect key="frame" x="27" y="220.5" width="31" height="10"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="8"/>
-                                <color key="textColor" name="background"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUrl" translatesAutoresizingMaskIntoConstraints="NO" id="07x-TC-A3z">
@@ -86,7 +85,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https://github.com/TeamNADA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oO0-od-Oxm">
                                 <rect key="frame" x="27" y="238" width="114.5" height="10"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="8"/>
-                                <color key="textColor" name="background"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -144,9 +143,6 @@
         <image name="card" width="327" height="540"/>
         <image name="iconInstagram" width="24" height="24"/>
         <image name="iconUrl" width="24" height="24"/>
-        <namedColor name="background">
-            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.xib
@@ -37,6 +37,7 @@
                         </constraints>
                     </view>
                 </subviews>
+                <color key="backgroundColor" name="background"/>
                 <constraints>
                     <constraint firstItem="waV-UG-3wC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="7UI-Gd-jcW"/>
                     <constraint firstAttribute="trailing" secondItem="waV-UG-3wC" secondAttribute="trailing" constant="16" id="Dmo-tw-PtZ"/>
@@ -54,6 +55,9 @@
         </tableViewCell>
     </objects>
     <resources>
+        <namedColor name="background">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="secondary">
             <color red="0.16862745098039217" green="0.17647058823529413" blue="0.19215686274509805" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/NADA-iOS-forRelease/Sources/Cells/MoreList/MoreListTableViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/MoreList/MoreListTableViewCell.swift
@@ -11,6 +11,7 @@ class MoreListTableViewCell: UITableViewCell {
 
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var modeSwitch: UISwitch!
+    @IBOutlet weak var separatorView: UIView!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/NADA-iOS-forRelease/Sources/Cells/MoreList/MoreListTableViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/MoreList/MoreListTableViewCell.xib
@@ -54,6 +54,7 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="modeSwitch" destination="X9p-6n-YCp" id="hL4-79-N7S"/>
+                <outlet property="separatorView" destination="QoL-PR-cfm" id="B7m-Td-SQ0"/>
                 <outlet property="titleLabel" destination="ZEb-kz-9Ea" id="cQm-Mv-7vw"/>
             </connections>
             <point key="canvasLocation" x="474.63768115942031" y="248.4375"/>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
@@ -30,7 +30,7 @@ class CommonBottomSheetViewController: UIViewController {
     // 기존 화면을 흐려지게 만들기 위한 뷰
     private let dimmedBackView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
+        view.backgroundColor = .bottomDimmedBackground
         return view
     }()
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
@@ -15,7 +15,7 @@ import UIKit
  3) InheritanceViewController에 텍스트 필드, 피커 뷰, 버튼 등 각 화면에 맞는 추가 기능 구현
  4) .setHeight 메서드 파라미터로 높이값을 조정 (default값은 475)
  5) .setTitle 메서드 파라미터로 가장 상단 타이틀 라벨에 들어갈 내용 입력 (String)
- 6) present 방식으로 화면에 표출
+ 6) present 방식으로 화면에 표출 (주의!! 이때 present animated는 false로 둬야 지연없이 바텀시트가 올라옵니다 ^_^)
 */
 
 class CommonBottomSheetViewController: UIViewController {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
@@ -37,7 +37,7 @@ class CommonBottomSheetViewController: UIViewController {
     // 바텀 시트 뷰
     let bottomSheetView: UIView = {
         let view = UIView()
-        view.backgroundColor = .white
+        view.backgroundColor = .background
         
         view.layer.cornerRadius = 27
         view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
@@ -49,7 +49,7 @@ class CommonBottomSheetViewController: UIViewController {
     // 자연스러운 애니메이션을 위한..커버..
     let bottomSheetCoverView: UIView = {
         let view = UIView()
-        view.backgroundColor = .white
+        view.backgroundColor = .background
         
         view.layer.cornerRadius = 27
         view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
@@ -70,7 +70,8 @@ class CommonBottomSheetViewController: UIViewController {
     // 바텀 시트 메인 라벨
     public let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.font = .title01
+        label.textColor = .primary
         label.textAlignment = .center
         label.sizeToFit()
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class CardCreationPreviewViewController: UIViewController {
-
+    
     var backgroundImage: Data?
     var frontCardDataModel: FrontCardDataModel?
     var backCardDataModel: BackCardDataModel?
@@ -25,7 +25,7 @@ class CardCreationPreviewViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         setUI()
     }
     @IBAction func touchCompleteButton(_ sender: Any) {
@@ -79,12 +79,12 @@ extension CardCreationPreviewViewController {
         guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
         
         // FIXME: - @IBDesignables err
-//        guard let frontCard = Bundle(for: FrontCardCell.self).loadNibNamed(Const.Xib.frontCardCell, owner: self, options: nil)?.first as? FrontCardCell else { return }
+        //        guard let frontCard = Bundle(for: FrontCardCell.self).loadNibNamed(Const.Xib.frontCardCell, owner: self, options: nil)?.first as? FrontCardCell else { return }
         
         frontCard.frame = CGRect(x: 0, y: 0, width: cardView.frame.width, height: cardView.frame.height)
         // FIXME: - 갤러리 추가/주석해제
-//        guard let frontCardDataModel = frontCardDataModel else { return }
-//        frontCard.initCell("", frontCardDataModel.title, frontCardDataModel.description, frontCardDataModel.name, frontCardDataModel.birthDate, frontCardDataModel.mbti, frontCardDataModel.instagramID, frontCardDataModel.linkURL)
+        //        guard let frontCardDataModel = frontCardDataModel else { return }
+        //        frontCard.initCell("", frontCardDataModel.title, frontCardDataModel.description, frontCardDataModel.name, frontCardDataModel.birthDate, frontCardDataModel.mbti, frontCardDataModel.instagramID, frontCardDataModel.linkURL)
         
         // FIXME: - dummy data
         frontCard.initCell("card", "nada", "NADA의 짱귀염둥이 ㅎ 막이래~", "개빡쳐하는 오야옹~", "1999/05/12", "ENFP", "yaeoni", "github.com/yaeoni")
@@ -95,10 +95,12 @@ extension CardCreationPreviewViewController {
         guard let backCard = BackCardCell.nib().instantiate(withOwner: self, options: nil).first as? BackCardCell else { return }
         guard let backCardDataModel = backCardDataModel else { return }
         backCard.frame = CGRect(x: 0, y: 0, width: cardView.frame.width, height: cardView.frame.height)
-        // TODO: - BackCardCell.initCell 수정되면 반영하기
-//        backCard.initCell("card", <#T##mintImage: String##String#>, <#T##noMintImage: String##String#>, <#T##sojuImage: String##String#>, <#T##beerImage: String##String#>, <#T##pourImage: String##String#>, <#T##putSauceImage: String##String#>, <#T##yangnyumImage: String##String#>, <#T##friedImage: String##String#>, <#T##firstTmi: String##String#>, <#T##secondTmi: String##String#>, <#T##thirdTmi: String##String#>)
+        
+        // FIXME: - dummy data
+        backCard.initCell("card", false, true, false, true, false, true, false, true, "티엠아이", "모쓰지", "모르겠다")
+        cardView.addSubview(backCard)
     }
-
+    
     // MARK: - Network
     
     func cardCreationWithAPI(request: CardCreationRequest, image: UIImage) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -12,9 +12,11 @@ class GroupViewController: UIViewController {
     // MARK: - Properties
     // 네비게이션 바
     @IBAction func presentToAddWithIdView(_ sender: Any) {
-        let nextVC = AddWithIdBottomSheetViewController().setTitle("ID로 명함 추가").setHeight(184)
+        let nextVC = AddWithIdBottomSheetViewController()
+                    .setTitle("ID로 명함 추가")
+                    .setHeight(184)
         nextVC.modalPresentationStyle = .overFullScreen
-        self.present(nextVC, animated: true, completion: nil)
+        self.present(nextVC, animated: false, completion: nil)
     }
     
     @IBAction func presentToAddWithQrView(_ sender: Any) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
@@ -31,9 +31,11 @@ class GroupEditViewController: UIViewController {
     }
     
     @IBAction func presentToAddGroupBottom(_ sender: UIButton) {
-        let nextVC = AddGroupBottomSheetViewController().setTitle("그룹 추가").setHeight(184)
+        let nextVC = AddGroupBottomSheetViewController()
+                    .setTitle("그룹 추가")
+                    .setHeight(184)
         nextVC.modalPresentationStyle = .overFullScreen
-        self.present(nextVC, animated: true, completion: nil)
+        self.present(nextVC, animated: false, completion: nil)
     }
 }
 
@@ -63,7 +65,6 @@ extension GroupEditViewController: UITableViewDelegate {
 
 // MARK: - TableView DataSource
 extension GroupEditViewController: UITableViewDataSource {
-    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return cardItems.count
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -91,23 +91,23 @@ extension FrontViewController {
         imageList.append(contentsOf: ["card",
                                       "card"
                                      ])
-        cardNameList.append(contentsOf: ["SOPT 28기 명함",
-                                         "SOPT 28기 명함"
+        cardNameList.append(contentsOf: ["SOPT 명함",
+                                         "SOPT 명함"
                                         ])
-        detailCardNameList.append(contentsOf: ["28기 디자인파트원",
-                                               "28기 디자인파트원"
+        detailCardNameList.append(contentsOf: ["29기 디자인파트",
+                                               "29기 디자인파트"
                                               ])
-        userNameList.append(contentsOf: ["김태양",
-                                         "김태양"
+        userNameList.append(contentsOf: ["이채연",
+                                         "이채연"
                                         ])
-        birthList.append(contentsOf: ["2002/11/06 (20세)",
-                                      "2002/11/06 (20세)"
+        birthList.append(contentsOf: ["1998.01.09 (24)",
+                                      "1998.01.09 (24)"
                                      ])
-        mbtiList.append(contentsOf: ["ISTJ",
-                                     "ISTJ"
+        mbtiList.append(contentsOf: ["ENFP",
+                                     "ENFP"
                                     ])
-        instagramIDList.append(contentsOf: ["@passio84ever",
-                                            "@passio84ever"
+        instagramIDList.append(contentsOf: ["chaens_",
+                                            "chaens_"
                                            ])
         linkImageList.append(contentsOf: ["testLink",
                                           "testLink"
@@ -115,8 +115,8 @@ extension FrontViewController {
         linkTextList.append(contentsOf: ["Blog",
                                          "Blog"
                                         ])
-        linkIDList.append(contentsOf: ["blog.naver.com/\npark_yunjung",
-                                       "blog.naver.com/\npark_yunjung"
+        linkIDList.append(contentsOf: ["https://github.com/TeamNADA",
+                                       "https://github.com/TeamNADA"
                                       ])
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -24,14 +24,14 @@ class FrontViewController: UIViewController {
     private var linkIDList = [String]()
     
     // 뒷면
-    private var mintImageList = [String]()
-    private var noMintImageList = [String]()
-    private var sojuImageList = [String]()
-    private var beerImageList = [String]()
-    private var pourImageList = [String]()
-    private var putSauceImageList = [String]()
-    private var yangnyumImageList = [String]()
-    private var friedImageList = [String]()
+    private var mintImageList = [Bool]()
+    private var noMintImageList = [Bool]()
+    private var sojuImageList = [Bool]()
+    private var beerImageList = [Bool]()
+    private var pourImageList = [Bool]()
+    private var putSauceImageList = [Bool]()
+    private var yangnyumImageList = [Bool]()
+    private var friedImageList = [Bool]()
     private var firstTmiList = [String]()
     private var secondTmiList = [String]()
     private var thirdTmiLabel = [String]()
@@ -121,29 +121,29 @@ extension FrontViewController {
     }
     
     private func setBackList() {
-        mintImageList.append(contentsOf: ["iconTasteOnMincho",
-                                          "iconTasteOnMincho"
+        mintImageList.append(contentsOf: [true,
+                                          false
                                          ])
-        noMintImageList.append(contentsOf: ["iconTasteOffBanmincho",
-                                            "iconTasteOffBanmincho"
+        noMintImageList.append(contentsOf: [false,
+                                            true
                                            ])
-        sojuImageList.append(contentsOf: ["iconTasteOnSoju",
-                                          "iconTasteOnSoju"
+        sojuImageList.append(contentsOf: [true,
+                                          false
                                          ])
-        beerImageList.append(contentsOf: ["iconTasteOffBeer",
-                                          "iconTasteOffBeer"
+        beerImageList.append(contentsOf: [false,
+                                          true
                                          ])
-        pourImageList.append(contentsOf: ["iconTasteOffBumeok",
-                                          "iconTasteOffBumeok"
+        pourImageList.append(contentsOf: [false,
+                                          true
                                          ])
-        putSauceImageList.append(contentsOf: ["iconTasteOnZzik",
-                                              "iconTasteOnZzik"
+        putSauceImageList.append(contentsOf: [true,
+                                              false
                                              ])
-        yangnyumImageList.append(contentsOf: ["iconTasteOffSeasoned",
-                                              "iconTasteOffSeasoned"
+        yangnyumImageList.append(contentsOf: [false,
+                                              true
                                              ])
-        friedImageList.append(contentsOf: ["iconTasteOnFried",
-                                           "iconTasteOnFried"
+        friedImageList.append(contentsOf: [true,
+                                           false
                                           ])
         firstTmiList.append(contentsOf: ["첫번째",
                                          "첫번째"

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -47,6 +47,9 @@ extension MoreViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if section == 2 {
+            return 0
+        }
         return 5
     }
     
@@ -55,14 +58,19 @@ extension MoreViewController: UITableViewDataSource {
         
         if indexPath.section == 0 {
             serviceCell.titleLabel.text = firstItems[indexPath.row]
+            if indexPath.row == firstItems.count - 1 {
+                serviceCell.separatorView.isHidden = true
+            }
         } else if indexPath.section == 1 {
             serviceCell.titleLabel.text = secondItems[indexPath.row]
             serviceCell.modeSwitch.isHidden = true
+            if indexPath.row == secondItems.count - 1 {
+                serviceCell.separatorView.isHidden = true
+            }
         } else if indexPath.section == 2 {
             serviceCell.titleLabel.text = thirdItems[indexPath.row]
             serviceCell.modeSwitch.isHidden = true
         }
-        
         return serviceCell
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#89

🌱 작업한 내용

⭐️카드 뒷면 셀
- 현규쌤 요청 -> BackCardCell, initCell 수정 (bool형으로 받아서, 메서드에서 처리하는 방식)
- 현규 쌤 PR 답변 부분 -> 미리보기 뷰 부분 맞춰서 수정
- Bundle 빠져있는 내용들 추가

⭐️바텀시트
- 표출 시간 delay 이슈 해결
- 다크 모드 적용

⭐️기타
- 더보기 뷰 구분선 색상 수정
- 이준쌤 명함 모음 뷰 명함 글씨 색 -> background에서 .white로 변경
- 뒷면셀 수정하면서, 현규쌤 앞면셀 모서리 redius 20으로 변경했습니다!
- 그룹 편집뷰 push로 넘어왔을 때, 탭바 안보이도록 변경
- 탭바 border line과 shadow 연구
- 앞면 더미 데이터 '그'에서 '천디'로 변경

## 📸 스크린샷
|기능|스크린샷|설명|
|:--:|:--:|:--:|
|GIF|![Simulator-Screen-Recording-iPhone-12-mini-2021-11-28-at-16 36 50](https://user-images.githubusercontent.com/69389288/143734028-ae0c00b0-2f54-4066-bd4a-72895e3b78f0.gif)| 바텀 시트를 present할 때는 바텀시트 자체 animation이 적용되기 때문에, <p> present animated는 false로 해야 지연없이 바텀시트가 표출되었습니다!! 바텀시트 올릴 때, 참고해주셔요 ^_^  <p> + 그룹에서 사용되는 present는 일괄적으로 수정했습니다!|

## 📮 관련 이슈
- Resolved: #89 
