### PR TITLE
[FIX] #126 - 명함 그룹 뷰 수정

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Storyboards/Group/Group.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/Group/Group.storyboard
@@ -101,10 +101,10 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="khE-2k-qTd">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="khE-2k-qTd">
                                 <rect key="frame" x="24" y="210" width="327" height="519"/>
                                 <color key="backgroundColor" name="background"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Nld-ty-a2r">
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Nld-ty-a2r">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>

--- a/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
@@ -35,6 +35,11 @@
                             <view alpha="0.40000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9V6-ba-Kga">
                                 <rect key="frame" x="0.0" y="0.0" width="156" height="258"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="15"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SOPT 명함" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rng-0l-SgL">
                                 <rect key="frame" x="12" y="25" width="43" height="11"/>

--- a/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
@@ -29,8 +29,13 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UBI-OG-7RY">
                         <rect key="frame" x="0.0" y="0.0" width="156" height="258"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="card" translatesAutoresizingMaskIntoConstraints="NO" id="nFQ-dL-nGf">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="card" translatesAutoresizingMaskIntoConstraints="NO" id="nFQ-dL-nGf">
                                 <rect key="frame" x="0.0" y="0.0" width="156" height="258"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="15"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </imageView>
                             <view alpha="0.40000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9V6-ba-Kga">
                                 <rect key="frame" x="0.0" y="0.0" width="156" height="258"/>
@@ -42,57 +47,57 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SOPT 명함" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rng-0l-SgL">
-                                <rect key="frame" x="12" y="25" width="43" height="11"/>
+                                <rect key="frame" x="12" y="30" width="43" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="9"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="29기 디자인파트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RM7-A9-SfR">
-                                <rect key="frame" x="12" y="40" width="62.5" height="11"/>
+                                <rect key="frame" x="12" y="45" width="62.5" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="9"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이채연" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBD-lZ-HlH">
-                                <rect key="frame" x="12" y="147" width="28" height="12"/>
+                                <rect key="frame" x="12" y="129" width="28" height="12"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="10"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1998.01.09 (24)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WCz-jU-GLW">
-                                <rect key="frame" x="12" y="165" width="66" height="11"/>
+                                <rect key="frame" x="12" y="147" width="66" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="9"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENFP" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wwx-y2-tN3">
-                                <rect key="frame" x="12" y="181" width="23" height="11"/>
+                                <rect key="frame" x="12" y="163" width="23" height="11"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="9"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconInstagram" translatesAutoresizingMaskIntoConstraints="NO" id="XFs-Sv-f0r">
-                                <rect key="frame" x="12" y="219" width="12" height="12"/>
+                                <rect key="frame" x="12" y="204" width="12" height="12"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="12" id="SUx-eT-18P"/>
                                     <constraint firstAttribute="width" constant="12" id="UYe-3z-FhB"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="chaens_" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R2H-kH-GqM">
-                                <rect key="frame" x="27" y="220.5" width="31" height="10"/>
+                                <rect key="frame" x="27" y="205" width="31" height="10"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="8"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUrl" translatesAutoresizingMaskIntoConstraints="NO" id="07x-TC-A3z">
-                                <rect key="frame" x="12" y="236" width="12" height="12"/>
+                                <rect key="frame" x="12" y="221" width="12" height="12"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="12" id="Syi-2K-OU3"/>
                                     <constraint firstAttribute="height" constant="12" id="XnU-uq-Fca"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https://github.com/TeamNADA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oO0-od-Oxm">
-                                <rect key="frame" x="27" y="238" width="114.5" height="10"/>
+                                <rect key="frame" x="27" y="222" width="114.5" height="10"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="8"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -106,29 +111,32 @@
                             <constraint firstItem="9V6-ba-Kga" firstAttribute="trailing" secondItem="nFQ-dL-nGf" secondAttribute="trailing" id="9xP-0b-rf8"/>
                             <constraint firstItem="R2H-kH-GqM" firstAttribute="leading" secondItem="XFs-Sv-f0r" secondAttribute="trailing" constant="3" id="ARH-vK-SuC"/>
                             <constraint firstItem="XFs-Sv-f0r" firstAttribute="leading" secondItem="UBI-OG-7RY" secondAttribute="leading" constant="12" id="DgX-lM-v3f"/>
+                            <constraint firstItem="oO0-od-Oxm" firstAttribute="centerY" secondItem="07x-TC-A3z" secondAttribute="centerY" id="J9e-Yy-ShX"/>
                             <constraint firstItem="nFQ-dL-nGf" firstAttribute="leading" secondItem="UBI-OG-7RY" secondAttribute="leading" id="JMw-lr-b2G"/>
-                            <constraint firstItem="Rng-0l-SgL" firstAttribute="top" secondItem="UBI-OG-7RY" secondAttribute="top" constant="25" id="NOP-Sz-J6E"/>
+                            <constraint firstItem="Rng-0l-SgL" firstAttribute="top" secondItem="UBI-OG-7RY" secondAttribute="top" constant="30" id="NOP-Sz-J6E"/>
                             <constraint firstItem="RM7-A9-SfR" firstAttribute="top" secondItem="Rng-0l-SgL" secondAttribute="bottom" constant="4" id="Nd6-dt-CuO"/>
                             <constraint firstItem="Rng-0l-SgL" firstAttribute="leading" secondItem="UBI-OG-7RY" secondAttribute="leading" constant="12" id="O4d-ho-MRW"/>
                             <constraint firstItem="Wwx-y2-tN3" firstAttribute="top" secondItem="WCz-jU-GLW" secondAttribute="bottom" constant="5" id="PVA-MH-sAU"/>
                             <constraint firstAttribute="bottom" secondItem="nFQ-dL-nGf" secondAttribute="bottom" id="R3q-Cr-hzY"/>
-                            <constraint firstItem="XFs-Sv-f0r" firstAttribute="top" secondItem="Wwx-y2-tN3" secondAttribute="bottom" constant="27" id="Tkm-8O-ElT"/>
+                            <constraint firstAttribute="bottom" secondItem="oO0-od-Oxm" secondAttribute="bottom" constant="26" id="SNZ-kd-uSv"/>
                             <constraint firstItem="RM7-A9-SfR" firstAttribute="leading" secondItem="UBI-OG-7RY" secondAttribute="leading" constant="12" id="U5c-7H-oL3"/>
                             <constraint firstItem="nFQ-dL-nGf" firstAttribute="top" secondItem="UBI-OG-7RY" secondAttribute="top" id="VXI-Ra-fR3"/>
                             <constraint firstItem="tBD-lZ-HlH" firstAttribute="leading" secondItem="UBI-OG-7RY" secondAttribute="leading" constant="12" id="Z6J-zV-A10"/>
                             <constraint firstItem="Wwx-y2-tN3" firstAttribute="leading" secondItem="UBI-OG-7RY" secondAttribute="leading" constant="12" id="ZGn-Jf-FsK"/>
-                            <constraint firstAttribute="width" constant="156" id="bCJ-f5-AU6"/>
                             <constraint firstAttribute="trailing" secondItem="nFQ-dL-nGf" secondAttribute="trailing" id="bYg-oY-TXD"/>
                             <constraint firstItem="07x-TC-A3z" firstAttribute="top" secondItem="XFs-Sv-f0r" secondAttribute="bottom" constant="5" id="dOi-vF-3nL"/>
+                            <constraint firstItem="R2H-kH-GqM" firstAttribute="centerY" secondItem="XFs-Sv-f0r" secondAttribute="centerY" id="g3W-uV-aQo"/>
                             <constraint firstItem="9V6-ba-Kga" firstAttribute="top" secondItem="nFQ-dL-nGf" secondAttribute="top" id="gzR-cH-WC7"/>
                             <constraint firstItem="WCz-jU-GLW" firstAttribute="top" secondItem="tBD-lZ-HlH" secondAttribute="bottom" constant="6" id="hZ7-6i-u0f"/>
-                            <constraint firstItem="R2H-kH-GqM" firstAttribute="top" secondItem="Wwx-y2-tN3" secondAttribute="bottom" constant="28.5" id="ihY-o5-XjH"/>
-                            <constraint firstItem="oO0-od-Oxm" firstAttribute="top" secondItem="R2H-kH-GqM" secondAttribute="bottom" constant="7.5" id="jy0-Iu-udc"/>
-                            <constraint firstAttribute="height" constant="258" id="k1e-3O-9RK"/>
-                            <constraint firstItem="tBD-lZ-HlH" firstAttribute="top" secondItem="RM7-A9-SfR" secondAttribute="bottom" constant="96" id="k2H-sd-orF"/>
                             <constraint firstItem="9V6-ba-Kga" firstAttribute="bottom" secondItem="nFQ-dL-nGf" secondAttribute="bottom" id="mtq-ik-plt"/>
                             <constraint firstItem="WCz-jU-GLW" firstAttribute="leading" secondItem="UBI-OG-7RY" secondAttribute="leading" constant="12" id="oUb-dX-0YV"/>
+                            <constraint firstItem="XFs-Sv-f0r" firstAttribute="top" secondItem="Wwx-y2-tN3" secondAttribute="bottom" constant="30" id="yky-y5-UXB"/>
                         </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="15"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
                     </view>
                 </subviews>
             </view>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -314,8 +314,8 @@ extension GroupViewController: UICollectionViewDelegateFlowLayout {
             }
             height = collectionView.frame.size.height
         case cardsCollectionView:
-            width = 156
-            height = 258
+            width = collectionView.frame.size.width * 156/327
+            height = collectionView.frame.size.height * 258/558
         default:
             width = 0
             height = 0
@@ -326,6 +326,8 @@ extension GroupViewController: UICollectionViewDelegateFlowLayout {
         switch collectionView {
         case groupCollectionView:
             return .init(top: 0, left: 0, bottom: 0, right: 10)
+        case cardsCollectionView:
+            return .init(top: 0, left: 0, bottom: 28, right: 0)
         default:
             return .zero
         }
@@ -334,6 +336,8 @@ extension GroupViewController: UICollectionViewDelegateFlowLayout {
         switch collectionView {
         case groupCollectionView:
             return 5
+        case cardsCollectionView:
+            return collectionView.frame.size.width * 15/327
         default:
             return 0
         }
@@ -341,7 +345,7 @@ extension GroupViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         switch collectionView {
         case cardsCollectionView:
-            return 14
+            return collectionView.frame.size.width * 15/327
         default:
             return 0
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#126

🌱 작업한 내용
- 명함 그룹뷰에서 테두리를 둥글게 만들었습니다
- 기기 마다 카드의 내용의 간격이 이상해지는 것을 수정했습니다

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|아이폰11맥스|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-12-10 at 21 41 08](https://user-images.githubusercontent.com/69078056/145575772-763f804e-ab57-4f32-988a-bcba66b3e6fc.png)|아이폰 11|![Simulator Screen Shot - iPhone 11 - 2021-12-10 at 21 41 25](https://user-images.githubusercontent.com/69078056/145575806-80457b85-c30a-4fda-bb08-df269056881a.png)|


## 📮 관련 이슈
- Resolved: #126 
