### PR TITLE
[FEAT] #142 - 그룹명 변경 기능 구현

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,8 @@ disabled_rules:
 - nesting
 - function_parameter_count
 - function_body_length
+- cyclomatic_complexity
+- file_length
 excluded:
 - Pods
 - NADA-iOS-forRelease/Sources/AppDelegate.swift

--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		39288E12273F52B20072F403 /* CardListLookUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39288E11273F52B20072F403 /* CardListLookUpRequest.swift */; };
 		392F7FB4274621F1008CDBF5 /* MoreListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392F7FB2274621F1008CDBF5 /* MoreListTableViewCell.swift */; };
 		392F7FB5274621F1008CDBF5 /* MoreListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 392F7FB3274621F1008CDBF5 /* MoreListTableViewCell.xib */; };
+		39317D2227646F8E00D87166 /* GroupNameEditBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39317D2127646F8E00D87166 /* GroupNameEditBottomSheetViewController.swift */; };
 		39369935274A4FCB00684420 /* NotoSansCJKkr-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 39369930274A4FCB00684420 /* NotoSansCJKkr-Bold.otf */; };
 		39369936274A4FCB00684420 /* NotoSansCJKkr-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 39369931274A4FCB00684420 /* NotoSansCJKkr-Regular.otf */; };
 		39369937274A4FCB00684420 /* NotoSansCJKkr-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 39369932274A4FCB00684420 /* NotoSansCJKkr-Medium.otf */; };
@@ -143,6 +144,7 @@
 		39288E11273F52B20072F403 /* CardListLookUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListLookUpRequest.swift; sourceTree = "<group>"; };
 		392F7FB2274621F1008CDBF5 /* MoreListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreListTableViewCell.swift; sourceTree = "<group>"; };
 		392F7FB3274621F1008CDBF5 /* MoreListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MoreListTableViewCell.xib; sourceTree = "<group>"; };
+		39317D2127646F8E00D87166 /* GroupNameEditBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupNameEditBottomSheetViewController.swift; sourceTree = "<group>"; };
 		39369930274A4FCB00684420 /* NotoSansCJKkr-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansCJKkr-Bold.otf"; sourceTree = "<group>"; };
 		39369931274A4FCB00684420 /* NotoSansCJKkr-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansCJKkr-Regular.otf"; sourceTree = "<group>"; };
 		39369932274A4FCB00684420 /* NotoSansCJKkr-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansCJKkr-Medium.otf"; sourceTree = "<group>"; };
@@ -480,6 +482,7 @@
 				39D88B6A274600B100A72164 /* CommonBottomSheetViewController.swift */,
 				77DFB870274F92F9000CD36F /* AddWithIdBottomSheetViewController.swift */,
 				398413B6274A7A1E005550BC /* AddGroupBottomSheetViewController.swift */,
+				39317D2127646F8E00D87166 /* GroupNameEditBottomSheetViewController.swift */,
 				77703156275005AA002CBD19 /* CardResultBottomSheetViewController.swift */,
 				7713E8472752E2A900724C8B /* SelectGroupBottomSheetViewController.swift */,
 				F8915A20275728F20013D609 /* SelectBirthBottomViewController.swift */,
@@ -1087,6 +1090,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F87122762733046300A24E74 /* Card.swift in Sources */,
+				39317D2227646F8E00D87166 /* GroupNameEditBottomSheetViewController.swift in Sources */,
 				F84BAF9D26FDB417004CA335 /* CardCreationViewController.swift in Sources */,
 				F8C83FCB272FA32C0009DF0D /* GroupService.swift in Sources */,
 				F858079E2700354E00872484 /* BackgroundCollectionViewCell.swift in Sources */,

--- a/NADA-iOS-forRelease/Resouces/Constants/ViewController.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/ViewController.swift
@@ -32,6 +32,7 @@ extension Const {
             static let onboardingViewController = "OnboardingViewController"
             static let openSourceViewController = "OpenSourceViewController"
             static let teamNADAViewController = "TeamNADAViewController"
+            static let groupNameEditBottomSheetViewController = "GroupNameEditBottomSheetViewController"
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.swift
@@ -48,12 +48,12 @@ extension GroupEditTableViewCell {
     }
     
     @objc private func labelClicked(_ tapRecognizer: UITapGestureRecognizer) {
-        delegate?.presentToGroupNameEdit()
+        delegate?.presentToGroupNameEdit(self.titleLabel)
     }
     
 }
 
 // MARK: - Protocol
 protocol GroupEditViewDelegate: AnyObject {
-    func presentToGroupNameEdit()
+    func presentToGroupNameEdit(_ sender: UILabel)
 }

--- a/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.swift
@@ -9,13 +9,20 @@ import UIKit
 
 class GroupEditTableViewCell: UITableViewCell {
 
+    // MARK: - Properties
+    weak var delegate: GroupEditViewDelegate?
+    
+    // MARK: - @IBOutlet Properties
     @IBOutlet weak var titleLabel: UILabel!
     
+    // MARK: - View Life Cycle
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+
+        setupGestureRecognizer()
     }
 
+    // MARK: - Functions
     static func nib() -> UINib {
         return UINib(nibName: "GroupEditTableViewCell", bundle: nil)
     }
@@ -29,4 +36,24 @@ class GroupEditTableViewCell: UITableViewCell {
     func initData(title: String) {
         titleLabel.text = title
     }
+}
+
+// MARK: - Extensions
+extension GroupEditTableViewCell {
+    
+    private func setupGestureRecognizer() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(labelClicked))
+        titleLabel.addGestureRecognizer(tapGestureRecognizer)
+        titleLabel.isUserInteractionEnabled = true
+    }
+    
+    @objc private func labelClicked(_ tapRecognizer: UITapGestureRecognizer) {
+        delegate?.presentToGroupNameEdit()
+    }
+    
+}
+
+// MARK: - Protocol
+protocol GroupEditViewDelegate: AnyObject {
+    func presentToGroupNameEdit()
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
@@ -186,11 +186,11 @@ class CommonBottomSheetViewController: UIViewController {
             self.dimmedBackView.alpha = 0.0
             self.view.layoutIfNeeded()
             self.bottomSheetCoverView.isHidden = false
-        }) { _ in
+        }, completion: { _ in
             if self.presentingViewController != nil {
                 self.dismiss(animated: false, completion: nil)
             }
-        }
+        })
     }
     
     // 바텀 시트 사라지고 바로 다시 다음 바텀 시트 올라오는 애니메이션
@@ -202,7 +202,7 @@ class CommonBottomSheetViewController: UIViewController {
             self.dimmedBackView.alpha = 0.0
             self.view.layoutIfNeeded()
             self.bottomSheetCoverView.isHidden = false
-        }) { _ in
+        }, completion: { _ in
             if self.presentingViewController != nil {
                 guard let presentingVC = self.presentingViewController else { return }
                 self.dismiss(animated: false) {
@@ -211,7 +211,7 @@ class CommonBottomSheetViewController: UIViewController {
                     presentingVC.present(nextVC, animated: false, completion: nil)
                 }
             }
-        }
+        })
     }
     
     func hideBottomSheetAndPresentVC(nextViewController: UIViewController) {
@@ -222,7 +222,7 @@ class CommonBottomSheetViewController: UIViewController {
             self.dimmedBackView.alpha = 0.0
             self.view.layoutIfNeeded()
             self.bottomSheetCoverView.isHidden = false
-        }) { _ in
+        }, completion: { _ in
             if self.presentingViewController != nil {
                 guard let presentingVC = self.presentingViewController else { return }
                 self.dismiss(animated: false) {
@@ -231,7 +231,7 @@ class CommonBottomSheetViewController: UIViewController {
                     presentingVC.present(nextVC, animated: true, completion: nil)
                 }
             }
-        }
+        })
     }
     
     // UITapGestureRecognizer 연결 함수 부분

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
@@ -11,6 +11,10 @@ import IQKeyboardManagerSwift
 class GroupNameEditBottomSheetViewController: CommonBottomSheetViewController, UITextFieldDelegate {
 
     // MARK: - Properties
+    
+    // 넘어온 그룹 이름 데이터를 받는 변수 선언
+    var text: String = ""
+    
     // 그룹 추가 텍스트 필드
     private let addGroupTextField: UITextField = {
         let textField = UITextField()
@@ -64,6 +68,8 @@ class GroupNameEditBottomSheetViewController: CommonBottomSheetViewController, U
         view.addSubview(explainLabel)
         
         setupLayout()
+        
+        addGroupTextField.text = text
     }
     
     // 레이아웃 세팅

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
@@ -1,0 +1,101 @@
+//
+//  GroupNameEditBottomSheetViewController.swift
+//  NADA-iOS-forRelease
+//
+//  Created by 민 on 2021/12/11.
+//
+
+import UIKit
+import IQKeyboardManagerSwift
+
+class GroupNameEditBottomSheetViewController: CommonBottomSheetViewController, UITextFieldDelegate {
+
+    // MARK: - Properties
+    // 그룹 추가 텍스트 필드
+    private let addGroupTextField: UITextField = {
+        let textField = UITextField()
+        textField.borderStyle = .none
+        textField.cornerRadius = 10
+        textField.backgroundColor = .textBox
+        textField.attributedPlaceholder = NSAttributedString(string: "변경할 그룹명을 입력하세요.", attributes: [.foregroundColor: UIColor.quaternary, .font: UIFont.textRegular04])
+        textField.returnKeyType = .done
+        textField.setLeftPaddingPoints(12)
+        textField.setRightPaddingPoints(12)
+        
+        return textField
+    }()
+    
+    private let checkImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "iconDone")
+        
+        return imageView
+    }()
+    
+    private let explainLabel: UILabel = {
+        let label = UILabel()
+        label.text = "새로운 그룹은 최대 4개까지만 등록 가능합니다."
+        label.textColor = .mainColorButtonText
+        label.font = .textRegular05
+        
+        return label
+    }()
+    
+    // MARK: - View Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupUI()
+        addGroupTextField.delegate = self
+        IQKeyboardManager.shared.shouldResignOnTouchOutside = false
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        self.addGroupTextField.becomeFirstResponder()
+    }
+    
+    // MARK: - @Functions
+    // UI 세팅 작업
+    private func setupUI() {
+        view.addSubview(addGroupTextField)
+        view.addSubview(checkImageView)
+        view.addSubview(explainLabel)
+        
+        setupLayout()
+    }
+    
+    // 레이아웃 세팅
+    private func setupLayout() {
+        addGroupTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            addGroupTextField.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+            addGroupTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            addGroupTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            addGroupTextField.heightAnchor.constraint(equalToConstant: 45)
+        ])
+        
+        checkImageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            checkImageView.topAnchor.constraint(equalTo: addGroupTextField.bottomAnchor, constant: 7),
+            checkImageView.leadingAnchor.constraint(equalTo: addGroupTextField.leadingAnchor, constant: 4),
+            checkImageView.widthAnchor.constraint(equalToConstant: 16),
+            checkImageView.heightAnchor.constraint(equalToConstant: 16)
+        ])
+        
+        explainLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            explainLabel.topAnchor.constraint(equalTo: addGroupTextField.bottomAnchor, constant: 8),
+            explainLabel.leadingAnchor.constraint(equalTo: checkImageView.trailingAnchor, constant: 5)
+        ])
+    }
+}
+
+extension GroupNameEditBottomSheetViewController {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        hideBottomSheetAndGoBack()
+        return true
+    }
+}

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardHarmonyViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardHarmonyViewController.swift
@@ -21,11 +21,11 @@ class CardHarmonyViewController: UIViewController {
             self.dimmedBackView.alpha = 0.0
             self.view.layoutIfNeeded()
             self.popUpView.isHidden = true
-        }) { _ in
+        }, completion: { _ in
             if self.presentingViewController != nil {
                 self.dismiss(animated: false, completion: nil)
             }
-        }
+        })
     }
     
     var percentageColor: UIColor?

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class GroupEditViewController: UIViewController {
+class GroupEditViewController: UIViewController, GroupEditViewDelegate {
 
     // MARK: - Properties
     var cardItems = ["SOPT", "동아리", "학교", "NADA NADA NADA NADA NADA"]
@@ -39,6 +39,19 @@ class GroupEditViewController: UIViewController {
     }
 }
 
+// MARK: - Extensions
+extension GroupEditViewController {
+    
+    func presentToGroupNameEdit() {
+        let nextVC = GroupNameEditBottomSheetViewController()
+                    .setTitle("그룹명 변경")
+                    .setHeight(184)
+        nextVC.modalPresentationStyle = .overFullScreen
+        self.present(nextVC, animated: false, completion: nil)
+    }
+    
+}
+
 // MARK: - TableView Delegate
 extension GroupEditViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -61,6 +74,7 @@ extension GroupEditViewController: UITableViewDelegate {
         
         return swipeActions
     }
+    
 }
 
 // MARK: - TableView DataSource
@@ -73,6 +87,7 @@ extension GroupEditViewController: UITableViewDataSource {
         guard let serviceCell = tableView.dequeueReusableCell(withIdentifier: Const.Xib.groupEditTableViewCell, for: indexPath) as? GroupEditTableViewCell else { return UITableViewCell() }
         
         serviceCell.initData(title: cardItems[indexPath.row])
+        serviceCell.delegate = self
         
         return serviceCell
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
@@ -42,12 +42,16 @@ class GroupEditViewController: UIViewController, GroupEditViewDelegate {
 // MARK: - Extensions
 extension GroupEditViewController {
     
-    func presentToGroupNameEdit() {
+    func presentToGroupNameEdit(_ sender: UILabel) {
+        let contentView = sender.superview
+        guard let cell = contentView?.superview as? UITableViewCell else { return }
+        let index = groupEditTableView.indexPath(for: cell)
+        
         let nextVC = GroupNameEditBottomSheetViewController()
             .setTitle("그룹명 변경")
             .setHeight(184)
         nextVC.modalPresentationStyle = .overFullScreen
-        nextVC.text = cardItems[0]
+        nextVC.text = cardItems[index!.row]
         
         self.present(nextVC, animated: false, completion: nil)
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
@@ -45,13 +45,13 @@ extension GroupEditViewController {
     func presentToGroupNameEdit(_ sender: UILabel) {
         let contentView = sender.superview
         guard let cell = contentView?.superview as? UITableViewCell else { return }
-        let index = groupEditTableView.indexPath(for: cell)
+        guard let index = groupEditTableView.indexPath(for: cell) else { return }
         
         let nextVC = GroupNameEditBottomSheetViewController()
             .setTitle("그룹명 변경")
             .setHeight(184)
         nextVC.modalPresentationStyle = .overFullScreen
-        nextVC.text = cardItems[index!.row]
+        nextVC.text = cardItems[index.row]
         
         self.present(nextVC, animated: false, completion: nil)
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class GroupEditViewController: UIViewController, GroupEditViewDelegate {
-
+    
     // MARK: - Properties
     var cardItems = ["SOPT", "동아리", "학교", "NADA NADA NADA NADA NADA"]
     
@@ -32,8 +32,8 @@ class GroupEditViewController: UIViewController, GroupEditViewDelegate {
     
     @IBAction func presentToAddGroupBottom(_ sender: UIButton) {
         let nextVC = AddGroupBottomSheetViewController()
-                    .setTitle("그룹 추가")
-                    .setHeight(184)
+            .setTitle("그룹 추가")
+            .setHeight(184)
         nextVC.modalPresentationStyle = .overFullScreen
         self.present(nextVC, animated: false, completion: nil)
     }
@@ -44,9 +44,11 @@ extension GroupEditViewController {
     
     func presentToGroupNameEdit() {
         let nextVC = GroupNameEditBottomSheetViewController()
-                    .setTitle("그룹명 변경")
-                    .setHeight(184)
+            .setTitle("그룹명 변경")
+            .setHeight(184)
         nextVC.modalPresentationStyle = .overFullScreen
+        nextVC.text = cardItems[0]
+        
         self.present(nextVC, animated: false, completion: nil)
     }
     
@@ -64,7 +66,7 @@ extension GroupEditViewController: UITableViewDelegate {
             self.makeCancelDeleteAlert(title: "그룹 삭제", message: "해당 그룹에 있던 명함은\n미분류 그룹으로 이동합니다.", cancelAction: { _ in
                 // 취소 눌렀을 때 액션이 들어갈 부분
             }, deleteAction: { _ in
-                // 
+                //
             })
         })
         deleteAction.backgroundColor = .red

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -77,7 +77,7 @@ extension LoginViewController {
             } else {
                 print("loginWithKakaoTalk() success.")
                 
-                UserApi.shared.me() {(user, error) in
+                UserApi.shared.me {(user, error) in
                     if let error = error {
                         print(error)
                     } else {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Splash/SplashViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Splash/SplashViewController.swift
@@ -15,7 +15,6 @@ class SplashViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
-
     /*
     // MARK: - Navigation
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#142

🌱 작업한 내용
- 그룹 편집 뷰, cell 라벨 클릭했을때 인식되도록 변경
- 그룹명 변경 바텀시트 추가 -> Const에도 추가
- 바텀 시트 데이터 전달되어서 텍스트 필드에는 값 포함되어 있는 상태로 표출
- 기타 SwiftLint 워닝 해결

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![Simulator-Screen-Recording-iPhone-12-mini-2021-12-12-at-20 47 34](https://user-images.githubusercontent.com/69389288/145710933-6d4bc5cb-774a-491b-ba6a-d76cf18687a7.gif)|

## 📮 관련 이슈
- Resolved: #142 
