### PR TITLE
[FIX] #145 - 메인 flip 속도 조절 및 공유버튼 히든

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -64,34 +64,37 @@ extension BackCardCell {
                   _ isSauced: Bool,
                   _ firstTMI: String,
                   _ secondTMI: String,
-                  _ thirdTMI: String) {
+                  _ thirdTMI: String,
+                  isShareable: Bool) {
         if let bgImage = UIImage(named: backgroundImageString) {
             self.backgroundImageView.image = bgImage
         }
         
-        self.mintImageView.image = isMint == true ?
+        mintImageView.image = isMint == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")
-        self.noMintImageView.image = isMint == false ?
+        noMintImageView.image = isMint == false ?
         UIImage(named: "iconTasteOnBanmincho") : UIImage(named: "iconTasteOffBanmincho")
         
-        self.sojuImageView.image = isSoju == true ?
+        sojuImageView.image = isSoju == true ?
         UIImage(named: "iconTasteOnSoju") : UIImage(named: "iconTasteOffSoju")
-        self.beerImageView.image = isSoju == false ?
+        beerImageView.image = isSoju == false ?
         UIImage(named: "iconTasteOnBeer") : UIImage(named: "iconTasteOffBeer")
         
-        self.pourEatImageView.image = isBoomuk == true ?
+        pourEatImageView.image = isBoomuk == true ?
         UIImage(named: "iconTasteOnBumeok") : UIImage(named: "iconTasteOffBumeok")
-        self.putSauceEatImageView.image = isBoomuk == false ?
+        putSauceEatImageView.image = isBoomuk == false ?
         UIImage(named: "iconTasteOnZzik") : UIImage(named: "iconTasteOffZzik")
         
-        self.sauceChickenImageView.image = isSauced == true ?
+        sauceChickenImageView.image = isSauced == true ?
         UIImage(named: "iconTasteOnSeasoned") : UIImage(named: "iconTasteOffSeasoned")
-        self.friedChickenImageView.image = isSauced == false ?
+        friedChickenImageView.image = isSauced == false ?
         UIImage(named: "iconTasteOnFried") : UIImage(named: "iconTasteOffFried")
         
-        self.firstTmiLabel.text = firstTMI
-        self.secondTmiLabel.text = secondTMI
-        self.thirdTmiLabel.text = thirdTMI
+        firstTmiLabel.text = firstTMI
+        secondTmiLabel.text = secondTMI
+        thirdTmiLabel.text = thirdTMI
+        
+        shareButton.isHidden = !isShareable
     }
     
     /// 명함생성할 때 image 를 UIImage 로 가져올 경우 사용

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -101,7 +101,8 @@ extension FrontCardCell {
                   _ birth: String,
                   _ mbti: String,
                   _ instagramID: String,
-                  _ linkURL: String) {
+                  _ linkURL: String,
+                  isShareable: Bool) {
         if let bgImage = UIImage(named: backgroundImage) {
             self.backgroundImageView.image = bgImage
         }
@@ -112,6 +113,8 @@ extension FrontCardCell {
         mbtiLabel.text = mbti
         instagramIDLabel.text = instagramID
         linkURLLabel.text = linkURL
+        
+        shareButton.isHidden = !isShareable
     }
     
     /// 명함생성할 때 image 를 UIImage 로 가져올 경우 사용
@@ -122,7 +125,8 @@ extension FrontCardCell {
                   _ birth: String,
                   _ mbti: String,
                   _ instagramID: String,
-                  _ linkURL: String) {
+                  _ linkURL: String,
+                  isShareable: Bool) {
         backgroundImageView.image = backgroundImage ?? UIImage()
         titleLabel.text = cardTitle
         descriptionLabel.text = cardDescription
@@ -131,5 +135,7 @@ extension FrontCardCell {
         mbtiLabel.text = mbti
         instagramIDLabel.text = instagramID
         linkURLLabel.text = linkURL
+        
+        shareButton.isHidden = !isShareable
     }
 }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -14,8 +14,8 @@ class MainCardCell: CardCell {
     // MARK: - Properties
     
     private var isFront = true
-    private var isShareable = true
     
+    public var isShareable: Bool?
     public var cardDataModel: Card?
     
     // MARK: - View Life Cycle
@@ -49,7 +49,7 @@ extension MainCardCell {
                            cardDataModel.mbti,
                            cardDataModel.instagram ?? "",
                            cardDataModel.link ?? "",
-                           isShareable: isShareable)
+                           isShareable: isShareable ?? false)
         
         contentView.addSubview(frontCard)
     }
@@ -81,7 +81,7 @@ extension MainCardCell {
                               cardDataModel.oneTMI ?? "",
                               cardDataModel.twoTMI ?? "",
                               cardDataModel.thirdTMI ?? "",
-                              isShareable: isShareable)
+                              isShareable: isShareable ?? false)
             
             contentView.addSubview(backCard)
             isFront = false
@@ -98,7 +98,7 @@ extension MainCardCell {
                                cardDataModel.mbti,
                                cardDataModel.instagram ?? "",
                                cardDataModel.link ?? "",
-                               isShareable: isShareable)
+                               isShareable: isShareable ?? false)
             
             contentView.addSubview(frontCard)
             isFront = true

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -14,6 +14,7 @@ class MainCardCell: CardCell {
     // MARK: - Properties
     
     private var isFront = true
+    private var isShareable = true
     
     public var cardDataModel: Card?
     
@@ -47,7 +48,8 @@ extension MainCardCell {
                            cardDataModel.birthDate,
                            cardDataModel.mbti,
                            cardDataModel.instagram ?? "",
-                           cardDataModel.link ?? "")
+                           cardDataModel.link ?? "",
+                           isShareable: isShareable)
         
         contentView.addSubview(frontCard)
     }
@@ -78,7 +80,8 @@ extension MainCardCell {
                               cardDataModel.isSauced,
                               cardDataModel.oneTMI ?? "",
                               cardDataModel.twoTMI ?? "",
-                              cardDataModel.thirdTMI ?? "")
+                              cardDataModel.thirdTMI ?? "",
+                              isShareable: isShareable)
             
             contentView.addSubview(backCard)
             isFront = false
@@ -94,7 +97,8 @@ extension MainCardCell {
                                cardDataModel.birthDate,
                                cardDataModel.mbti,
                                cardDataModel.instagram ?? "",
-                               cardDataModel.link ?? "")
+                               cardDataModel.link ?? "",
+                               isShareable: isShareable)
             
             contentView.addSubview(frontCard)
             isFront = true

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -36,7 +36,6 @@ class MainCardCell: CardCell {
 // MARK: - Extensions
 
 extension MainCardCell {
-    private func setUI() { }
     public func setFrontCard() {
         guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
         
@@ -102,11 +101,11 @@ extension MainCardCell {
             isFront = true
         }
         if swipeGesture.direction == .right {
-            UIView.transition(with: contentView, duration: 1, options: .transitionFlipFromLeft, animations: nil) { _ in
+            UIView.transition(with: contentView, duration: 0.5, options: .transitionFlipFromLeft, animations: nil) { _ in
                 self.contentView.subviews[0].removeFromSuperview()
             }
         } else {
-            UIView.transition(with: contentView, duration: 1, options: .transitionFlipFromRight, animations: nil) { _ in
+            UIView.transition(with: contentView, duration: 0.5, options: .transitionFlipFromRight, animations: nil) { _ in
                 self.contentView.subviews[0].removeFromSuperview()
             }
         }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -21,8 +21,7 @@ class MainCardCell: CardCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        
-        setUI()
+
         setGestureRecognizer()
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -16,6 +16,7 @@ class CardCreationPreviewViewController: UIViewController {
     
     private var isFront = true
     private var cardCreationRequest: CardCreationRequest?
+    private var isShareable = false
     
     // MARK: - @IBOutlet Properties
     
@@ -83,7 +84,15 @@ extension CardCreationPreviewViewController {
         
         frontCard.frame = CGRect(x: 0, y: 0, width: cardView.frame.width, height: cardView.frame.height)
         guard let frontCardDataModel = frontCardDataModel else { return }
-        frontCard.initCell(cardBackgroundImage, frontCardDataModel.title, frontCardDataModel.description, frontCardDataModel.name, frontCardDataModel.birthDate, frontCardDataModel.mbti, frontCardDataModel.instagramID, frontCardDataModel.linkURL)
+        frontCard.initCell(cardBackgroundImage,
+                           frontCardDataModel.title,
+                           frontCardDataModel.description,
+                           frontCardDataModel.name,
+                           frontCardDataModel.birthDate,
+                           frontCardDataModel.mbti,
+                           frontCardDataModel.instagramID,
+                           frontCardDataModel.linkURL,
+                           isShareable: isShareable)
         
         cardView.addSubview(frontCard)
     }
@@ -147,7 +156,8 @@ extension CardCreationPreviewViewController {
                                frontCardDataModel.birthDate,
                                frontCardDataModel.mbti,
                                frontCardDataModel.instagramID,
-                               frontCardDataModel.linkURL)
+                               frontCardDataModel.linkURL,
+                               isShareable: isShareable)
             
             cardView.addSubview(frontCard)
             isFront = true

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -38,6 +38,7 @@ class CardDetailViewController: UIViewController {
     @IBOutlet weak var backButton: UIButton!
     
     public var cardDataModel: Card?
+    private var isShareable: Bool = false
     
     private var isFront = true
     var status: Status = .group
@@ -98,7 +99,8 @@ extension CardDetailViewController {
                            cardDataModel?.birthDate ?? "",
                            cardDataModel?.mbti ?? "",
                            cardDataModel?.instagram ?? "",
-                           cardDataModel?.link ?? "")
+                           cardDataModel?.link ?? "",
+                           isShareable: isShareable)
         
         cardView.addSubview(frontCard)
     }
@@ -126,7 +128,8 @@ extension CardDetailViewController {
                               cardDataModel?.isSauced ?? true,
                               cardDataModel?.oneTMI ?? "",
                               cardDataModel?.twoTMI ?? "",
-                              cardDataModel?.thirdTMI ?? "")
+                              cardDataModel?.thirdTMI ?? "",
+                              isShareable: isShareable)
             
             cardView.addSubview(backCard)
             isFront = false
@@ -141,7 +144,8 @@ extension CardDetailViewController {
                                cardDataModel?.birthDate ?? "",
                                cardDataModel?.mbti ?? "",
                                cardDataModel?.instagram ?? "",
-                               cardDataModel?.link ?? "")
+                               cardDataModel?.link ?? "",
+                               isShareable: isShareable)
             
             cardView.addSubview(frontCard)
             isFront = true

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -147,6 +147,7 @@ extension FrontViewController: VerticalCardSwiperDatasource {
         guard let cell = verticalCardSwiperView.dequeueReusableCell(withReuseIdentifier: Const.Xib.mainCardCell, for: index) as? MainCardCell else { return CardCell() }
         guard let cardDataList = cardDataList else { return CardCell() }
         cell.initCell(cardDataModel: cardDataList[index])
+        cell.isShareable = true
         cell.setFrontCard()
         
         return cell

--- a/NADA-iOS-forRelease/Sources/ViewControllers/TeamNADA/TeamNADAViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/TeamNADA/TeamNADAViewController.swift
@@ -167,6 +167,7 @@ extension TeamNADAViewController: VerticalCardSwiperDatasource {
         guard let cell = verticalCardSwiperView.dequeueReusableCell(withReuseIdentifier: Const.Xib.mainCardCell, for: index) as? MainCardCell else { return CardCell() }
         guard let cardDataList = cardDataList else { return CardCell() }
         cell.initCell(cardDataModel: cardDataList[index])
+        cell.isShareable = false
         cell.setFrontCard()
         
         return cell


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#145

🌱 작업한 내용
- 메인 flip 속도 변경 1 -> 0.5
- 사용하지 않는 `setUI()` 메서드 삭제
### 공유하기 버튼
- 명함 메인뷰 공유하기 보이게 하기
- 팀나다뷰 공유하기 hidden
- 명함 상세뷰 공유하기 hidden
- 명함생성 미리보기뷰 공유하기 hidden

> 워닝이 없는 곳에서의 self 지웠습니당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|상세보기|<img src="https://user-images.githubusercontent.com/69136340/145983215-2d934064-48a4-4bf5-9c6c-bc15b35e4733.jpeg" width="250">
|팀나다|<img src="https://user-images.githubusercontent.com/69136340/145983219-e601aaac-5b2c-4da6-b789-f01142e896e7.jpeg" width="250">
|메인|<img src="https://user-images.githubusercontent.com/69136340/145983187-cc075ba4-0ae9-4d9a-ad68-cca2c2feb552.jpeg" width="250">


## 📮 관련 이슈
- Resolved: #145
