### PR TITLE
[FIX] #153 - 카드가 겹쳐보이는 버그

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -14,6 +14,10 @@ class MainCardCell: CardCell {
     // MARK: - Properties
     
     private var isFront = true
+    private enum Size {
+        static let cellHeight: CGFloat = 540
+        static let cellWidth: CGFloat = 327
+    }
     
     public var isShareable: Bool?
     public var cardDataModel: Card?
@@ -24,6 +28,12 @@ class MainCardCell: CardCell {
         super.awakeFromNib()
 
         setGestureRecognizer()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        contentView.subviews.forEach { $0.removeFromSuperview() }
     }
     
     // MARK: - Methods
@@ -39,7 +49,7 @@ extension MainCardCell {
     public func setFrontCard() {
         guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
         
-        frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
+        frontCard.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
         guard let cardDataModel = cardDataModel else { return }
         frontCard.initCell(cardDataModel.background,
                            cardDataModel.title,
@@ -71,7 +81,7 @@ extension MainCardCell {
     private func transitionCardWithAnimation(_ swipeGesture: UISwipeGestureRecognizer) {
         if isFront {
             guard let backCard = BackCardCell.nib().instantiate(withOwner: self, options: nil).first as? BackCardCell else { return }
-            backCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
+            backCard.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
             guard let cardDataModel = cardDataModel else { return }
             backCard.initCell(cardDataModel.background,
                               cardDataModel.isMincho,
@@ -88,7 +98,7 @@ extension MainCardCell {
         } else {
             guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
             
-            frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
+            frontCard.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
             guard let cardDataModel = cardDataModel else { return }
             frontCard.initCell(cardDataModel.background,
                                cardDataModel.title,

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -34,6 +34,7 @@ class MainCardCell: CardCell {
         super.prepareForReuse()
         
         contentView.subviews.forEach { $0.removeFromSuperview() }
+        contentView.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
     }
     
     // MARK: - Methods
@@ -49,7 +50,7 @@ extension MainCardCell {
     public func setFrontCard() {
         guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
         
-        frontCard.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
+        frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
         guard let cardDataModel = cardDataModel else { return }
         frontCard.initCell(cardDataModel.background,
                            cardDataModel.title,
@@ -81,7 +82,7 @@ extension MainCardCell {
     private func transitionCardWithAnimation(_ swipeGesture: UISwipeGestureRecognizer) {
         if isFront {
             guard let backCard = BackCardCell.nib().instantiate(withOwner: self, options: nil).first as? BackCardCell else { return }
-            backCard.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
+            backCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
             guard let cardDataModel = cardDataModel else { return }
             backCard.initCell(cardDataModel.background,
                               cardDataModel.isMincho,
@@ -98,7 +99,7 @@ extension MainCardCell {
         } else {
             guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
             
-            frontCard.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
+            frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
             guard let cardDataModel = cardDataModel else { return }
             frontCard.initCell(cardDataModel.background,
                                cardDataModel.title,


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#153

🌱 작업한 내용
- prepareForReuse() 오버라이드해서 subview 를 다 지워서 초기화해주었다.
- 카드크기가 contentview 로 잡아버리니까 작아져서 prepareForReuse() 에서 크기도 초기화해주었다.
> 카드가 현재 위로 올라가면 좌우 폭이 줄어드는데 이것이 초기화 되지 않는 원인으로 파악됨.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src="https://user-images.githubusercontent.com/69136340/146048793-98f02162-0387-4d8a-a8d7-f23d0119d638.gif" width="250">|

## 📮 관련 이슈
- Resolved: #153
