### PR TITLE
[FIX] #152 - 뷰 수정 한번에 처리

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
@@ -73,6 +73,7 @@
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="540" id="QoQ-xU-ny7"/>
+                                    <constraint firstAttribute="width" constant="327" id="kxJ-eu-o5K"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -101,13 +102,14 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
+                            <constraint firstItem="3LS-7h-1h3" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="24" id="2og-jr-jCJ"/>
                             <constraint firstItem="0P6-1k-dQm" firstAttribute="top" secondItem="Bq2-MB-M50" secondAttribute="bottom" constant="20" id="4hH-Kb-3uL"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="3LS-7h-1h3" secondAttribute="bottom" id="7Tv-CU-X3h"/>
                             <constraint firstItem="yM7-jk-cSi" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="CGs-NI-i21"/>
                             <constraint firstItem="Bq2-MB-M50" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="DKg-sD-igs"/>
                             <constraint firstItem="Bq2-MB-M50" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="Oh4-BP-iH9"/>
                             <constraint firstItem="yM7-jk-cSi" firstAttribute="top" secondItem="0P6-1k-dQm" secondAttribute="bottom" constant="13" id="XRH-f9-jqw"/>
-                            <constraint firstItem="0P6-1k-dQm" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="24" id="Yhm-Gf-yqd"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="3LS-7h-1h3" secondAttribute="trailing" constant="24" id="fag-w7-Yoe"/>
                             <constraint firstItem="Bq2-MB-M50" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="jse-aF-Dba"/>
                             <constraint firstItem="0P6-1k-dQm" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="qBS-fn-4f0"/>
                             <constraint firstItem="3LS-7h-1h3" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="qYv-Oj-pjV"/>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
@@ -99,7 +99,7 @@
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="0P6-1k-dQm" firstAttribute="top" secondItem="Bq2-MB-M50" secondAttribute="bottom" constant="20" id="4hH-Kb-3uL"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="3LS-7h-1h3" secondAttribute="bottom" id="7Tv-CU-X3h"/>
@@ -134,9 +134,6 @@
         <namedColor name="secondary">
             <color red="0.16862745098039217" green="0.17647058823529413" blue="0.19215686274509805" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemGray6Color">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
@@ -67,7 +67,9 @@ class CardResultBottomSheetViewController: CommonBottomSheetViewController {
         addButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             addButton.topAnchor.constraint(equalTo: cardView.bottomAnchor, constant: 30),
-            addButton.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor)
+            addButton.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor),
+            addButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            addButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
         ])
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -55,14 +55,18 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
         groupPicker.selectedRow(inComponent: 0)
         groupPicker.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            groupPicker.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 14),
-            groupPicker.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor)
+            groupPicker.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: -20),
+            groupPicker.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor),
+            groupPicker.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            groupPicker.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
         ])
         
         doneButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             doneButton.topAnchor.constraint(equalTo: groupPicker.bottomAnchor, constant: 0),
-            doneButton.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor)
+            doneButton.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor),
+            doneButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            doneButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
         ])
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -316,7 +316,7 @@ extension GroupViewController: UICollectionViewDelegateFlowLayout {
             }
             height = collectionView.frame.size.height
         case cardsCollectionView:
-            width = collectionView.frame.size.width * 156/327
+            width = collectionView.frame.size.width/2 - collectionView.frame.size.width * 8/327
             height = collectionView.frame.size.height * 258/558
         default:
             width = 0

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
@@ -17,7 +17,7 @@ class QRScanViewController: UIViewController {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "QR스캔"
-        label.textColor = .background
+        label.textColor = .white
         label.font = UIFont.title01
         return label
     }()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#152

🌱 작업한 내용
- 그룹 선택 바텀시트 수정
- QR스캔 라벨 화이트로 고정
- 명함 상세뷰 네비바 색깔 수정
- 명함 그룹 뷰 맥스 대응

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|그룹선택 바텀시트 수정|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-12-15 at 02 31 41](https://user-images.githubusercontent.com/69078056/146049942-c2c2a764-6dbf-4ac5-9943-f7d08ffa9a1d.png)|명함 그룹 뷰 맥스 대응|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-12-15 at 02 30 51](https://user-images.githubusercontent.com/69078056/146049965-7c00e15c-9ea5-4b18-8149-a82c3faa31dd.png)|
|네비바 색깔 수정|![Simulator Screen Shot - iPhone 12 mini - 2021-12-15 at 02 32 41](https://user-images.githubusercontent.com/69078056/146049937-186b0e17-b2bd-4afd-a729-fca9ad5f9f74.png)|QR스캔 라벨 화이트|진짜죄송한데실기기키기가너무귀찮아요아하하하근데바꼈어요!|


## 📮 관련 이슈
- Resolved: #152
