### PR TITLE
[FIX] #156 - 명함생성뷰 버그 해결

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 extension Notification.Name {
-    static let frontCardBirth = Notification.Name("frontCardBirth")
-    static let frontCardMBTI = Notification.Name("frontCardMBTI")
+    static let completeFrontCardBirth = Notification.Name("completeFrontCardBirth")
+    static let completeFrontCardMBTI = Notification.Name("completeFrontCardMBTI")
     static let presentingImagePicker = Notification.Name("presentingImagePicker")
     static let sendNewImage = Notification.Name("sendNewImage")
     static let touchRequiredView = Notification.Name("touchRequiredView")

--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -12,4 +12,6 @@ extension Notification.Name {
     static let frontCardMBTI = Notification.Name("frontCardMBTI")
     static let presentingImagePicker = Notification.Name("presentingImagePicker")
     static let sendNewImage = Notification.Name("sendNewImage")
+    static let touchRequiredView = Notification.Name("touchRequiredView")
+    static let dismissRequiredBottomSheet = Notification.Name("dismissRequiredBottomSheet")
 }

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
@@ -119,6 +119,7 @@ extension BackCardCreationCollectionViewCell {
     }
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissKeyboard), name: .touchRequiredView, object: nil)
     }
     private func checkBackCardStatus() {
         backCardCreationDelegate?.backCardCreation(withRequired: [
@@ -170,6 +171,10 @@ extension BackCardCreationCollectionViewCell {
                 return
             }
         }
+    }
+    @objc
+    private func dismissKeyboard() {
+        _ = textFieldList.map { $0.resignFirstResponder() }
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import IQKeyboardManagerSwift
+
 class BackCardCreationCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Properties
@@ -53,6 +55,8 @@ class BackCardCreationCollectionViewCell: UICollectionViewCell {
 
 extension BackCardCreationCollectionViewCell {
     private func setUI() {
+        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
+        
         initUITextFieldList()
         initCollectionViewList()
         

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -178,8 +178,8 @@ extension FrontCardCreationCollectionViewCell {
         _ = optionalTextFieldList.map { $0.delegate = self }
     }
     private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(setBirthTextField(notification:)), name: .frontCardBirth, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(setMBTITextField(notification:)), name: .frontCardMBTI, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setBirthText(notification:)), name: .completeFrontCardBirth, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setMBTIText(notification:)), name: .completeFrontCardMBTI, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(setCardBackgroundImage(notifiation:)), name: .sendNewImage, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(dismissBorderLine), name: .dismissRequiredBottomSheet, object: nil)
@@ -218,16 +218,22 @@ extension FrontCardCreationCollectionViewCell {
     // MARK: - @objc Methods
     
     @objc
-    private func setBirthTextField(notification: NSNotification) {
+    private func setBirthText(notification: NSNotification) {
         birthLabel.text = notification.object as? String
-        birthView.borderWidth = 0
         birthLabel.textColor = .primary
+        
+        birthView.borderWidth = 0
+        
+        checkFrontCradStatus()
     }
     @objc
-    private func setMBTITextField(notification: NSNotification) {
+    private func setMBTIText(notification: NSNotification) {
         mbtiLabel.text = notification.object as? String
-        mbtiView.borderWidth = 0
         mbtiLabel.textColor = .primary
+        
+        mbtiView.borderWidth = 0
+        
+        checkFrontCradStatus()
     }
     @objc
     private func setCardBackgroundImage(notifiation: NSNotification) {

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import IQKeyboardManagerSwift
+
 class FrontCardCreationCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Protocols
@@ -61,6 +63,8 @@ class FrontCardCreationCollectionViewCell: UICollectionViewCell {
 
 extension FrontCardCreationCollectionViewCell {
     private func setUI() {
+        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
+        
         initUITextFieldList()
         backgroundSettingCollectionView.showsHorizontalScrollIndicator = false
         scrollView.indicatorStyle = .default

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -342,6 +342,11 @@ extension FrontCardCreationCollectionViewCell: UICollectionViewDataSource {
             guard let image = UIImage(named: backgroundList[indexPath.item]) else { return UICollectionViewCell() }
             cell.initCell(image: image, isFirst: false)
         }
+        
+        if defaultImageIndex == 0 &&
+           indexPath.item == 0 {
+            collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .init())
+        }
         return cell
     }
 }

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.xib
@@ -71,22 +71,6 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Ss-SD-KCR">
-                                        <rect key="frame" x="24" y="335" width="305" height="44"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="dPR-VB-I9a"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits"/>
-                                    </textField>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="EdP-zA-fyD">
-                                        <rect key="frame" x="24" y="389" width="305" height="44"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="eeN-Lu-dTl"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits"/>
-                                    </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FC8-TR-MGL">
                                         <rect key="frame" x="24" y="463" width="42" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -117,40 +101,74 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bnb-dB-y9j">
+                                        <rect key="frame" x="24" y="335" width="305" height="44"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f7b-Sb-tdA">
+                                                <rect key="frame" x="12" y="11.5" width="41.5" height="21"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                        <constraints>
+                                            <constraint firstItem="f7b-Sb-tdA" firstAttribute="centerY" secondItem="bnb-dB-y9j" secondAttribute="centerY" id="7GM-EB-9lN"/>
+                                            <constraint firstItem="f7b-Sb-tdA" firstAttribute="leading" secondItem="bnb-dB-y9j" secondAttribute="leading" constant="12" id="l9s-7O-qu1"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XZy-Ne-utd">
+                                        <rect key="frame" x="24" y="389" width="305" height="44"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xuR-Ne-hLd">
+                                                <rect key="frame" x="12" y="11.5" width="41.5" height="21"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                        <constraints>
+                                            <constraint firstItem="xuR-Ne-hLd" firstAttribute="leading" secondItem="XZy-Ne-utd" secondAttribute="leading" constant="12" id="H3M-l7-OqP"/>
+                                            <constraint firstItem="xuR-Ne-hLd" firstAttribute="centerY" secondItem="XZy-Ne-utd" secondAttribute="centerY" id="dJ3-gW-4i6"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="hYQ-8Z-Bod" firstAttribute="top" secondItem="Ki8-qn-Bo1" secondAttribute="bottom" constant="30" id="0rN-Ck-PwW"/>
                                     <constraint firstItem="d1H-pL-FAS" firstAttribute="top" secondItem="hYQ-8Z-Bod" secondAttribute="bottom" constant="10" id="2uL-Wi-fyP"/>
                                     <constraint firstAttribute="bottom" secondItem="mxK-gN-Nz2" secondAttribute="bottom" constant="14" id="4Dp-gY-Uak"/>
-                                    <constraint firstItem="2Ss-SD-KCR" firstAttribute="leading" secondItem="VfE-eb-mbT" secondAttribute="leading" id="6GD-YY-zzh"/>
-                                    <constraint firstItem="ldM-3t-32q" firstAttribute="trailing" secondItem="EdP-zA-fyD" secondAttribute="trailing" id="6xN-KS-gal"/>
+                                    <constraint firstItem="bnb-dB-y9j" firstAttribute="top" secondItem="VfE-eb-mbT" secondAttribute="bottom" constant="10" id="9EU-Px-08f"/>
                                     <constraint firstItem="ZK4-3D-SM0" firstAttribute="top" secondItem="ldM-3t-32q" secondAttribute="bottom" constant="10" id="9pH-EC-W5x"/>
                                     <constraint firstAttribute="trailing" secondItem="d1H-pL-FAS" secondAttribute="trailing" constant="24" id="BFd-eV-ue0"/>
                                     <constraint firstItem="Ij6-4i-oGx" firstAttribute="top" secondItem="rtM-7c-eeD" secondAttribute="top" constant="23" id="Iog-P0-VBi"/>
                                     <constraint firstItem="l0G-Oe-aZm" firstAttribute="leading" secondItem="hYQ-8Z-Bod" secondAttribute="leading" id="KAR-CA-812"/>
                                     <constraint firstItem="VfE-eb-mbT" firstAttribute="trailing" secondItem="d1H-pL-FAS" secondAttribute="trailing" id="KUY-9m-Aqe"/>
                                     <constraint firstItem="ldM-3t-32q" firstAttribute="top" secondItem="FC8-TR-MGL" secondAttribute="bottom" constant="10" id="Kbg-vM-z16"/>
+                                    <constraint firstItem="ldM-3t-32q" firstAttribute="trailing" secondItem="VfE-eb-mbT" secondAttribute="trailing" id="MSJ-8e-ho3"/>
                                     <constraint firstItem="Ki8-qn-Bo1" firstAttribute="top" secondItem="Ij6-4i-oGx" secondAttribute="bottom" constant="11" id="MWZ-BM-51t"/>
                                     <constraint firstAttribute="trailing" secondItem="Ki8-qn-Bo1" secondAttribute="trailing" id="NV0-oS-82P"/>
                                     <constraint firstItem="l0G-Oe-aZm" firstAttribute="top" secondItem="d1H-pL-FAS" secondAttribute="bottom" constant="30" id="NnQ-Hr-KPD"/>
-                                    <constraint firstItem="ldM-3t-32q" firstAttribute="leading" secondItem="EdP-zA-fyD" secondAttribute="leading" id="Nu4-pk-abX"/>
-                                    <constraint firstItem="EdP-zA-fyD" firstAttribute="trailing" secondItem="2Ss-SD-KCR" secondAttribute="trailing" id="SgG-c6-RnM"/>
+                                    <constraint firstItem="bnb-dB-y9j" firstAttribute="trailing" secondItem="VfE-eb-mbT" secondAttribute="trailing" id="TDV-as-jo2"/>
                                     <constraint firstItem="VfE-eb-mbT" firstAttribute="top" secondItem="l0G-Oe-aZm" secondAttribute="bottom" constant="10" id="Wm7-Xp-BAw"/>
-                                    <constraint firstItem="EdP-zA-fyD" firstAttribute="leading" secondItem="2Ss-SD-KCR" secondAttribute="leading" id="amf-f8-LFT"/>
+                                    <constraint firstItem="XZy-Ne-utd" firstAttribute="leading" secondItem="VfE-eb-mbT" secondAttribute="leading" id="ZtX-yr-VQj"/>
                                     <constraint firstItem="VfE-eb-mbT" firstAttribute="leading" secondItem="d1H-pL-FAS" secondAttribute="leading" id="bXt-8y-Bv4"/>
-                                    <constraint firstItem="FC8-TR-MGL" firstAttribute="top" secondItem="EdP-zA-fyD" secondAttribute="bottom" constant="30" id="bdX-Ek-H4L"/>
-                                    <constraint firstItem="EdP-zA-fyD" firstAttribute="top" secondItem="2Ss-SD-KCR" secondAttribute="bottom" constant="10" id="fLw-u4-paB"/>
+                                    <constraint firstItem="XZy-Ne-utd" firstAttribute="height" secondItem="VfE-eb-mbT" secondAttribute="height" id="bZ0-GX-32r"/>
+                                    <constraint firstItem="bnb-dB-y9j" firstAttribute="leading" secondItem="VfE-eb-mbT" secondAttribute="leading" id="gvw-hi-LsF"/>
                                     <constraint firstItem="hYQ-8Z-Bod" firstAttribute="leading" secondItem="Ij6-4i-oGx" secondAttribute="leading" id="hI1-hs-5Um"/>
+                                    <constraint firstItem="bnb-dB-y9j" firstAttribute="height" secondItem="VfE-eb-mbT" secondAttribute="height" id="joZ-cv-RuI"/>
                                     <constraint firstItem="Ij6-4i-oGx" firstAttribute="leading" secondItem="rtM-7c-eeD" secondAttribute="leading" constant="24" id="lWr-yU-M6y"/>
                                     <constraint firstItem="Ki8-qn-Bo1" firstAttribute="leading" secondItem="rtM-7c-eeD" secondAttribute="leading" id="m4d-DD-Lvn"/>
                                     <constraint firstItem="mxK-gN-Nz2" firstAttribute="leading" secondItem="ZK4-3D-SM0" secondAttribute="leading" id="mGg-DW-FeS"/>
+                                    <constraint firstItem="ldM-3t-32q" firstAttribute="leading" secondItem="VfE-eb-mbT" secondAttribute="leading" id="mSv-oy-0lj"/>
+                                    <constraint firstItem="XZy-Ne-utd" firstAttribute="trailing" secondItem="VfE-eb-mbT" secondAttribute="trailing" id="nqu-lm-FpM"/>
                                     <constraint firstItem="d1H-pL-FAS" firstAttribute="leading" secondItem="rtM-7c-eeD" secondAttribute="leading" constant="24" id="pCp-Ef-yYJ"/>
                                     <constraint firstItem="mxK-gN-Nz2" firstAttribute="trailing" secondItem="ZK4-3D-SM0" secondAttribute="trailing" id="rUO-0c-ysZ"/>
                                     <constraint firstItem="ZK4-3D-SM0" firstAttribute="trailing" secondItem="ldM-3t-32q" secondAttribute="trailing" id="s06-4b-wVs"/>
-                                    <constraint firstItem="2Ss-SD-KCR" firstAttribute="trailing" secondItem="VfE-eb-mbT" secondAttribute="trailing" id="sx1-3D-Bqs"/>
-                                    <constraint firstItem="2Ss-SD-KCR" firstAttribute="top" secondItem="VfE-eb-mbT" secondAttribute="bottom" constant="10" id="tfI-l0-flx"/>
                                     <constraint firstItem="FC8-TR-MGL" firstAttribute="leading" secondItem="hYQ-8Z-Bod" secondAttribute="leading" id="uFU-Z7-VnJ"/>
+                                    <constraint firstItem="XZy-Ne-utd" firstAttribute="top" secondItem="bnb-dB-y9j" secondAttribute="bottom" constant="10" id="unY-Qm-9bx"/>
+                                    <constraint firstItem="FC8-TR-MGL" firstAttribute="top" secondItem="XZy-Ne-utd" secondAttribute="bottom" constant="30" id="vqH-bf-2fK"/>
                                     <constraint firstItem="ZK4-3D-SM0" firstAttribute="leading" secondItem="ldM-3t-32q" secondAttribute="leading" id="wHb-zY-tv5"/>
                                     <constraint firstItem="mxK-gN-Nz2" firstAttribute="top" secondItem="ZK4-3D-SM0" secondAttribute="bottom" constant="10" id="zxl-yQ-SlX"/>
                                 </constraints>
@@ -178,13 +196,15 @@
             <connections>
                 <outlet property="backgroundSettingCollectionView" destination="Ki8-qn-Bo1" id="ztC-tg-hsZ"/>
                 <outlet property="bgView" destination="rtM-7c-eeD" id="z4A-CV-rwk"/>
-                <outlet property="birthTextField" destination="2Ss-SD-KCR" id="hwG-ZC-BgY"/>
+                <outlet property="birthLabel" destination="f7b-Sb-tdA" id="2Dt-Rw-Zcy"/>
+                <outlet property="birthView" destination="bnb-dB-y9j" id="cdd-wn-YbP"/>
                 <outlet property="cardTitleInfoTextLabel" destination="hYQ-8Z-Bod" id="fpo-bj-GPa"/>
                 <outlet property="cardTitleTextField" destination="d1H-pL-FAS" id="bO6-Y8-SBy"/>
                 <outlet property="descriptionTextField" destination="mxK-gN-Nz2" id="dBV-rM-2Gz"/>
                 <outlet property="instagramIDTextField" destination="ldM-3t-32q" id="QNp-NA-Xir"/>
                 <outlet property="linkURLTextField" destination="ZK4-3D-SM0" id="LTF-ja-WmF"/>
-                <outlet property="mbtiTextField" destination="EdP-zA-fyD" id="LA8-Jh-D8n"/>
+                <outlet property="mbtiLabel" destination="xuR-Ne-hLd" id="lw4-FA-En4"/>
+                <outlet property="mbtiView" destination="XZy-Ne-utd" id="KTF-cd-oSt"/>
                 <outlet property="optionalInfoTextLabel" destination="FC8-TR-MGL" id="RnF-6K-xml"/>
                 <outlet property="requiredInfoTextLabel" destination="l0G-Oe-aZm" id="7Nt-UG-Ag5"/>
                 <outlet property="scrollView" destination="EMJ-HM-pPN" id="ftT-Ax-WnF"/>
@@ -195,6 +215,9 @@
         </collectionViewCell>
     </objects>
     <resources>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectBirthBottomViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectBirthBottomViewController.swift
@@ -88,7 +88,7 @@ extension SelectBirthBottomSheetViewController {
     // MARK: - @objc Methods
     
     @objc func dismissToCardCreationViewController() {
-        NotificationCenter.default.post(name: .frontCardBirth, object: selectedBirth)
+        NotificationCenter.default.post(name: .completeFrontCardBirth, object: selectedBirth)
         hideBottomSheetAndGoBack()
     }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectBirthBottomViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectBirthBottomViewController.swift
@@ -42,6 +42,14 @@ class SelectBirthBottomSheetViewController: CommonBottomSheetViewController {
         
         setupUI()
     }
+    
+    // MARK: - override Methods
+    
+    override func hideBottomSheetAndGoBack() {
+        super.hideBottomSheetAndGoBack()
+        
+        NotificationCenter.default.post(name: .dismissRequiredBottomSheet, object: nil)
+    }
 }
     
 // MARK: - Extensions

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectMBTIBottomViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectMBTIBottomViewController.swift
@@ -85,7 +85,7 @@ class SelectMBTIBottmViewController: CommonBottomSheetViewController {
     }
     
     @objc func dismissToCardCreationViewController() {
-        NotificationCenter.default.post(name: .frontCardMBTI, object: selectedMBTI)
+        NotificationCenter.default.post(name: .completeFrontCardMBTI, object: selectedMBTI)
         hideBottomSheetAndGoBack()
     }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectMBTIBottomViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectMBTIBottomViewController.swift
@@ -45,6 +45,14 @@ class SelectMBTIBottmViewController: CommonBottomSheetViewController {
         setupUI()
     }
     
+    // MARK: - override Methods
+    
+    override func hideBottomSheetAndGoBack() {
+        super.hideBottomSheetAndGoBack()
+        
+        NotificationCenter.default.post(name: .dismissRequiredBottomSheet, object: nil)
+    }
+    
     // MARK: - Methods
     
     // UI 세팅 작업


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature#156

🌱 작업한 내용

### 키보드
- 뷰 클릭하면 키보드 다운.

### 피커뷰 완료버튼
- 필수 정보 체크 기능 추가.
- 필수, 옵션 정보 갱신 기능 추가.

### 명함배경 선택
- 이미지 피커 선택 이후 셀 셀렉트 유지
- 이미지를 선택한 직후에 뷰가 다시 등장할 때 0 인덱스를 셀렉트 하도록 함

### birth, mbti
- birth 와 mbti 텍스트필드 -> 텍스트뷰와 라벨로 구성 변경
- 텍필 -> birth, mbti 이동시에 키보드 내려가지 않던 버그 해결
- birth, mbti 수정 시 테두리 변경 추가
- 바텀시트 hideBottomSheetAndGoBack 오버라이드해서 birth,mbti 바텀시트 닫힐 때 노티보내도록 함

> 브랜치 이동해보셔서... 정말 다른 버그는 없는지 봐주십시오.. 선배륌들 그래서 스샷은 없습니다.. ㅋ.ㅋ

## 📮 관련 이슈
- Resolved: #156
