### PR TITLE
[FIX] #158 - 명함생성뷰 이미지피커 dismiss 동작 추가 

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -14,4 +14,5 @@ extension Notification.Name {
     static let sendNewImage = Notification.Name("sendNewImage")
     static let touchRequiredView = Notification.Name("touchRequiredView")
     static let dismissRequiredBottomSheet = Notification.Name("dismissRequiredBottomSheet")
+    static let cancelImagePicker = Notification.Name("cancelImagePicker")
 }

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -183,7 +183,7 @@ extension FrontCardCreationCollectionViewCell {
         NotificationCenter.default.addObserver(self, selector: #selector(setCardBackgroundImage(notifiation:)), name: .sendNewImage, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(dismissBorderLine), name: .dismissRequiredBottomSheet, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(setDefaultImageIndexEmpty), name: .cancelImagePicker, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(cancelImagePicker), name: .cancelImagePicker, object: nil)
     }
     
     /// front card 가 편집되었는지. 필수 항목이 다 입력되었는지 체크.
@@ -231,7 +231,6 @@ extension FrontCardCreationCollectionViewCell {
     private func setMBTIText(notification: NSNotification) {
         mbtiLabel.text = notification.object as? String
         mbtiLabel.textColor = .primary
-        
         mbtiView.borderWidth = 0
         
         checkFrontCradStatus()
@@ -239,7 +238,10 @@ extension FrontCardCreationCollectionViewCell {
     @objc
     private func setCardBackgroundImage(notifiation: NSNotification) {
         cardBackgroundImage = notifiation.object as? UIImage
+        defaultImageIndex = 0
         backgroundSettingCollectionView.reloadData()
+        
+        checkFrontCradStatus()
     }
     @objc
     private func textFieldDidChange(_ notification: Notification) {
@@ -303,10 +305,10 @@ extension FrontCardCreationCollectionViewCell {
         mbtiView.layer.borderWidth = 0
     }
     @objc
-    private func setDefaultImageIndexEmpty() {
-        defaultImageIndex = nil
-        
-        backgroundSettingCollectionView.reloadData()
+    private func cancelImagePicker() {
+        if cardBackgroundImage == nil {
+            backgroundSettingCollectionView.deselectItem(at: IndexPath.init(item: 0, section: 0), animated: true)
+        }
     }
 }
 
@@ -316,7 +318,11 @@ extension FrontCardCreationCollectionViewCell: UICollectionViewDelegate {
         switch indexPath.item {
         case 0:
             NotificationCenter.default.post(name: .presentingImagePicker, object: nil)
-            defaultImageIndex = 0
+            if cardBackgroundImage == nil {
+                defaultImageIndex = nil
+            } else {
+                defaultImageIndex = 0
+            }
         case 1:
             defaultImageIndex = 1
         case 2:

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -183,6 +183,7 @@ extension FrontCardCreationCollectionViewCell {
         NotificationCenter.default.addObserver(self, selector: #selector(setCardBackgroundImage(notifiation:)), name: .sendNewImage, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(dismissBorderLine), name: .dismissRequiredBottomSheet, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setDefaultImageIndexEmpty), name: .cancelImagePicker, object: nil)
     }
     
     /// front card 가 편집되었는지. 필수 항목이 다 입력되었는지 체크.
@@ -300,6 +301,12 @@ extension FrontCardCreationCollectionViewCell {
     private func dismissBorderLine() {
         birthView.layer.borderWidth = 0
         mbtiView.layer.borderWidth = 0
+    }
+    @objc
+    private func setDefaultImageIndexEmpty() {
+        defaultImageIndex = nil
+        
+        backgroundSettingCollectionView.reloadData()
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/SceneDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/SceneDelegate.swift
@@ -22,8 +22,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        // window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.tabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.tabBarViewController)
-        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.splash, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.splashViewController)
+         window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.tabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.tabBarViewController)
+//        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.splash, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.splashViewController)
         // window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
         window?.makeKeyAndVisible()
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -37,9 +37,10 @@ class CardCreationPreviewViewController: UIViewController {
     @IBAction func touchCompleteButton(_ sender: Any) {
         guard let frontCardDataModel = frontCardDataModel, let backCardDataModel = backCardDataModel else { return }
         cardCreationRequest = CardCreationRequest(userID: "", frontCard: frontCardDataModel, backCard: backCardDataModel)
-        guard let cardCreationRequest = cardCreationRequest else { return }
+        guard let cardCreationRequest = cardCreationRequest,
+              let cardBackgroundImage = cardBackgroundImage else { return }
 
-        cardCreationWithAPI(request: cardCreationRequest, image: cardBackgroundImage ?? UIImage())
+        cardCreationWithAPI(request: cardCreationRequest, image: cardBackgroundImage)
     }
     @IBAction func touchBackButton(_ sender: Any) {
         navigationController?.popViewController(animated: true)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
@@ -216,6 +216,7 @@ extension CardCreationViewController {
         imagePicker.sourceType = .photoLibrary
         imagePicker.allowsEditing = true
         imagePicker.delegate = self
+        imagePicker.modalPresentationStyle = .overFullScreen
         
         present(imagePicker, animated: true, completion: nil)
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
@@ -423,4 +423,9 @@ extension CardCreationViewController: UIImagePickerControllerDelegate, UINavigat
         
         picker.dismiss(animated: true, completion: nil)
     }
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        NotificationCenter.default.post(name: .cancelImagePicker, object: nil)
+        
+        dismiss(animated: true, completion: nil)
+    }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#158

🌱 작업한 내용

- 앱시작부분 탭바로 변경
- 미리보기 뷰에서는 guard let 구문 추가

### 이미지 피커
- 이미지피커 cancel 할 때 dismiss 추가

### 버그 픽스
- 명함배경을 마지막으로 선택하면 필수정보체크하지 않던 버그 해결
- 명함배경선택시 imagepicker 를 fullscreen 으로 띄워서 pagesheet 인 경우 취소를 누를때 통제가 되지만 창을 드래그해서 내릴때는 아무런 통제를 할 수 없는 부분을 해결
- imagepicker 선택 후 아무것도 선택하지 않으면 셀 디셀렉트 구현
- 커스텀 배경을 사용할 경우(defaultImageIndex 변수가 0이 될 경우)는 imagepicker 에서 사진 고른 후 / 사진 고른 후 다른 기본명함 선택했다가 다시 imagepicker 띄웠지만 취소 누른경우에도 기존에 고른 배경 적용

# 피엠의 QA? 무섭지않아
> 저 단단히 준비했습니다 이번엔 정말 믿어주십시오

## 📮 관련 이슈
- Resolved: #158
