### PR TITLE
[FIX] #171 - 명함생성 미리보기 뷰 안내문구 추가 및 서버 service 에 토큰 추가

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreationPreview.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreationPreview.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -63,8 +63,10 @@
                                     <constraint firstItem="JTT-Cr-gmG" firstAttribute="centerY" secondItem="uDr-em-N5O" secondAttribute="centerY" id="lyV-T8-gvk"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한 번 만든 명함은 수정할 수 없습니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cgr-Tn-nVH">
-                                <rect key="frame" x="61.666666666666657" y="670" width="251.99999999999997" height="20.333333333333371"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cgr-Tn-nVH">
+                                <rect key="frame" x="41.666666666666657" y="670" width="291.66666666666674" height="40.666666666666629"/>
+                                <string key="text">명함을 좌우로 넘겨 앞/뒷면을 확인해보세요.
+한 번 만든 명함은 수정할 수 없습니다.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Card/CardCreationRequest.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Card/CardCreationRequest.swift
@@ -9,7 +9,6 @@ import Foundation
 
 // MARK: - CardCreation
 struct CardCreationRequest: Codable {
-    let userID: String
     let frontCard: FrontCardDataModel
     let backCard: BackCardDataModel
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
@@ -62,8 +62,6 @@ extension CardService: TargetType {
             
             var multiPartData: [Moya.MultipartFormData] = []
             
-            let userIDData = request.userID.data(using: .utf8) ?? Data()
-            multiPartData.append(MultipartFormData(provider: .data(userIDData), name: "card.userId"))
             let defaultImageData = Int(request.frontCard.defaultImage).description.data(using: .utf8) ?? Data()
             multiPartData.append(MultipartFormData(provider: .data(defaultImageData), name: "card.defaultImage"))
             let titleData = request.frontCard.title.data(using: .utf8) ?? Data()
@@ -114,7 +112,7 @@ extension CardService: TargetType {
         case .cardDetailFetch, .cardListFetch, .cardDelete:
             return .none
         case .cardCreation:
-            return ["Content-Type": "multipart/form-data"]
+            return Const.Header.basicHeader
         case .cardListEdit:
             return ["Content-Type": "application/json"]
         }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -182,6 +182,7 @@ extension CardCreationPreviewViewController {
             switch response {
             case .success:
                 print("cardCreationWithAPI - success")
+                self.dismiss(animated: true, completion: nil)
             case .requestErr(let message):
                 print("cardCreationWithAPI - requestErr: \(message)")
             case .pathErr:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -36,7 +36,7 @@ class CardCreationPreviewViewController: UIViewController {
     }
     @IBAction func touchCompleteButton(_ sender: Any) {
         guard let frontCardDataModel = frontCardDataModel, let backCardDataModel = backCardDataModel else { return }
-        cardCreationRequest = CardCreationRequest(userID: "", frontCard: frontCardDataModel, backCard: backCardDataModel)
+        cardCreationRequest = CardCreationRequest(frontCard: frontCardDataModel, backCard: backCardDataModel)
         guard let cardCreationRequest = cardCreationRequest,
               let cardBackgroundImage = cardBackgroundImage else { return }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#171

🌱 작업한 내용
- 명함생성 미리보기 뷰 안내문구 추가
- bearer 토큰 추가 및 userId 사용하지 않아서 삭제

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|문구추가|<img src="https://user-images.githubusercontent.com/69136340/146734539-ff643937-7fed-4e07-a476-0c440b04c1c7.jpeg" width ="250">|

## 📮 관련 이슈
- Resolved: #171
