### PR TITLE
[FIX] #174 - 알림창 문구 수정 (리스트, 로그아웃 뷰)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
@@ -110,7 +110,7 @@ extension CardListViewController: UITableViewDelegate {
     // Swipe Action
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .normal, title: "삭제", handler: { (_ action, _ view, _ success) in
-            self.makeCancelDeleteAlert(title: "명함 삭제", message: "명함을 정말 삭제하시겠습니까?", cancelAction: { _ in
+            self.makeCancelDeleteAlert(title: "명함 삭제", message: "명함을 정말 삭제하시겠습니까?\n공유된 명함일 경우, 친구의 명함 모음에서도 해당 명함이 삭제됩니다.", cancelAction: { _ in
                 // 취소 눌렀을 때 액션이 들어갈 부분
             }, deleteAction: { _ in
                 // FIXME: - 카드 삭제 서버 테스트

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -98,7 +98,7 @@ extension MoreViewController: UITableViewDelegate {
         } else if indexPath.section == 1 {
             switch indexPath.row {
             case 0:     // 로그아웃
-                makeOKCancelAlert(title: "알림", message: "로그아웃을 하시겠습니까?", okAction: { _ in
+                makeOKCancelAlert(title: "", message: "로그아웃을 하시겠습니까?", okAction: { _ in
                     UserApi.shared.logout { (error) in
                         if let error = error {
                             print(error)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#174

🌱 작업한 내용
- 리스트 뷰 명함 삭제 시 문구 추가
- 더보기 뷰 로그아웃 클릭 시 '알림' 워딩 삭제

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|리스트|![Simulator Screen Shot - iPhone 12 mini - 2021-12-20 at 17 56 06](https://user-images.githubusercontent.com/69389288/146740905-8d11376e-e94d-4ed7-bc96-e5922229534b.png)|로그아웃|![Simulator Screen Shot - iPhone 12 mini - 2021-12-20 at 17 53 52](https://user-images.githubusercontent.com/69389288/146740706-7252ca55-885f-4805-a74c-51717b347a44.png)|


## 📮 관련 이슈
- Resolved: #174 
