### PR TITLE
[FIX] #176 - 명함 앞면 뷰 URL 앞에 https:// 체크

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -86,7 +86,13 @@ extension FrontCardCell {
     @objc
     private func tapLinkURLLabel() {
         let linkURL = linkURLLabel.text ?? ""
-        let webURL = URL(string: linkURL)!
+        let webURL: URL
+        
+        if linkURL.hasPrefix("https://") {
+            webURL = URL(string: linkURL)!
+        } else {
+            webURL = URL(string: "https://" + linkURL)!
+        }
         
         if UIApplication.shared.canOpenURL(webURL) {
             UIApplication.shared.open(webURL, options: [:], completionHandler: nil)


### PR DESCRIPTION

## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#176

🌱 작업한 내용
- prefix 확인 후 https:// 추가

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|주소입력|<img src="https://user-images.githubusercontent.com/69136340/146875374-05b1bab7-e5a1-4999-80e4-c6ed6c31f095.png" width ="250">|
|네이버접속|<img src="https://user-images.githubusercontent.com/69136340/146875427-10f1fee1-c624-46f6-bc5b-f7619022d985.png" width ="250">|

## 📮 관련 이슈
- Resolved: #176
