### PR TITLE
[FIX] #178 - 명함생성 미리보기 뷰 뒷면 공유하기 버튼 히든

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -105,7 +105,8 @@ extension BackCardCell {
                   _ isSauced: Bool,
                   _ firstTMI: String,
                   _ secondTMI: String,
-                  _ thirdTMI: String) {
+                  _ thirdTMI: String,
+                  isShareable: Bool) {
         backgroundImageView.image = backgroundImage ?? UIImage()
         mintImageView.image = isMint == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -106,29 +106,31 @@ extension BackCardCell {
                   _ firstTMI: String,
                   _ secondTMI: String,
                   _ thirdTMI: String) {
-        self.backgroundImageView.image = backgroundImage ?? UIImage()
-        self.mintImageView.image = isMint == true ?
+        backgroundImageView.image = backgroundImage ?? UIImage()
+        mintImageView.image = isMint == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")
-        self.noMintImageView.image = isMint == false ?
+        noMintImageView.image = isMint == false ?
         UIImage(named: "iconTasteOnBanmincho") : UIImage(named: "iconTasteOffBanmincho")
         
-        self.sojuImageView.image = isSoju == true ?
+        sojuImageView.image = isSoju == true ?
         UIImage(named: "iconTasteOnSoju") : UIImage(named: "iconTasteOffSoju")
-        self.beerImageView.image = isSoju == false ?
+        beerImageView.image = isSoju == false ?
         UIImage(named: "iconTasteOnBeer") : UIImage(named: "iconTasteOffBeer")
         
-        self.pourEatImageView.image = isBoomuk == true ?
+        pourEatImageView.image = isBoomuk == true ?
         UIImage(named: "iconTasteOnBumeok") : UIImage(named: "iconTasteOffBumeok")
-        self.putSauceEatImageView.image = isBoomuk == false ?
+        putSauceEatImageView.image = isBoomuk == false ?
         UIImage(named: "iconTasteOnZzik") : UIImage(named: "iconTasteOffZzik")
         
-        self.sauceChickenImageView.image = isSauced == true ?
+        sauceChickenImageView.image = isSauced == true ?
         UIImage(named: "iconTasteOnSeasoned") : UIImage(named: "iconTasteOffSeasoned")
-        self.friedChickenImageView.image = isSauced == false ?
+        friedChickenImageView.image = isSauced == false ?
         UIImage(named: "iconTasteOnFried") : UIImage(named: "iconTasteOffFried")
         
-        self.firstTmiLabel.text = firstTMI
-        self.secondTmiLabel.text = secondTMI
-        self.thirdTmiLabel.text = thirdTMI
+        firstTmiLabel.text = firstTMI
+        secondTmiLabel.text = secondTMI
+        thirdTmiLabel.text = thirdTMI
+        
+        shareButton.isHidden = !isShareable
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -141,7 +141,8 @@ extension CardCreationPreviewViewController {
                               backCardDataModel.isSauced,
                               backCardDataModel.firstTMI,
                               backCardDataModel.secondTMI,
-                              backCardDataModel.thirdTMI)
+                              backCardDataModel.thirdTMI,
+                              isShareable: isShareable)
             
             cardView.addSubview(backCard)
             isFront = false


### PR DESCRIPTION

## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#178

🌱 작업한 내용
- 필수가 아닌 self 제거
- 공유하기 때 사용하는 initCell() 메서드 변경
- 공유하기 버튼 히든

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|공유하기 히든|<img src="https://user-images.githubusercontent.com/69136340/146876032-26ed9d7e-09c1-4174-a0f0-84419f754067.png" width ="250">|

## 📮 관련 이슈
- Resolved: #178
