### PR TITLE
[FIX] #177 - 앞면 인스타그램 미입력 시 레이아웃 수정 및 뒷면 글머리 기호 추가

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -105,7 +105,8 @@ extension BackCardCell {
                   _ isSauced: Bool,
                   _ firstTMI: String,
                   _ secondTMI: String,
-                  _ thirdTMI: String) {
+                  _ thirdTMI: String,
+                  isShareable: Bool) {
         backgroundImageView.image = backgroundImage ?? UIImage()
         mintImageView.image = isMint == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -106,29 +106,31 @@ extension BackCardCell {
                   _ firstTMI: String,
                   _ secondTMI: String,
                   _ thirdTMI: String) {
-        self.backgroundImageView.image = backgroundImage ?? UIImage()
-        self.mintImageView.image = isMint == true ?
+        backgroundImageView.image = backgroundImage ?? UIImage()
+        mintImageView.image = isMint == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")
-        self.noMintImageView.image = isMint == false ?
+        noMintImageView.image = isMint == false ?
         UIImage(named: "iconTasteOnBanmincho") : UIImage(named: "iconTasteOffBanmincho")
         
-        self.sojuImageView.image = isSoju == true ?
+        sojuImageView.image = isSoju == true ?
         UIImage(named: "iconTasteOnSoju") : UIImage(named: "iconTasteOffSoju")
-        self.beerImageView.image = isSoju == false ?
+        beerImageView.image = isSoju == false ?
         UIImage(named: "iconTasteOnBeer") : UIImage(named: "iconTasteOffBeer")
         
-        self.pourEatImageView.image = isBoomuk == true ?
+        pourEatImageView.image = isBoomuk == true ?
         UIImage(named: "iconTasteOnBumeok") : UIImage(named: "iconTasteOffBumeok")
-        self.putSauceEatImageView.image = isBoomuk == false ?
+        putSauceEatImageView.image = isBoomuk == false ?
         UIImage(named: "iconTasteOnZzik") : UIImage(named: "iconTasteOffZzik")
         
-        self.sauceChickenImageView.image = isSauced == true ?
+        sauceChickenImageView.image = isSauced == true ?
         UIImage(named: "iconTasteOnSeasoned") : UIImage(named: "iconTasteOffSeasoned")
-        self.friedChickenImageView.image = isSauced == false ?
+        friedChickenImageView.image = isSauced == false ?
         UIImage(named: "iconTasteOnFried") : UIImage(named: "iconTasteOffFried")
         
-        self.firstTmiLabel.text = firstTMI
-        self.secondTmiLabel.text = secondTMI
-        self.thirdTmiLabel.text = thirdTMI
+        firstTmiLabel.text = firstTMI
+        secondTmiLabel.text = secondTMI
+        thirdTmiLabel.text = thirdTMI
+        
+        shareButton.isHidden = !isShareable
     }
 }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -90,9 +90,23 @@ extension BackCardCell {
         friedChickenImageView.image = isSauced == false ?
         UIImage(named: "iconTasteOnFried") : UIImage(named: "iconTasteOffFried")
         
-        firstTmiLabel.text = firstTMI
-        secondTmiLabel.text = secondTMI
-        thirdTmiLabel.text = thirdTMI
+        if !firstTMI.isEmpty {
+            firstTmiLabel.text = "•  " + firstTMI
+        } else {
+            firstTmiLabel.text = firstTMI
+        }
+        
+        if !secondTMI.isEmpty {
+            secondTmiLabel.text = "•  " + secondTMI
+        } else {
+            secondTmiLabel.text = secondTMI
+        }
+        
+        if !thirdTMI.isEmpty {
+            thirdTmiLabel.text = "•  " + thirdTMI
+        } else {
+            thirdTmiLabel.text = thirdTMI
+        }
         
         shareButton.isHidden = !isShareable
     }
@@ -128,9 +142,23 @@ extension BackCardCell {
         friedChickenImageView.image = isSauced == false ?
         UIImage(named: "iconTasteOnFried") : UIImage(named: "iconTasteOffFried")
         
-        firstTmiLabel.text = firstTMI
-        secondTmiLabel.text = secondTMI
-        thirdTmiLabel.text = thirdTMI
+        if !firstTMI.isEmpty {
+            firstTmiLabel.text = "● " + firstTMI
+        } else {
+            firstTmiLabel.text = firstTMI
+        }
+        
+        if !secondTMI.isEmpty {
+            secondTmiLabel.text = "● " + secondTMI
+        } else {
+            secondTmiLabel.text = secondTMI
+        }
+        
+        if !thirdTMI.isEmpty {
+            thirdTmiLabel.text = "● " + thirdTMI
+        } else {
+            thirdTmiLabel.text = thirdTMI
+        }
         
         shareButton.isHidden = !isShareable
     }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -21,6 +21,9 @@ class FrontCardCell: CardCell {
     @IBOutlet weak var linkURLLabel: UILabel!
     @IBOutlet weak var shareButton: UIButton!
     
+    @IBOutlet weak var instagramImageView: UIImageView!
+    @IBOutlet weak var linkURLImageView: UIImageView!
+    
     // MARK: - Life Cycle
     
     override func awakeFromNib() {
@@ -114,6 +117,13 @@ extension FrontCardCell {
         instagramIDLabel.text = instagramID
         linkURLLabel.text = linkURL
         
+        if instagramID.isEmpty {
+            instagramImageView.isHidden = true
+        }
+        if linkURL.isEmpty {
+            linkURLImageView.isHidden = true
+        }
+        
         shareButton.isHidden = !isShareable
     }
     
@@ -135,6 +145,13 @@ extension FrontCardCell {
         mbtiLabel.text = mbti
         instagramIDLabel.text = instagramID
         linkURLLabel.text = linkURL
+        
+        if instagramID.isEmpty {
+            instagramImageView.isHidden = true
+        }
+        if linkURL.isEmpty {
+            linkURLImageView.isHidden = true
+        }
         
         shareButton.isHidden = !isShareable
     }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -71,7 +71,7 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqW-bV-yHr">
-                        <rect key="frame" x="53" y="472" width="41.5" height="21"/>
+                        <rect key="frame" x="53" y="469.5" width="41.5" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -110,13 +110,13 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cO6-DY-EUn" secondAttribute="trailing" constant="27" id="7rI-g8-Ig7"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8oi-jO-fkf" secondAttribute="trailing" constant="36" id="9HM-25-0VI"/>
                 <constraint firstItem="LqW-bV-yHr" firstAttribute="leading" secondItem="el0-x0-WD9" secondAttribute="trailing" constant="5" id="A8j-k1-Zdw"/>
+                <constraint firstItem="el0-x0-WD9" firstAttribute="top" secondItem="eyB-c0-PQB" secondAttribute="bottom" constant="89" id="AzQ-Hm-97T"/>
                 <constraint firstItem="8oi-jO-fkf" firstAttribute="centerY" secondItem="TXF-fP-7YQ" secondAttribute="centerY" id="BNK-kd-R8I"/>
                 <constraint firstItem="aAt-PF-ce3" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="16" id="CPV-z2-Q2H"/>
                 <constraint firstItem="D6t-Nc-4xH" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="DeT-lx-Vdm"/>
                 <constraint firstItem="aik-Vi-yux" firstAttribute="leading" secondItem="OeE-mZ-GcL" secondAttribute="leading" id="DzT-ZF-buY"/>
                 <constraint firstItem="eyB-c0-PQB" firstAttribute="top" secondItem="aik-Vi-yux" secondAttribute="bottom" constant="10" id="Ebd-SK-4i7"/>
                 <constraint firstAttribute="trailing" secondItem="D6t-Nc-4xH" secondAttribute="trailing" id="GGx-Tf-nEl"/>
-                <constraint firstItem="LqW-bV-yHr" firstAttribute="top" secondItem="8oi-jO-fkf" secondAttribute="bottom" constant="16" id="Hg4-24-oOy"/>
                 <constraint firstItem="TXF-fP-7YQ" firstAttribute="leading" secondItem="OeE-mZ-GcL" secondAttribute="leading" id="ITf-JC-Tm4"/>
                 <constraint firstItem="S8I-Fv-fkf" firstAttribute="bottom" secondItem="D6t-Nc-4xH" secondAttribute="bottom" id="N52-K9-r1O"/>
                 <constraint firstItem="aik-Vi-yux" firstAttribute="top" secondItem="cO6-DY-EUn" secondAttribute="bottom" constant="13" id="RLL-SV-ohE"/>
@@ -126,13 +126,13 @@
                 <constraint firstAttribute="trailing" secondItem="aAt-PF-ce3" secondAttribute="trailing" constant="24" id="WO7-2q-KoQ"/>
                 <constraint firstAttribute="bottom" secondItem="D6t-Nc-4xH" secondAttribute="bottom" id="g3O-ib-dRy"/>
                 <constraint firstItem="S8I-Fv-fkf" firstAttribute="trailing" secondItem="D6t-Nc-4xH" secondAttribute="trailing" id="gIl-Qp-bCT"/>
+                <constraint firstItem="LqW-bV-yHr" firstAttribute="centerY" secondItem="el0-x0-WD9" secondAttribute="centerY" id="h8s-tB-C8s"/>
                 <constraint firstItem="OeE-mZ-GcL" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="24" id="kch-bF-wdy"/>
                 <constraint firstItem="el0-x0-WD9" firstAttribute="leading" secondItem="OeE-mZ-GcL" secondAttribute="leading" id="ks3-oC-rKr"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OeE-mZ-GcL" secondAttribute="trailing" constant="54" id="oi1-gH-AEU"/>
                 <constraint firstItem="D6t-Nc-4xH" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="pVv-z5-cfR"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="LqW-bV-yHr" secondAttribute="trailing" constant="16" id="rNN-Bn-HHJ"/>
                 <constraint firstItem="VDj-1w-jyf" firstAttribute="leading" secondItem="OeE-mZ-GcL" secondAttribute="leading" id="txG-gf-qMy"/>
-                <constraint firstItem="el0-x0-WD9" firstAttribute="top" secondItem="TXF-fP-7YQ" secondAttribute="bottom" constant="10" id="uLD-KR-vXa"/>
             </constraints>
             <size key="customSize" width="307" height="444"/>
             <connections>
@@ -140,6 +140,8 @@
                 <outlet property="birthLabel" destination="aik-Vi-yux" id="QTx-yd-LoY"/>
                 <outlet property="descriptionLabel" destination="VDj-1w-jyf" id="YqY-uP-XQV"/>
                 <outlet property="instagramIDLabel" destination="8oi-jO-fkf" id="eIE-ch-cCT"/>
+                <outlet property="instagramImageView" destination="TXF-fP-7YQ" id="CVp-bU-T3I"/>
+                <outlet property="linkURLImageView" destination="el0-x0-WD9" id="kWS-T3-Urt"/>
                 <outlet property="linkURLLabel" destination="LqW-bV-yHr" id="vD7-qs-hSc"/>
                 <outlet property="mbtiLabel" destination="eyB-c0-PQB" id="waJ-j4-tRM"/>
                 <outlet property="shareButton" destination="aAt-PF-ce3" id="tNu-aM-Dsc"/>

--- a/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -141,7 +141,8 @@ extension CardCreationPreviewViewController {
                               backCardDataModel.isSauced,
                               backCardDataModel.firstTMI,
                               backCardDataModel.secondTMI,
-                              backCardDataModel.thirdTMI)
+                              backCardDataModel.thirdTMI,
+                              isShareable: isShareable)
             
             cardView.addSubview(backCard)
             isFront = false


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#177

🌱 작업한 내용
- 앞면 인스타그램 미입력 시 아이콘 히든
- 앞면 링크 라벨 정중앙 위치
- 뒷면 글머리 기호 추가

> 이 브랜치에서는 공유하기 히든이 적용되지 않았습니다.

> 일단 임의로 말머리 기호 설정해두었고 슬랙에서 얘기하고 수정하겠습니다.

> 이준이 그룹 속 카드에서도 인스타그램 미입력시 예외처리 해주어야할거같아용~

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|레이아웃 수정|<img src="https://user-images.githubusercontent.com/69136340/146878878-21047c62-894d-4ec2-9d8e-d882114e5463.png" width ="250">|

## 📮 관련 이슈
- Resolved: #177
