### PR TITLE
[FEAT] #190 - 그룹 속 명함 삭제 서버

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Header.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Header.swift
@@ -11,8 +11,8 @@ extension Const {
     struct Header {
 //        static let bearerHeader = ["Content-Type": "application/json",
 //                                   "Authorization": "Bearer " + Const.UserDefaults.accessToken]
-        static let bearerHeader = ["Authorization": "Bearer " + "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJuYWRhMiIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDAxMTAyNTB9.qH2fMkrtcVk9GtMEsBEWo0YFvIRTgKPVntBzpeGyyAe5POqnuKf3AtUTJE8yy6gPsAOl0bq8ChCn4RCL0fchpA"]
+        static let bearerHeader = ["Authorization": "Bearer " + "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJuYWRhMiIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDEwMDQ0ODJ9.qNYjBirHaJ03ST2vSKNDspzm7nDXuLdCkl6vxCQxC29W0yJgMvp14Wq2ATOR5mCBrIUAaP0w4c7qx7kXZ4U2Gg"]
         static let basicHeader = ["Content-Type": "application/json",
-                                   "Authorization": "Bearer " + "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJuYWRhMiIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDAxMTAyNTB9.qH2fMkrtcVk9GtMEsBEWo0YFvIRTgKPVntBzpeGyyAe5POqnuKf3AtUTJE8yy6gPsAOl0bq8ChCn4RCL0fchpA"]
+                                   "Authorization": "Bearer " + "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJuYWRhMiIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDEwMDQ0ODJ9.qNYjBirHaJ03ST2vSKNDspzm7nDXuLdCkl6vxCQxC29W0yJgMvp14Wq2ATOR5mCBrIUAaP0w4c7qx7kXZ4U2Gg"]
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -43,6 +43,7 @@ class CardDetailViewController: UIViewController {
     
     private var isFront = true
     var status: Status = .group
+    var groupId: Int?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,6 +53,28 @@ class CardDetailViewController: UIViewController {
         setGestureRecognizer()
     }
 
+}
+
+extension CardDetailViewController {
+    // TODO: - group 서버통신. 위치변경.
+    func cardDeleteInGroupWithAPI(groupID: Int, cardID: String) {
+        GroupAPI.shared.cardDeleteInGroup(groupID: groupID, cardID: cardID) { response in
+            switch response {
+            case .success:
+                print("cardDeleteInGroupWithAPI - success")
+                self.navigationController?.popViewController(animated: true)
+            case .requestErr(let message):
+                print("cardDeleteInGroupWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("cardDeleteInGroupWithAPI - pathErr")
+            case .serverErr:
+                print("cardDeleteInGroupWithAPI - serverErr")
+            case .networkFail:
+                print("cardDeleteInGroupWithAPI - networkFail")
+            }
+            
+        }
+    }
 }
 
 extension CardDetailViewController {
@@ -79,7 +102,8 @@ extension CardDetailViewController {
             self.makeCancelDeleteAlert(title: "명함 삭제",
                                        message: "명함을 정말 삭제하시겠습니까?",
                                        deleteAction: { _ in
-                // TODO: 명함 삭제 서버통신
+                // 명함 삭제 서버통신
+                self.cardDeleteInGroupWithAPI(groupID: self.groupId ?? 0, cardID: self.cardDataModel?.cardID ?? "")
             }) })
         let options = UIMenu(title: "options", options: .displayInline, children: [changeGroup, deleteCard])
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -56,7 +56,6 @@ class CardDetailViewController: UIViewController {
 }
 
 extension CardDetailViewController {
-    // TODO: - group 서버통신. 위치변경.
     func cardDeleteInGroupWithAPI(groupID: Int, cardID: String) {
         GroupAPI.shared.cardDeleteInGroup(groupID: groupID, cardID: cardID) { response in
             switch response {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -63,26 +63,31 @@ class GroupViewController: UIViewController {
     var serverGroups: Groups?
     var serverCards: CardsInGroupResponse?
     var serverCardsWithBack: Card?
+    var groupId: Int?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         registerCell()
         setUI()
         // 그룹 리스트 조회 서버 테스트
-        groupListFetchWithAPI(userID: "nada")
+//        groupListFetchWithAPI(userID: "nada2")
 //         그룹 삭제 서버 테스트
 //        groupDeleteWithAPI(groupID: 1)
 //         그룹 추가 서버 테스트
-//        groupAddWithAPI(groupRequest: GroupAddRequest(userId: "nada", groupName: "대학교"))
+//        groupAddWithAPI(groupRequest: GroupAddRequest(userId: "nada", groupName: "미분류"))
 //         그룹 수정 서버 테스트
 //        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: 5, groupName: "수정나다"))
 //         그룹 속 명함 추가 테스트
-//        cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardId: "cardC", userId: "nada", groupId: 18))
+//        cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardId: "cardA", userId: "nada2", groupId: 1))
 //         그룹 속 명함 조회 테스트
 //        cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada", groupId: 5, offset: 0))
 //         명함 검색 테스트
 //        cardDetailFetchWithAPI(cardID: "cardA")
         
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        groupListFetchWithAPI(userID: "nada2")
     }
     
 }
@@ -113,7 +118,8 @@ extension GroupViewController {
                 if let group = data as? Groups {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
-                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada", groupId: group.groups[0].groupID, offset: 0))
+                    self.groupId = group.groups[0].groupID
+                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada2", groupId: group.groups[0].groupID, offset: 0))
                 }
             case .requestErr(let message):
                 print("groupListFetchWithAPI - requestErr: \(message)")
@@ -221,6 +227,7 @@ extension GroupViewController {
                                                 oneTmi: card.card.oneTmi,
                                                 twoTmi: card.card.twoTmi,
                                                 threeTmi: card.card.threeTmi)
+                    nextVC.groupId = self.groupId
                     self.navigationController?.pushViewController(nextVC, animated: true)
                 }
             case .requestErr(let message):
@@ -308,7 +315,8 @@ extension GroupViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch collectionView {
         case groupCollectionView:
-            cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada", groupId: serverGroups?.groups[indexPath.row].groupID ?? 0, offset: 0))
+            groupId = serverGroups?.groups[indexPath.row].groupID
+            cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada2", groupId: serverGroups?.groups[indexPath.row].groupID ?? 0, offset: 0))
         case cardsCollectionView:
             cardDetailFetchWithAPI(cardID: serverCards?.cards[indexPath.row].cardID ?? "")
         default:


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#190

🌱 작업한 내용
- 그룹 속 명함 삭제 서버를 연결했습니다
- 삭제 뒤에는 그룹 뷰로 오게 했습니다
- 삭제 시 그룹 ID가 필요하기 때문에 따로 변수를 만들어줬습니다
- 이거 엠티뷰랑 킹피셔 적용안된 상태에서 브랜치 판거라 움짤에는 안된거처럼 보여요! 합치면 될겁니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/69078056/146974015-881d3f3f-fc19-40ac-9d51-2fc0aa0128f2.gif)|


## 📮 관련 이슈
- Resolved: #190 
