### PR TITLE
[FEAT] #199 - SceneDelegate에서 토큰 재발급 처리 로직 구현

### DIFF
--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserAPI.swift
@@ -110,7 +110,7 @@ public class UserAPI {
         }
     }
     
-    func userTokenReissue(request: UserWithTokenRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
+    func userTokenReissue(request: UserTokenReissueRequset, completion: @escaping (NetworkResult<Any>) -> Void) {
         userProvider.request(.userTokenReissue(request: request)) { (result) in
             switch result {
             case .success(let response):

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
@@ -15,7 +15,7 @@ enum UserSevice {
     case userDelete(token: String)
     case userSocialSignUp(userID: String)
     case userLogout(token: String)
-    case userTokenReissue(request: UserWithTokenRequest)
+    case userTokenReissue(request: UserTokenReissueRequset)
 }
 
 extension UserSevice: TargetType {
@@ -73,9 +73,9 @@ extension UserSevice: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .userIDFetch, .userTokenFetch, .userTokenReissue:
+        case .userIDFetch, .userTokenFetch:
             return Const.Header.bearerHeader
-        case .userSignUp, .userSocialSignUp:
+        case .userSignUp, .userSocialSignUp, .userTokenReissue:
             return ["Content-Type": "application/json"]
         case .userDelete(let token):
             return ["Content-Type": "application/json", "Authorization": "Bearer " + token]

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -226,21 +226,4 @@ extension LoginViewController {
         }
     }
     
-    func postUserTokenReissue(request: UserWithTokenRequest) {
-        UserAPI.shared.userTokenReissue(request: request) { response in
-            switch response {
-            case .success(let data):
-                print("postUserTokenReissue - Success")
-            case .requestErr(let message):
-                print("postUserTokenReissue - requestErr: \(message)")
-            case .pathErr:
-                print("postUserTokenReissue - pathErr")
-            case .serverErr:
-                print("postUserTokenReissue - serverErr")
-            case .networkFail:
-                print("postUserTokenReissue - networkFail")
-            }
-        }
-    }
-    
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#199

🌱 작업한 내용
- 토큰 재발급 서버 전달 모델 변경
- 토큰 만료 상태에 따른 분기 처리 -> 만료시 로그인뷰로, 만료x시 토큰 확인 후 로그인, 탭바 위치 결정

## 📮 관련 이슈
- Resolved: #199 
