### PR TITLE
[FEAT] #201 - ID로 명함 검색해서 추가하기 서버  

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/UserDefaults.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/UserDefaults.swift
@@ -12,6 +12,7 @@ extension Const {
         static let darkModeState = "darkModeState"
         static let accessToken = "accessToken"
         static let refreshToken = "refreshToken"
-        static let userID = "userID"
+//        static let userID = "userID"
+        static let userID = "nada2"
     }
 }

--- a/NADA-iOS-forRelease/Resouces/Extensions/UIViewController+Extension.swift
+++ b/NADA-iOS-forRelease/Resouces/Extensions/UIViewController+Extension.swift
@@ -80,6 +80,10 @@ extension UIViewController {
             toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width/2 - 85,
                                                    y: self.view.frame.size.height/2,
                                                    width: 170, height: 35))
+        case "wrongCard":
+            toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width/2 - 120,
+                                                   y: self.view.frame.size.height/2,
+                                                   width: 240, height: 35))
         default:
             toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width/2 - 85,
                                                    y: self.view.frame.size.height - 230,
@@ -95,7 +99,7 @@ extension UIViewController {
         toastLabel.layer.cornerRadius = 10
         toastLabel.clipsToBounds = true
         self.view.addSubview(toastLabel)
-        UIView.animate(withDuration: 2.0, delay: 0.1,
+        UIView.animate(withDuration: 3.0, delay: 0.1,
                        options: .curveEaseOut, animations: { toastLabel.alpha = 0.0 },
                        completion: {_ in toastLabel.removeFromSuperview() })
     }

--- a/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.swift
@@ -19,6 +19,8 @@ class CardInGroupCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var instagramIDLabel: UILabel!
     @IBOutlet weak var lineURLLabel: UILabel!
     
+    @IBOutlet weak var instagramIcon: UIImageView!
+    @IBOutlet weak var urlIcon: UIImageView!
     var groupId: Int?
     var cardId: String?
     

--- a/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -152,9 +152,11 @@
                 <outlet property="birthLabel" destination="WCz-jU-GLW" id="JWN-qF-cmV"/>
                 <outlet property="descriptionLabel" destination="RM7-A9-SfR" id="Taf-hG-9yJ"/>
                 <outlet property="instagramIDLabel" destination="R2H-kH-GqM" id="gNa-to-IoK"/>
+                <outlet property="instagramIcon" destination="XFs-Sv-f0r" id="419-Xr-AxM"/>
                 <outlet property="lineURLLabel" destination="oO0-od-Oxm" id="Y5l-wc-JJu"/>
                 <outlet property="mbtiLabel" destination="Wwx-y2-tN3" id="TN4-Or-c2j"/>
                 <outlet property="titleLabel" destination="Rng-0l-SgL" id="9nl-nq-ggY"/>
+                <outlet property="urlIcon" destination="07x-TC-A3z" id="wNd-jb-LjS"/>
                 <outlet property="userNameLabel" destination="tBD-lZ-HlH" id="i74-Z7-zHd"/>
             </connections>
             <point key="canvasLocation" x="137.68115942028987" y="78.348214285714278"/>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
@@ -108,6 +108,7 @@ extension AddWithIdBottomSheetViewController {
             switch response {
             case .success(let data):
                 if let card = data as? CardClass {
+                    //TODO: 내가 쓴거 내가 추가 하면 예외처리 필요
                     let nextVC = CardResultBottomSheetViewController()
                     nextVC.cardDataModel = Card(cardID: card.card.cardID,
                                                 background: card.card.background,

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
@@ -142,4 +142,3 @@ extension AddWithIdBottomSheetViewController {
     }
 }
 
-

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
@@ -97,7 +97,49 @@ extension AddWithIdBottomSheetViewController {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         // 서버 연결과 더불어... 검색 결과가 없으면 bottomsheet dismiss 하지 말고 hidden 풀어주기
-        hideBottomSheetAndPresent(nextBottomSheet: CardResultBottomSheetViewController(), title: "이채연", height: 574)
+        cardDetailFetchWithAPI(cardID: textField.text ?? "")
         return true
     }
 }
+
+extension AddWithIdBottomSheetViewController {
+    func cardDetailFetchWithAPI(cardID: String) {
+        CardAPI.shared.cardDetailFetch(cardID: cardID) { response in
+            switch response {
+            case .success(let data):
+                if let card = data as? CardClass {
+                    let nextVC = CardResultBottomSheetViewController()
+                    nextVC.cardDataModel = Card(cardID: card.card.cardID,
+                                                background: card.card.background,
+                                                title: card.card.title,
+                                                name: card.card.name,
+                                                birthDate: card.card.birthDate,
+                                                mbti: card.card.mbti,
+                                                instagram: card.card.instagram,
+                                                link: card.card.link,
+                                                cardDescription: card.card.cardDescription,
+                                                isMincho: card.card.isMincho,
+                                                isSoju: card.card.isSoju,
+                                                isBoomuk: card.card.isBoomuk,
+                                                isSauced: card.card.isSauced,
+                                                oneTmi: card.card.oneTmi,
+                                                twoTmi: card.card.twoTmi,
+                                                threeTmi: card.card.threeTmi)
+                    self.hideBottomSheetAndPresent(nextBottomSheet: nextVC, title: card.card.name, height: 574)
+                }
+            case .requestErr(let message):
+                print("cardDetailFetchWithAPI - requestErr: \(message)")
+                self.errorImageView.isHidden = false
+                self.explainLabel.isHidden = false
+            case .pathErr:
+                print("cardDetailFetchWithAPI - pathErr")
+            case .serverErr:
+                print("cardDetailFetchWithAPI - serverErr")
+            case .networkFail:
+                print("cardDetailFetchWithAPI - networkFail")
+            }
+        }
+    }
+}
+
+

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
@@ -96,9 +96,32 @@ class CardResultBottomSheetViewController: CommonBottomSheetViewController {
     }
     
     @objc func presentGroupSelectBottomSheet() {
-        let nextVC = SelectGroupBottomSheetViewController()
-        nextVC.status = .add
-        hideBottomSheetAndPresent(nextBottomSheet: nextVC, title: "그룹선택", height: 386)
+        groupListFetchWithAPI(userID: Const.UserDefaults.userID)
     }
 
+}
+
+extension CardResultBottomSheetViewController {
+    func groupListFetchWithAPI(userID: String) {
+        GroupAPI.shared.groupListFetch(userID: userID) { response in
+            switch response {
+            case .success(let data):
+                if let group = data as? Groups {
+                    let nextVC = SelectGroupBottomSheetViewController()
+                    nextVC.status = .add
+                    nextVC.cardDataModel = self.cardDataModel
+                    nextVC.serverGroups = group
+                    self.hideBottomSheetAndPresent(nextBottomSheet: nextVC, title: "그룹선택", height: 386)
+                }
+            case .requestErr(let message):
+                print("groupListFetchWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("groupListFetchWithAPI - pathErr")
+            case .serverErr:
+                print("groupListFetchWithAPI - serverErr")
+            case .networkFail:
+                print("groupListFetchWithAPI - networkFail")
+            }
+        }
+    }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
@@ -11,16 +11,17 @@ import IQKeyboardManagerSwift
 class CardResultBottomSheetViewController: CommonBottomSheetViewController {
 
     // MARK: - Properties
+    var cardDataModel: Card?
+    
     private let groupLabel: UILabel = {
         let label = UILabel()
-        label.text = "어쩌구 동아리 명함"
         label.textColor = .secondary
         label.font = .textRegular03
         
         return label
     }()
     
-    private let cardView: UIView = {
+    private let cardView: CardView = {
         let view = CardView()
         return view
     }()
@@ -46,6 +47,8 @@ class CardResultBottomSheetViewController: CommonBottomSheetViewController {
         view.addSubview(cardView)
         view.addSubview(addButton)
         setupLayout()
+        
+        groupLabel.text = cardDataModel?.cardDescription
     }
     
     // 레이아웃 세팅
@@ -77,7 +80,6 @@ class CardResultBottomSheetViewController: CommonBottomSheetViewController {
         let nextVC = SelectGroupBottomSheetViewController()
         nextVC.status = .add
         hideBottomSheetAndPresent(nextBottomSheet: nextVC, title: "그룹선택", height: 386)
-        print("next bottomsheet")
     }
 
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
@@ -49,6 +49,25 @@ class CardResultBottomSheetViewController: CommonBottomSheetViewController {
         setupLayout()
         
         groupLabel.text = cardDataModel?.cardDescription
+        setCardView()
+    }
+    
+    private func setCardView() {
+        cardView.backgroundImageView.updateServerImage(cardDataModel?.background ?? "")
+        cardView.titleLabel.text = cardDataModel?.title ?? ""
+        cardView.descriptionLabel.text = cardDataModel?.cardDescription ?? ""
+        cardView.userNameLabel.text = cardDataModel?.name ?? ""
+        cardView.birthLabel.text = cardDataModel?.birthDate ?? ""
+        cardView.mbtiLabel.text = cardDataModel?.mbti ?? ""
+        cardView.instagramIDLabel.text = cardDataModel?.instagram ?? ""
+        cardView.lineURLLabel.text = cardDataModel?.link ?? ""
+        
+        if cardDataModel?.instagram == ""{
+            cardView.instagramIcon.isHidden = true
+        }
+        if cardDataModel?.link == ""{
+            cardView.urlIcon.isHidden = true
+        }
     }
     
     // 레이아웃 세팅

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -135,6 +135,7 @@ extension SelectGroupBottomSheetViewController {
                 self.hideBottomSheetAndPresentVC(nextViewController: nextVC)
             case .requestErr(let message):
                 print("postCardAddInGroupWithAPI - requestErr", message)
+                self.showToast(message: message as? String ?? "", font: UIFont.button03, view: "wrongCard")
             case .pathErr:
                 print("postCardAddInGroupWithAPI - pathErr")
             case .serverErr:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -129,7 +129,6 @@ extension SelectGroupBottomSheetViewController {
         GroupAPI.shared.cardAddInGroup(cardRequest: cardRequest) { response in
             switch response {
             case .success:
-                print("postCardAddInGroupWithAPI - success")
                 guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.cardDetail, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardDetailViewController) as? CardDetailViewController else { return }
                 nextVC.status = .add
                 nextVC.cardDataModel = self.cardDataModel

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -10,7 +10,8 @@ import UIKit
 class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
 
     // MARK: - Properties
-    var groupList = ["미분류", "SOPT", "동아리", "인하대학교"]
+    var cardDataModel: Card?
+    var serverGroups: Groups?
     var selectedGroup = ""
     enum Status {
         case detail
@@ -44,7 +45,7 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     private func setupUI() {
         view.addSubview(groupPicker)
         view.addSubview(doneButton)
-        selectedGroup = groupList[0]
+        selectedGroup = serverGroups?.groups[0].groupName ?? ""
         groupPicker.delegate = self
         groupPicker.dataSource = self
         setupLayout()
@@ -80,6 +81,7 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
             
             guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.cardDetail, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardDetailViewController) as? CardDetailViewController else { return }
             nextVC.status = .add
+            nextVC.cardDataModel = self.cardDataModel
             hideBottomSheetAndPresentVC(nextViewController: nextVC)
         }
     }
@@ -92,7 +94,7 @@ extension SelectGroupBottomSheetViewController: UIPickerViewDelegate, UIPickerVi
     }
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return groupList.count
+        return serverGroups?.groups.count ?? 1
     }
 
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
@@ -101,16 +103,16 @@ extension SelectGroupBottomSheetViewController: UIPickerViewDelegate, UIPickerVi
         label.textAlignment = .center
         
         if pickerView.selectedRow(inComponent: component) == row {
-            label.attributedText = NSAttributedString(string: groupList[row], attributes: [NSAttributedString.Key.font: UIFont.textBold01, NSAttributedString.Key.foregroundColor: UIColor.mainColorNadaMain])
+            label.attributedText = NSAttributedString(string: serverGroups?.groups[row].groupName ?? "", attributes: [NSAttributedString.Key.font: UIFont.textBold01, NSAttributedString.Key.foregroundColor: UIColor.mainColorNadaMain])
         } else {
-            label.attributedText = NSAttributedString(string: groupList[row], attributes: [NSAttributedString.Key.font: UIFont.textRegular03, NSAttributedString.Key.foregroundColor: UIColor.quaternary])
+            label.attributedText = NSAttributedString(string: serverGroups?.groups[row].groupName ?? "", attributes: [NSAttributedString.Key.font: UIFont.textRegular03, NSAttributedString.Key.foregroundColor: UIColor.quaternary])
         }
         
         return label
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        selectedGroup = groupList[row]
+        selectedGroup = serverGroups?.groups[row].groupName ?? ""
         pickerView.reloadAllComponents()
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -22,6 +22,7 @@ class CardDetailViewController: UIViewController {
             self.navigationController?.popViewController(animated: true)
         case .add:
             self.dismiss(animated: true, completion: nil)
+            presentingViewController?.viewWillAppear(true)
         }
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -70,6 +70,7 @@ class GroupViewController: UIViewController {
         super.viewDidLoad()
         registerCell()
         setUI()
+        print(Const.UserDefaults.userID)
 //        groupListFetchWithAPI(userID: Const.UserDefaults.userID)
 //         그룹 삭제 서버 테스트
 //        groupDeleteWithAPI(groupID: 1)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -88,7 +88,7 @@ class GroupViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         // 그룹 리스트 조회 서버 테스트
-        groupListFetchWithAPI(userID: "nada2")
+        groupListFetchWithAPI(userID: Const.UserDefaults.userID)
     }
     
 }
@@ -122,8 +122,8 @@ extension GroupViewController {
                     self.groupCollectionView.reloadData()
                     self.groupId = group.groups[0].groupID
                     if !group.groups.isEmpty {
-                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada2", groupId: group.groups[0].groupID, offset: 0))
-//                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: Const.UserDefaults.userID, groupId: group.groups[0].groupID, offset: 0))
+//                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada2", groupId: group.groups[0].groupID, offset: 0))
+                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: Const.UserDefaults.userID, groupId: group.groups[0].groupID, offset: 0))
                     }
                 }
             case .requestErr(let message):

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -297,6 +297,13 @@ extension GroupViewController: UICollectionViewDataSource {
             cardCell.instagramIDLabel.text = serverCards?.cards[indexPath.row].instagram
             cardCell.lineURLLabel.text = serverCards?.cards[indexPath.row].link
             
+            if serverCards?.cards[indexPath.row].instagram == "" {
+                cardCell.instagramIcon.isHidden = true
+            }
+            if serverCards?.cards[indexPath.row].link == "" {
+                cardCell.urlIcon.isHidden = true
+            }
+            
             return cardCell
         default:
             return UICollectionViewCell()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -77,8 +77,6 @@ class GroupViewController: UIViewController {
 //        groupAddWithAPI(groupRequest: GroupAddRequest(userId: "nada2", groupName: "대학교"))
 //         그룹 수정 서버 테스트
 //        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: 5, groupName: "수정나다"))
-//         그룹 속 명함 추가 테스트
-//        cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardId: "cardA", userId: "nada2", groupId: 1))
 //         그룹 속 명함 조회 테스트
 //        cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada", groupId: 5, offset: 0))
 //         명함 검색 테스트
@@ -248,23 +246,6 @@ extension GroupViewController {
                 print("cardDetailFetchWithAPI - serverErr")
             case .networkFail:
                 print("cardDetailFetchWithAPI - networkFail")
-            }
-        }
-    }
-    
-    func cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest) {
-        GroupAPI.shared.cardAddInGroup(cardRequest: cardRequest) { response in
-            switch response {
-            case .success:
-                print("postCardAddInGroupWithAPI - success")
-            case .requestErr(let message):
-                print("postCardAddInGroupWithAPI - requestErr", message)
-            case .pathErr:
-                print("postCardAddInGroupWithAPI - pathErr")
-            case .serverErr:
-                print("postCardAddInGroupWithAPI - serverErr")
-            case .networkFail:
-                print("postCardAddInGroupWithAPI - networkFail")
             }
         }
     }

--- a/NADA-iOS-forRelease/Sources/Views/CardView.swift
+++ b/NADA-iOS-forRelease/Sources/Views/CardView.swift
@@ -19,6 +19,9 @@ class CardView: UIView {
     @IBOutlet weak var instagramIDLabel: UILabel!
     @IBOutlet weak var lineURLLabel: UILabel!
     
+    @IBOutlet weak var instagramIcon: UIImageView!
+    @IBOutlet weak var urlIcon: UIImageView!
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         xibSetup()

--- a/NADA-iOS-forRelease/Sources/Views/CardView.xib
+++ b/NADA-iOS-forRelease/Sources/Views/CardView.xib
@@ -21,9 +21,11 @@
                 <outlet property="birthLabel" destination="bKT-Iy-Vgq" id="6Hc-yn-esH"/>
                 <outlet property="descriptionLabel" destination="ODd-rW-HN9" id="kCD-Cv-Tok"/>
                 <outlet property="instagramIDLabel" destination="tmB-6S-myw" id="Qnd-JG-X8v"/>
+                <outlet property="instagramIcon" destination="IMZ-cI-mgN" id="cbv-Wj-HUF"/>
                 <outlet property="lineURLLabel" destination="a7e-eY-RKP" id="lp5-qw-hfu"/>
                 <outlet property="mbtiLabel" destination="d9j-mu-jog" id="p9v-KB-doC"/>
                 <outlet property="titleLabel" destination="Swh-6B-eGz" id="XOc-XI-iVf"/>
+                <outlet property="urlIcon" destination="rDx-zx-jkd" id="Kw6-Ur-f78"/>
                 <outlet property="userNameLabel" destination="Jlf-bz-O5n" id="SID-U2-JeG"/>
             </connections>
         </placeholder>
@@ -34,39 +36,44 @@
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="card" translatesAutoresizingMaskIntoConstraints="NO" id="BM7-of-ZP2">
                     <rect key="frame" x="0.0" y="0.0" width="201" height="331"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="15"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SOPT 명함" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Swh-6B-eGz">
-                    <rect key="frame" x="16" y="33" width="57" height="14"/>
+                    <rect key="frame" x="16" y="33" width="56" height="14"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="12"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이채연" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jlf-bz-O5n">
-                    <rect key="frame" x="16" y="175" width="36" height="16"/>
+                    <rect key="frame" x="16" y="175" width="34" height="16"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="13"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1998.01.09" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bKT-Iy-Vgq">
-                    <rect key="frame" x="16" y="200" width="63" height="14"/>
+                    <rect key="frame" x="16" y="200" width="60.5" height="14"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="29기 디자인파트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ODd-rW-HN9">
-                    <rect key="frame" x="16" y="52" width="76.5" height="13"/>
+                    <rect key="frame" x="16" y="52" width="72.5" height="13"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="11"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENFP" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d9j-mu-jog">
-                    <rect key="frame" x="16" y="221" width="30" height="14"/>
+                    <rect key="frame" x="16" y="221" width="31" height="14"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="12"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="chaens_" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmB-6S-myw">
-                    <rect key="frame" x="35" y="270" width="39" height="12"/>
+                    <rect key="frame" x="35" y="270" width="37.5" height="12"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="10"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
@@ -86,7 +93,7 @@
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https://github.com/TeamNADA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a7e-eY-RKP">
-                    <rect key="frame" x="35" y="292" width="143" height="12"/>
+                    <rect key="frame" x="35" y="292" width="137.5" height="12"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Regular" family="Spoqa Han Sans Neo" pointSize="10"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#201

🌱 작업한 내용
- ID로 명함을 검색해서 추가가 가능합니다.
- 명함을 검색해서 추가 한다면 명함 상세뷰가 띄워집니다.
- 명함 상세뷰를 dismiss 하면 자동으로 그룹 뷰가 리로드 됩니다.
- 인스타그램과 링크에 아무것도 없다면 인스타그램과 링크 아이콘이 hidden 처리 됩니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|파일첨부바람|

## 📮 관련 이슈
- Resolved: #201 
