### PR TITLE
[FIX] #207 - 첫명함 알람 바텀시트 로직 변경

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -193,23 +193,23 @@ extension CardCreationPreviewViewController {
             switch response {
             case .success:
                 print("cardCreationWithAPI - success")
-                self.dismiss(animated: true, completion: nil)
-                // FIXME: - 초기에만등장
-//                if UserDefaults.standard.object(forKey: Const.UserDefaults.isFirstCard) == nil {
-//                    self.dismiss(animated: true) {
-//                        let nextVC = FirstCardAlertBottomSheetViewController()
-//                            .setTitle("""
-//                                      🎉
-//                                      첫 명함이 생성되었어요!
-//                                      """)
-//                            .setHeight(587)
-//                        nextVC.modalPresentationStyle = .overFullScreen
-//                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
-//                            self.presentingViewController?.present(nextVC, animated: false, completion: nil)
-//                        }
-//                    }
-//                }
-//                UserDefaults.standard.set(false, forKey: Const.UserDefaults.isFirstCard)
+                
+                guard let presentingVC = self.presentingViewController else { return }
+                
+                self.dismiss(animated: true) {
+                    if UserDefaults.standard.object(forKey: Const.UserDefaults.isFirstCard) == nil {
+                        let nextVC = FirstCardAlertBottomSheetViewController()
+                            .setTitle("""
+                                      🎉
+                                      첫 명함이 생성되었어요!
+                                      """)
+                            .setHeight(587)
+                        nextVC.modalPresentationStyle = .overFullScreen
+                        presentingVC.present(nextVC, animated: true) {
+                            UserDefaults.standard.set(false, forKey: Const.UserDefaults.isFirstCard)
+                        }
+                    }
+                }
             case .requestErr(let message):
                 print("cardCreationWithAPI - requestErr: \(message)")
             case .pathErr:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -63,20 +63,6 @@ class FrontViewController: UIViewController {
 //        cardListFetchWithAPI(userID: "nada", isList: false, offset: 0)
     }
     
-    // FIXME: - qa테스트
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        let nextVC = FirstCardAlertBottomSheetViewController()
-            .setTitle("""
-                      🎉
-                      첫 명함이 생성되었어요!
-                      """)
-            .setHeight(587)
-        nextVC.modalPresentationStyle = .overFullScreen
-        present(nextVC, animated: true, completion: nil)
-    }
-    
     // MARK: - @IBAction Properties
     // 명함 생성 뷰로 화면 전환
     @IBAction func presentToCardCreationView(_ sender: Any) {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#207

🌱 작업한 내용
- UserDefaults 를 활용한 첫명함 생성시에만 첫명함 알람 바텀시트 등장
> 앱을 재설치하게 되면 첫명함이 아니더라도 명함을 처음만들 때 첫명함 알람 바텀시트 등장. -> 서버의 도움이 필요할듯 일단 노션에 체크리스트 만들어두고 우선순위 미뤄뒀습니다

## 📮 관련 이슈
- Resolved: #207
