### PR TITLE
[FEAT] #214 - initCell 에서 서버에서 받아오는 이미지 분기처리

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -68,7 +68,12 @@ extension BackCardCell {
                   _ thirdTMI: String,
                   isShareable: Bool) {
         
-        backgroundImageView.updateServerImage(backgroundImageString)
+        if backgroundImageString.hasPrefix("https://") {
+            self.backgroundImageView.updateServerImage(backgroundImageString)
+        } else {
+            if let bgImage = UIImage(named: backgroundImageString) {
+                self.backgroundImageView.image = bgImage
+            }
         
         mintImageView.image = isMint == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import VerticalCardSwiper
+import Kingfisher
 
 class BackCardCell: CardCell {
     
@@ -74,6 +75,7 @@ extension BackCardCell {
             if let bgImage = UIImage(named: backgroundImageString) {
                 self.backgroundImageView.image = bgImage
             }
+        }
         
         mintImageView.image = isMint == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -115,12 +115,13 @@ extension FrontCardCell {
                   _ linkURL: String,
                   isShareable: Bool) {
 
-        if backgroundImageString.hasPrefix("https://") {
-            self.backgroundImageView.updateServerImage(backgroundImageString)
+        if backgroundImage.hasPrefix("https://") {
+            self.backgroundImageView.updateServerImage(backgroundImage)
         } else {
-            if let bgImage = UIImage(named: backgroundImageString) {
+            if let bgImage = UIImage(named: backgroundImage) {
                 self.backgroundImageView.image = bgImage
             }
+        }
             
         titleLabel.text = cardTitle
         descriptionLabel.text = cardDescription

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -115,7 +115,13 @@ extension FrontCardCell {
                   _ linkURL: String,
                   isShareable: Bool) {
 
-        backgroundImageView.updateServerImage(backgroundImage)
+        if backgroundImageString.hasPrefix("https://") {
+            self.backgroundImageView.updateServerImage(backgroundImageString)
+        } else {
+            if let bgImage = UIImage(named: backgroundImageString) {
+                self.backgroundImageView.image = bgImage
+            }
+            
         titleLabel.text = cardTitle
         descriptionLabel.text = cardDescription
         userNameLabel.text = userName

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -52,7 +52,7 @@ extension MainCardCell {
         
         frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
         guard let cardDataModel = cardDataModel else { return }
-        frontCard.initCell(UIImage(named: cardDataModel.background),
+        frontCard.initCell(cardDataModel.background,
                            cardDataModel.title,
                            cardDataModel.cardDescription ?? "",
                            cardDataModel.name,
@@ -84,7 +84,7 @@ extension MainCardCell {
             guard let backCard = BackCardCell.nib().instantiate(withOwner: self, options: nil).first as? BackCardCell else { return }
             backCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
             guard let cardDataModel = cardDataModel else { return }
-            backCard.initCell(UIImage(named: cardDataModel.background),
+            backCard.initCell(cardDataModel.background,
                               cardDataModel.isMincho,
                               cardDataModel.isSoju,
                               cardDataModel.isBoomuk,
@@ -101,7 +101,7 @@ extension MainCardCell {
             
             frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
             guard let cardDataModel = cardDataModel else { return }
-            frontCard.initCell(UIImage(named: cardDataModel.background),
+            frontCard.initCell(cardDataModel.background,
                                cardDataModel.title,
                                cardDataModel.cardDescription ?? "",
                                cardDataModel.name,


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#214

🌱 작업한 내용
- FronCardCell, BackCardCell 분기처리를 추가 해줬습니다
- MainCardCell 에서 UIImage 를 String 타입으로 변경했습니다
- 서버에서 받아오는 이미지는 킹피셔를 통해 업데이트 해주고, 로컬에 저장되어있는 이미지는 이미지를 불러와서 업데이트 합니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|파일첨부바람|

## 📮 관련 이슈
- Resolved: #214 
