### PR TITLE
[FEAT] #219 - 명함 그룹 수정 서버

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -16,4 +16,5 @@ extension Notification.Name {
     static let dismissRequiredBottomSheet = Notification.Name("dismissRequiredBottomSheet")
     static let cancelImagePicker = Notification.Name("cancelImagePicker")
     static let presentCardShare = Notification.Name("presentCardShare")
+    static let passDataToGroup = Notification.Name("passDataToGroup")
 }

--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -17,4 +17,5 @@ extension Notification.Name {
     static let cancelImagePicker = Notification.Name("cancelImagePicker")
     static let presentCardShare = Notification.Name("presentCardShare")
     static let passDataToGroup = Notification.Name("passDataToGroup")
+    static let passDataToDetail = Notification.Name("passDataToDetail")
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -159,7 +159,6 @@ extension SelectGroupBottomSheetViewController {
             case .success:
                 print("changeGroupWithAPI - success")
                 self.hideBottomSheetAndGoBack()
-                // TODO: 그룹 뷰로 한번 더 pop 되게
             case .requestErr(let message):
                 print("changeGroupWithAPI - requestErr: \(message)")
             case .pathErr:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -13,6 +13,7 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     var cardDataModel: Card?
     var serverGroups: Groups?
     var selectedGroup = 0
+    var selectedGroupIndex = 0
     var groupId: Int?
     enum Status {
         case detail
@@ -117,6 +118,7 @@ extension SelectGroupBottomSheetViewController: UIPickerViewDelegate, UIPickerVi
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         selectedGroup = serverGroups?.groups[row].groupID ?? 0
+        selectedGroupIndex = row
         pickerView.reloadAllComponents()
     }
     
@@ -139,6 +141,7 @@ extension SelectGroupBottomSheetViewController {
                 nextVC.cardDataModel = self.cardDataModel
                 nextVC.groupId = self.groupId
                 nextVC.serverGroups = self.serverGroups
+                NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: self.selectedGroupIndex, userInfo: nil)
                 self.hideBottomSheetAndPresentVC(nextViewController: nextVC)
             case .requestErr(let message):
                 print("postCardAddInGroupWithAPI - requestErr", message)
@@ -158,6 +161,7 @@ extension SelectGroupBottomSheetViewController {
             switch response {
             case .success:
                 print("changeGroupWithAPI - success")
+                NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: self.selectedGroupIndex, userInfo: nil)
                 self.hideBottomSheetAndGoBack()
             case .requestErr(let message):
                 print("changeGroupWithAPI - requestErr: \(message)")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -76,15 +76,11 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     @objc func presentCardInfoViewController() {
         switch status {
         case .detail:
-            //                     그룹 변경 서버통신
-            print(selectedGroup)
             changeGroupWithAPI(request: ChangeGroupRequest(cardID: cardDataModel?.cardID ?? "",
                                                            userID: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "",
                                                            groupID: groupId ?? 0,
                                                            newGroupID: selectedGroup))
         case .add:
-            print(selectedGroup)
-//                     그룹 속 명함 추가 테스트
             cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardId: cardDataModel?.cardID ?? "",
                                                                      userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "",
                                                                      groupId: selectedGroup))
@@ -139,7 +135,7 @@ extension SelectGroupBottomSheetViewController {
                 guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.cardDetail, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardDetailViewController) as? CardDetailViewController else { return }
                 nextVC.status = .add
                 nextVC.cardDataModel = self.cardDataModel
-                nextVC.groupId = self.groupId
+                nextVC.groupId = self.selectedGroup
                 nextVC.serverGroups = self.serverGroups
                 NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: self.selectedGroupIndex, userInfo: nil)
                 self.hideBottomSheetAndPresentVC(nextViewController: nextVC)
@@ -160,8 +156,8 @@ extension SelectGroupBottomSheetViewController {
         GroupAPI.shared.changeCardGroup(request: request) { response in
             switch response {
             case .success:
-                print("changeGroupWithAPI - success")
                 NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: self.selectedGroupIndex, userInfo: nil)
+                NotificationCenter.default.post(name: Notification.Name.passDataToDetail, object: self.selectedGroup, userInfo: nil)
                 self.hideBottomSheetAndGoBack()
             case .requestErr(let message):
                 print("changeGroupWithAPI - requestErr: \(message)")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -13,6 +13,7 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     var cardDataModel: Card?
     var serverGroups: Groups?
     var selectedGroup = 0
+    var groupId: Int?
     enum Status {
         case detail
         case add
@@ -74,8 +75,12 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     @objc func presentCardInfoViewController() {
         switch status {
         case .detail:
-            // TODO: 그룹 변경 서버통신
-            hideBottomSheetAndGoBack()
+            //                     그룹 변경 서버통신
+            print(selectedGroup)
+            changeGroupWithAPI(request: ChangeGroupRequest(cardID: cardDataModel?.cardID ?? "",
+                                                           userID: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "",
+                                                           groupID: groupId ?? 0,
+                                                           newGroupID: selectedGroup))
         case .add:
             print(selectedGroup)
 //                     그룹 속 명함 추가 테스트
@@ -132,6 +137,8 @@ extension SelectGroupBottomSheetViewController {
                 guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.cardDetail, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardDetailViewController) as? CardDetailViewController else { return }
                 nextVC.status = .add
                 nextVC.cardDataModel = self.cardDataModel
+                nextVC.groupId = self.groupId
+                nextVC.serverGroups = self.serverGroups
                 self.hideBottomSheetAndPresentVC(nextViewController: nextVC)
             case .requestErr(let message):
                 print("postCardAddInGroupWithAPI - requestErr", message)
@@ -142,6 +149,25 @@ extension SelectGroupBottomSheetViewController {
                 print("postCardAddInGroupWithAPI - serverErr")
             case .networkFail:
                 print("postCardAddInGroupWithAPI - networkFail")
+            }
+        }
+    }
+    
+    func changeGroupWithAPI(request: ChangeGroupRequest) {
+        GroupAPI.shared.changeCardGroup(request: request) { response in
+            switch response {
+            case .success:
+                print("changeGroupWithAPI - success")
+                self.hideBottomSheetAndGoBack()
+                // TODO: 그룹 뷰로 한번 더 pop 되게
+            case .requestErr(let message):
+                print("changeGroupWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("changeGroupWithAPI - pathErr")
+            case .serverErr:
+                print("changeGroupWithAPI - serverErr")
+            case .networkFail:
+                print("changeGroupWithAPI - networkFail")
             }
         }
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
@@ -245,23 +245,6 @@ extension CardCreationViewController {
 //    }
 
     // TODO: - group 서버통신. 위치변경.
-//    func changeGroupWithAPI(request: ChangeGroupRequest) {
-//        GroupAPI.shared.changeCardGroup(request: request) { response in
-//            switch response {
-//            case .success:
-//                print("changeGroupWithAPI - success")
-//            case .requestErr(let message):
-//                print("changeGroupWithAPI - requestErr: \(message)")
-//            case .pathErr:
-//                print("changeGroupWithAPI - pathErr")
-//            case .serverErr:
-//                print("changeGroupWithAPI - serverErr")
-//            case .networkFail:
-//                print("changeGroupWithAPI - networkFail")
-//            }
-//        }
-//    }
-    // TODO: - group 서버통신. 위치변경.
 //    func cardDeleteInGroupWithAPI(groupID: Int, cardID: String) {
 //        GroupAPI.shared.cardDeleteInGroup(groupID: groupID, cardID: cardID) { response in
 //            switch response {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -55,6 +55,9 @@ class CardDetailViewController: UIViewController {
         setGestureRecognizer()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        NotificationCenter.default.addObserver(self, selector: #selector(didRecieveDataNotification(_:)), name: Notification.Name.passDataToDetail, object: nil)
+    }
 }
 
 extension CardDetailViewController {
@@ -145,6 +148,10 @@ extension CardDetailViewController {
     }
     
     // MARK: - @objc Methods
+    
+    @objc func didRecieveDataNotification(_ notification: Notification) {
+        groupId = notification.object as? Int ?? 0
+    }
     
     @objc
     private func transitionCardWithAnimation(_ swipeGesture: UISwipeGestureRecognizer) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -44,6 +44,7 @@ class CardDetailViewController: UIViewController {
     
     private var isFront = true
     var status: Status = .group
+    var serverGroups: Groups?
     var groupId: Int?
     
     override func viewDidLoad() {
@@ -94,6 +95,9 @@ extension CardDetailViewController {
                         .setTitle("그룹선택")
                         .setHeight(386)
             nextVC.status = .detail
+            nextVC.groupId = self.groupId
+            nextVC.serverGroups = self.serverGroups
+            nextVC.cardDataModel = self.cardDataModel
             nextVC.modalPresentationStyle = .overFullScreen
             self.present(nextVC, animated: false, completion: nil)
         })

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -66,6 +66,8 @@ class GroupViewController: UIViewController {
     var serverCardsWithBack: Card?
     var groupId: Int?
     
+    var selectedRow = 0
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         registerCell()
@@ -120,9 +122,9 @@ extension GroupViewController {
                 if let group = data as? Groups {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
-                    self.groupId = group.groups[0].groupID
+                    self.groupId = group.groups[self.selectedRow].groupID
                     if !group.groups.isEmpty {
-                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "", groupId: group.groups[0].groupID, offset: 0))
+                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "", groupId: group.groups[self.selectedRow].groupID, offset: 0))
                     }
                 }
             case .requestErr(let message):
@@ -280,7 +282,7 @@ extension GroupViewController: UICollectionViewDataSource {
             
             groupCell.groupName.text = serverGroups?.groups[indexPath.row].groupName
             
-            if indexPath.row == 0 {
+            if indexPath.row == selectedRow {
                 collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .init())
             }
             return groupCell
@@ -315,6 +317,7 @@ extension GroupViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch collectionView {
         case groupCollectionView:
+            selectedRow = indexPath.row
             groupId = serverGroups?.groups[indexPath.row].groupID
             cardListInGroupWithAPI(cardListInGroupRequest:
                                     CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "",

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -73,7 +73,8 @@ class GroupViewController: UIViewController {
 //         그룹 삭제 서버 테스트
 //        groupDeleteWithAPI(groupID: 1)
 //         그룹 추가 서버 테스트
-//        groupAddWithAPI(groupRequest: GroupAddRequest(userId: "nada2", groupName: "대학교"))
+//        groupAddWithAPI(groupRequest: GroupAddRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "",
+//                                                      groupName: "대학교"))
 //         그룹 수정 서버 테스트
 //        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: 5, groupName: "수정나다"))
 //         그룹 속 명함 조회 테스트
@@ -85,7 +86,7 @@ class GroupViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         // 그룹 리스트 조회 서버 테스트
-//        groupListFetchWithAPI(userID: UserConst.UserDefaults.userID)
+        print("viewWillAppear")
         groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "")
 
     }
@@ -121,7 +122,6 @@ extension GroupViewController {
                     self.groupCollectionView.reloadData()
                     self.groupId = group.groups[0].groupID
                     if !group.groups.isEmpty {
-//                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada2", groupId: group.groups[0].groupID, offset: 0))
                         self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "", groupId: group.groups[0].groupID, offset: 0))
                     }
                 }
@@ -237,6 +237,7 @@ extension GroupViewController {
                                                 twoTmi: card.card.twoTmi,
                                                 threeTmi: card.card.threeTmi)
                     nextVC.groupId = self.groupId
+                    nextVC.serverGroups = self.serverGroups
                     self.navigationController?.pushViewController(nextVC, animated: true)
                 }
             case .requestErr(let message):
@@ -315,7 +316,10 @@ extension GroupViewController: UICollectionViewDataSource {
         switch collectionView {
         case groupCollectionView:
             groupId = serverGroups?.groups[indexPath.row].groupID
-            cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada2", groupId: serverGroups?.groups[indexPath.row].groupID ?? 0, offset: 0))
+            cardListInGroupWithAPI(cardListInGroupRequest:
+                                    CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "",
+                                                           groupId: serverGroups?.groups[indexPath.row].groupID ?? 0,
+                                                           offset: 0))
         case cardsCollectionView:
             cardDetailFetchWithAPI(cardID: serverCards?.cards[indexPath.row].cardID ?? "")
         default:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -88,6 +88,7 @@ class GroupViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         // 그룹 리스트 조회 서버 테스트
+        NotificationCenter.default.addObserver(self, selector: #selector(didRecieveDataNotification(_:)), name: Notification.Name.passDataToGroup, object: nil)
         print("viewWillAppear")
         groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "")
 
@@ -109,6 +110,10 @@ extension GroupViewController {
     private func setUI() {
         emptyView.isHidden = true
         navigationController?.navigationBar.isHidden = true
+    }
+    
+    @objc func didRecieveDataNotification(_ notification: Notification) {
+        selectedRow = notification.object as? Int ?? 0
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -76,7 +76,7 @@ class GroupViewController: UIViewController {
 //        groupDeleteWithAPI(groupID: 1)
 //         그룹 추가 서버 테스트
 //        groupAddWithAPI(groupRequest: GroupAddRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaults.userID) ?? "",
-//                                                      groupName: "대학교"))
+//                                                      groupName: "SOPT"))
 //         그룹 수정 서버 테스트
 //        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: 5, groupName: "수정나다"))
 //         그룹 속 명함 조회 테스트


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#219

🌱 작업한 내용
- 명함 수정 서버를 붙였습니다
- 그룹 뷰로 돌아올때마다 미분류로 초기화 되는 문제가 있어서 selectedRow라는 변수를 추가하고 저장했습니다.

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|전체화면|![Simulator Screen Shot - iPhone 12 mini - 2021-12-25 at 16 42 50](https://user-images.githubusercontent.com/69078056/147380298-5886944c-4523-4bdf-9f41-02a54455c601.png)|GIF|![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/69078056/147380799-b9804e41-4bd0-4334-a8bb-8600c6de856b.gif)|


## 📮 관련 이슈
- Resolved: #219 
