### PR TITLE
[FEAT] #216 - 명함 이미지 렌더링해서 앨범에 저장 구현

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -11,6 +11,10 @@ import Kingfisher
 
 class BackCardCell: CardCell {
     
+    // MARK: - Properties
+    
+    private var cardData: Card?
+    
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var backgroundImageView: UIImageView!
     @IBOutlet weak var tasteTitleLabel: UILabel!
@@ -34,7 +38,7 @@ class BackCardCell: CardCell {
         setUI()
     }
     @IBAction func touchShareButton(_ sender: Any) {
-        NotificationCenter.default.post(name: Notification.Name.presentCardShare, object: nil, userInfo: nil)
+        NotificationCenter.default.post(name: Notification.Name.presentCardShare, object: cardData, userInfo: nil)
     }
     
     // MARK: - Functions
@@ -59,60 +63,54 @@ extension BackCardCell {
     }
     
     /// 서버에서 image 를 URL 로 가져올 경우 사용.
-    func initCell(_ backgroundImageString: String,
-                  _ isMint: Bool,
-                  _ isSoju: Bool,
-                  _ isBoomuk: Bool,
-                  _ isSauced: Bool,
-                  _ firstTMI: String,
-                  _ secondTMI: String,
-                  _ thirdTMI: String,
+    func initCellFromServer(cardData: Card,
                   isShareable: Bool) {
+        self.cardData = cardData
         
-        if backgroundImageString.hasPrefix("https://") {
-            self.backgroundImageView.updateServerImage(backgroundImageString)
+        if cardData.background.hasPrefix("https://") {
+            self.backgroundImageView.updateServerImage(cardData.background)
         } else {
-            if let bgImage = UIImage(named: backgroundImageString) {
+            if let bgImage = UIImage(named: cardData.background) {
                 self.backgroundImageView.image = bgImage
             }
         }
         
-        mintImageView.image = isMint == true ?
+        mintImageView.image = cardData.isMincho == true ?
         UIImage(named: "iconTasteOnMincho") : UIImage(named: "iconTasteOffMincho")
-        noMintImageView.image = isMint == false ?
+        noMintImageView.image = cardData.isMincho == false ?
         UIImage(named: "iconTasteOnBanmincho") : UIImage(named: "iconTasteOffBanmincho")
         
-        sojuImageView.image = isSoju == true ?
+        sojuImageView.image = cardData.isSoju == true ?
         UIImage(named: "iconTasteOnSoju") : UIImage(named: "iconTasteOffSoju")
-        beerImageView.image = isSoju == false ?
+        beerImageView.image = cardData.isSoju == false ?
         UIImage(named: "iconTasteOnBeer") : UIImage(named: "iconTasteOffBeer")
         
-        pourEatImageView.image = isBoomuk == true ?
+        pourEatImageView.image = cardData.isBoomuk == true ?
         UIImage(named: "iconTasteOnBumeok") : UIImage(named: "iconTasteOffBumeok")
-        putSauceEatImageView.image = isBoomuk == false ?
+        putSauceEatImageView.image = cardData.isBoomuk == false ?
         UIImage(named: "iconTasteOnZzik") : UIImage(named: "iconTasteOffZzik")
         
-        sauceChickenImageView.image = isSauced == true ?
+        sauceChickenImageView.image = cardData.isSauced == true ?
         UIImage(named: "iconTasteOnSeasoned") : UIImage(named: "iconTasteOffSeasoned")
-        friedChickenImageView.image = isSauced == false ?
+        friedChickenImageView.image = cardData.isSauced == false ?
         UIImage(named: "iconTasteOnFried") : UIImage(named: "iconTasteOffFried")
         
-        if !firstTMI.isEmpty {
-            firstTmiLabel.text = "•  " + firstTMI
+        if !cardData.oneTmi.isEmpty {
+            firstTmiLabel.text = "•  " + cardData.oneTmi
         } else {
-            firstTmiLabel.text = firstTMI
+            firstTmiLabel.text = cardData.oneTmi
         }
         
-        if !secondTMI.isEmpty {
-            secondTmiLabel.text = "•  " + secondTMI
+        if !cardData.twoTmi.isEmpty {
+            secondTmiLabel.text = "•  " + cardData.twoTmi
         } else {
-            secondTmiLabel.text = secondTMI
+            secondTmiLabel.text = cardData.twoTmi
         }
         
-        if !thirdTMI.isEmpty {
-            thirdTmiLabel.text = "•  " + thirdTMI
+        if !cardData.threeTmi.isEmpty {
+            thirdTmiLabel.text = "•  " + cardData.threeTmi
         } else {
-            thirdTmiLabel.text = thirdTMI
+            thirdTmiLabel.text = cardData.threeTmi
         }
         
         shareButton.isHidden = !isShareable

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -11,6 +11,10 @@ import Kingfisher
 
 class FrontCardCell: CardCell {
     
+    // MARK: - Properties
+    
+    var userID: String?
+    
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var backgroundImageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -13,7 +13,7 @@ class FrontCardCell: CardCell {
     
     // MARK: - Properties
     
-    var userID: String?
+    private var cardData: Card?
     
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var backgroundImageView: UIImageView!
@@ -38,7 +38,7 @@ class FrontCardCell: CardCell {
         setTapGesture()
     }
     @IBAction func touchShareButton(_ sender: Any) {
-        NotificationCenter.default.post(name: Notification.Name.presentCardShare, object: nil, userInfo: nil)
+        NotificationCenter.default.post(name: Notification.Name.presentCardShare, object: cardData, userInfo: nil)
     }
     
     static func nib() -> UINib {
@@ -109,36 +109,30 @@ extension FrontCardCell {
     }
     
     /// 서버에서 image 를 URL 로 가져올 경우 사용.
-    func initCell(_ backgroundImage: String,
-                  _ cardTitle: String,
-                  _ cardDescription: String,
-                  _ userName: String,
-                  _ birth: String,
-                  _ mbti: String,
-                  _ instagramID: String,
-                  _ linkURL: String,
+    func initCellFromServer(cardData: Card,
                   isShareable: Bool) {
-
-        if backgroundImage.hasPrefix("https://") {
-            self.backgroundImageView.updateServerImage(backgroundImage)
+        self.cardData = cardData
+        
+        if cardData.background.hasPrefix("https://") {
+            self.backgroundImageView.updateServerImage(cardData.background)
         } else {
-            if let bgImage = UIImage(named: backgroundImage) {
+            if let bgImage = UIImage(named: cardData.background) {
                 self.backgroundImageView.image = bgImage
             }
         }
             
-        titleLabel.text = cardTitle
-        descriptionLabel.text = cardDescription
-        userNameLabel.text = userName
-        birthLabel.text = birth
-        mbtiLabel.text = mbti
-        instagramIDLabel.text = instagramID
-        linkURLLabel.text = linkURL
+        titleLabel.text = cardData.title
+        descriptionLabel.text = cardData.cardDescription
+        userNameLabel.text = cardData.name
+        birthLabel.text = cardData.birthDate
+        mbtiLabel.text = cardData.mbti
+        instagramIDLabel.text = cardData.instagram
+        linkURLLabel.text = cardData.link
         
-        if instagramID.isEmpty {
+        if cardData.instagram.isEmpty {
             instagramImageView.isHidden = true
         }
-        if linkURL.isEmpty {
+        if cardData.link.isEmpty {
             linkURLImageView.isHidden = true
         }
         

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -52,15 +52,7 @@ extension MainCardCell {
         
         frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
         guard let cardDataModel = cardDataModel else { return }
-        frontCard.initCell(cardDataModel.background,
-                           cardDataModel.title,
-                           cardDataModel.cardDescription ?? "",
-                           cardDataModel.name,
-                           cardDataModel.birthDate,
-                           cardDataModel.mbti,
-                           cardDataModel.instagram ?? "",
-                           cardDataModel.link ?? "",
-                           isShareable: isShareable ?? false)
+        frontCard.initCellFromServer(cardData: cardDataModel, isShareable: isShareable ?? false)
         
         contentView.addSubview(frontCard)
     }
@@ -84,15 +76,7 @@ extension MainCardCell {
             guard let backCard = BackCardCell.nib().instantiate(withOwner: self, options: nil).first as? BackCardCell else { return }
             backCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
             guard let cardDataModel = cardDataModel else { return }
-            backCard.initCell(cardDataModel.background,
-                              cardDataModel.isMincho,
-                              cardDataModel.isSoju,
-                              cardDataModel.isBoomuk,
-                              cardDataModel.isSauced,
-                              cardDataModel.oneTmi ?? "",
-                              cardDataModel.twoTmi ?? "",
-                              cardDataModel.threeTmi ?? "",
-                              isShareable: isShareable ?? false)
+            backCard.initCellFromServer(cardData: cardDataModel, isShareable: isShareable ?? false)
             
             contentView.addSubview(backCard)
             isFront = false
@@ -101,15 +85,7 @@ extension MainCardCell {
             
             frontCard.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: contentView.frame.height)
             guard let cardDataModel = cardDataModel else { return }
-            frontCard.initCell(cardDataModel.background,
-                               cardDataModel.title,
-                               cardDataModel.cardDescription ?? "",
-                               cardDataModel.name,
-                               cardDataModel.birthDate,
-                               cardDataModel.mbti,
-                               cardDataModel.instagram ?? "",
-                               cardDataModel.link ?? "",
-                               isShareable: isShareable ?? false)
+            frontCard.initCellFromServer(cardData: cardDataModel, isShareable: isShareable ?? false)
             
             contentView.addSubview(frontCard)
             isFront = true

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardShareBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardShareBottomSheetViewController.swift
@@ -10,8 +10,11 @@ import UIKit
 class CardShareBottomSheetViewController: CommonBottomSheetViewController {
 
     // MARK: - Properties
+
     var cardID: String? = "1D856A"
-    
+    var isShareable = false
+    var cardDataModel: Card?
+
     private let qrImage: UIImageView = {
         // 여기를 만든 QR이미지로 바꿔주시면 됩니당
         let imageView = UIImageView()
@@ -107,13 +110,83 @@ class CardShareBottomSheetViewController: CommonBottomSheetViewController {
         ])
     }
     
+    private func setImageWriteToSavedPhotosAlbum() {
+        let frontCardImage = setFrontCardImage()
+        let backCardImage = setBackCardImage()
+        
+        UIImageWriteToSavedPhotosAlbum(frontCardImage, self, #selector(image(_:didFinishSavingWithError:contextInfo:)), nil)
+        UIImageWriteToSavedPhotosAlbum(backCardImage, self, #selector(image(_:didFinishSavingWithError:contextInfo:)), nil)
+    }
+    
+    private func setFrontCardImage() -> UIImage {
+        guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return UIImage() }
+        
+        frontCard.frame = CGRect(x: 0, y: 0, width: 327, height: 540)
+        guard let cardDataModel = cardDataModel else { return UIImage() }
+        frontCard.initCell(UIImage(named: cardDataModel.background),
+                           cardDataModel.title,
+                           cardDataModel.cardDescription,
+                           cardDataModel.name,
+                           cardDataModel.birthDate,
+                           cardDataModel.mbti,
+                           cardDataModel.instagram ,
+                           cardDataModel.link,
+                           isShareable: isShareable)
+        
+        let frontCardView = UIView()
+        frontCardView.addSubview(frontCard)
+        
+        let renderer = UIGraphicsImageRenderer(size: frontCardView.bounds.size)
+        let frontImage = renderer.image { _ in
+            frontCardView.drawHierarchy(in: frontCardView.bounds, afterScreenUpdates: true)
+        }
+        
+        return frontImage
+    }
+    private func setBackCardImage() -> UIImage {
+        guard let backCard = BackCardCell.nib().instantiate(withOwner: self, options: nil).first as? BackCardCell else { return UIImage() }
+        backCard.frame = CGRect(x: 0, y: 0, width: 327, height: 540)
+        guard let cardDataModel = cardDataModel else { return UIImage() }
+        backCard.initCell(UIImage(named: cardDataModel.background),
+                          cardDataModel.isMincho,
+                          cardDataModel.isSoju,
+                          cardDataModel.isBoomuk,
+                          cardDataModel.isSauced,
+                          cardDataModel.oneTmi,
+                          cardDataModel.twoTmi,
+                          cardDataModel.threeTmi,
+                          isShareable: isShareable)
+
+        let backCardView = UIView()
+        backCardView.addSubview(backCard)
+        
+        let renderer = UIGraphicsImageRenderer(size: backCardView.bounds.size)
+        let backImage = renderer.image { _ in
+            backCardView.drawHierarchy(in: backCardView.bounds, afterScreenUpdates: true)
+        }
+        
+        return backImage
+    }
+    
+    // MARK: - @objc Methods
+    
     @objc func copyId() {
         UIPasteboard.general.string = cardID
         showToast(message: "명함 아이디가 복사되었습니다.", font: UIFont.button02, view: "copyID")
     }
     
     @objc func saveAsImage() {
-        showToast(message: "갤러리에 저장되었습니다.", font: UIFont.button02, view: "saveImage")
+//        showToast(message: "갤러리에 저장되었습니다.", font: UIFont.button02, view: "saveImage")
+        setImageWriteToSavedPhotosAlbum()
     }
 
+    @objc
+    private func image(_ image: UIImage, didFinishSavingWithError error: NSError?, contextInfo: UnsafeMutableRawPointer) {
+        if let error = error {
+            print(error.localizedDescription)
+        } else {
+            print("🪓success")
+            showToast(message: "갤러리에 저장되었습니다.", font: UIFont.button02, view: "saveImage")
+        }
+    }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardShareBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardShareBottomSheetViewController.swift
@@ -118,6 +118,7 @@ class CardShareBottomSheetViewController: CommonBottomSheetViewController {
         UIImageWriteToSavedPhotosAlbum(backCardImage, self, #selector(image(_:didFinishSavingWithError:contextInfo:)), nil)
     }
     
+    // FIXME: - 명함 저장시에도 테두리 둥글게 가능한가 찾기
     private func setFrontCardImage() -> UIImage {
         guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return UIImage() }
         
@@ -133,7 +134,7 @@ class CardShareBottomSheetViewController: CommonBottomSheetViewController {
                            cardDataModel.link,
                            isShareable: isShareable)
         
-        let frontCardView = UIView()
+        let frontCardView = UIView(frame: CGRect(x: 0, y: 0, width: 327, height: 540))
         frontCardView.addSubview(frontCard)
         
         let renderer = UIGraphicsImageRenderer(size: frontCardView.bounds.size)
@@ -157,7 +158,7 @@ class CardShareBottomSheetViewController: CommonBottomSheetViewController {
                           cardDataModel.threeTmi,
                           isShareable: isShareable)
 
-        let backCardView = UIView()
+        let backCardView = UIView(frame: CGRect(x: 0, y: 0, width: 327, height: 540))
         backCardView.addSubview(backCard)
         
         let renderer = UIGraphicsImageRenderer(size: backCardView.bounds.size)
@@ -176,7 +177,6 @@ class CardShareBottomSheetViewController: CommonBottomSheetViewController {
     }
     
     @objc func saveAsImage() {
-//        showToast(message: "갤러리에 저장되었습니다.", font: UIFont.button02, view: "saveImage")
         setImageWriteToSavedPhotosAlbum()
     }
 
@@ -185,7 +185,6 @@ class CardShareBottomSheetViewController: CommonBottomSheetViewController {
         if let error = error {
             print(error.localizedDescription)
         } else {
-            print("🪓success")
             showToast(message: "갤러리에 저장되었습니다.", font: UIFont.button02, view: "saveImage")
         }
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -118,15 +118,8 @@ extension CardDetailViewController {
         guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
         
         frontCard.frame = CGRect(x: 0, y: 0, width: cardView.frame.width, height: cardView.frame.height)
-        frontCard.initCell(cardDataModel?.background ?? "",
-                           cardDataModel?.title ?? "",
-                           cardDataModel?.cardDescription ?? "",
-                           cardDataModel?.name ?? "",
-                           cardDataModel?.birthDate ?? "",
-                           cardDataModel?.mbti ?? "",
-                           cardDataModel?.instagram ?? "",
-                           cardDataModel?.link ?? "",
-                           isShareable: isShareable)
+        guard let cardDataModel = cardDataModel else { return }
+        frontCard.initCellFromServer(cardData: cardDataModel, isShareable: isShareable)
         
         cardView.addSubview(frontCard)
     }
@@ -147,15 +140,8 @@ extension CardDetailViewController {
         if isFront {
             guard let backCard = BackCardCell.nib().instantiate(withOwner: self, options: nil).first as? BackCardCell else { return }
             backCard.frame = CGRect(x: 0, y: 0, width: cardView.frame.width, height: cardView.frame.height)
-            backCard.initCell(cardDataModel?.background ?? "",
-                              cardDataModel?.isMincho ?? true,
-                              cardDataModel?.isSoju ?? true,
-                              cardDataModel?.isBoomuk ?? true,
-                              cardDataModel?.isSauced ?? true,
-                              cardDataModel?.oneTmi ?? "",
-                              cardDataModel?.twoTmi ?? "",
-                              cardDataModel?.threeTmi ?? "",
-                              isShareable: isShareable)
+            guard let cardDataModel = cardDataModel else { return }
+            backCard.initCellFromServer(cardData: cardDataModel, isShareable: isShareable)
             
             cardView.addSubview(backCard)
             isFront = false
@@ -163,15 +149,8 @@ extension CardDetailViewController {
             guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
             
             frontCard.frame = CGRect(x: 0, y: 0, width: cardView.frame.width, height: cardView.frame.height)
-            frontCard.initCell(cardDataModel?.background ?? "",
-                               cardDataModel?.title ?? "",
-                               cardDataModel?.cardDescription ?? "",
-                               cardDataModel?.name ?? "",
-                               cardDataModel?.birthDate ?? "",
-                               cardDataModel?.mbti ?? "",
-                               cardDataModel?.instagram ?? "",
-                               cardDataModel?.link ?? "",
-                               isShareable: isShareable)
+            guard let cardDataModel = cardDataModel else { return }
+            frontCard.initCellFromServer(cardData: cardDataModel, isShareable: isShareable)
             
             cardView.addSubview(frontCard)
             isFront = true

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -104,23 +104,10 @@ extension FrontViewController {
             .setTitle("명함공유")
             .setHeight(404)
 
-//        nextVC.cardDataModel =
-        nextVC.cardDataModel = Card(cardID: "card",
-                                    background: "card",
-                                    title: "SOPT 명함",
-                                    name: "이채연",
-                                    birthDate: "1998.01.09 (24)",
-                                    mbti: "ENFP",
-                                    instagram: "minimin.0_0",
-                                    link: "https://www.naver.com",
-                                    cardDescription: "29기 디자인파트",
-                                    isMincho: true,
-                                    isSoju: true,
-                                    isBoomuk: true,
-                                    isSauced: true,
-                                    oneTmi: "첫번째",
-                                    twoTmi: "두번째",
-                                    threeTmi: "세번째세번째세번째")
+        if let cardData = notification.object as? Card {
+            nextVC.cardDataModel = cardData
+        }
+        
         nextVC.modalPresentationStyle = .overFullScreen
         self.present(nextVC, animated: false, completion: nil)
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -96,13 +96,31 @@ extension FrontViewController {
     }
     
     private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(didRecievePresentCardShare(_:)), name: Notification.Name.presentCardShare, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didRecievePresentCardShare(_:)), name: .presentCardShare, object: nil)
     }
     
     @objc func didRecievePresentCardShare(_ notification: Notification) {
         let nextVC = CardShareBottomSheetViewController()
             .setTitle("명함공유")
             .setHeight(404)
+
+//        nextVC.cardDataModel =
+        nextVC.cardDataModel = Card(cardID: "card",
+                                    background: "card",
+                                    title: "SOPT 명함",
+                                    name: "이채연",
+                                    birthDate: "1998.01.09 (24)",
+                                    mbti: "ENFP",
+                                    instagram: "minimin.0_0",
+                                    link: "https://www.naver.com",
+                                    cardDescription: "29기 디자인파트",
+                                    isMincho: true,
+                                    isSoju: true,
+                                    isBoomuk: true,
+                                    isSauced: true,
+                                    oneTmi: "첫번째",
+                                    twoTmi: "두번째",
+                                    threeTmi: "세번째세번째세번째")
         nextVC.modalPresentationStyle = .overFullScreen
         self.present(nextVC, animated: false, completion: nil)
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#216

🌱 작업한 내용
- 공유하기 때 QR 이미지와 명함이미지 저장을 위해서 card 데이터가 필요
-> 메인에서 mainCell 을 만들 때 card 데이터를 통째로 넘김
-> front,backCardCell 에서 공유하기 버튼이 눌리면 card 데이터를 노티피케이션으로 전송
-> 공유하기 바텀시트에서 활용 가능
> 이준선배~ userID 만 뽑아서 쓰면돼 **^^**
> 명함 이미지를 둥글게 저장하는 방법을 지금 못찾아서.. 일단 노션에 이슈 남겨뒀습니다! 근데 저장할 때 CGRect 으로 받아서 정말 이악물고 한다면 bezierpath 로 둥근 사각형을 이악물고 만드는 방법이 있을거 같은데.. 일단 다른 방법부터 찾아볼게요! 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|저장되는앞면|<img src="https://user-images.githubusercontent.com/69136340/147386783-c2dfa9e7-e4e0-442f-a028-c9df40c6e07b.jpeg" width ="250">|
|저장되는뒷면|<img src="https://user-images.githubusercontent.com/69136340/147386782-935a1393-2ce2-4dc9-a425-16312b631f2f.jpeg" width ="250">|

## 📮 관련 이슈
- Resolved: #216
