### PR TITLE
[FIX] #247 - 메인뷰 명함리스트조회 로직 변경 및 명함생성 url 포함시키기

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -18,4 +18,5 @@ extension Notification.Name {
     static let presentCardShare = Notification.Name("presentCardShare")
     static let passDataToGroup = Notification.Name("passDataToGroup")
     static let passDataToDetail = Notification.Name("passDataToDetail")
+    static let reloadMainCardSwiper = Notification.Name("reloadMainCardSwiper")
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
@@ -77,7 +77,7 @@ extension CardService: TargetType {
             let instagramIDData = request.frontCard.instagramID.data(using: .utf8) ?? Data()
             multiPartData.append(MultipartFormData(provider: .data(instagramIDData), name: "card.instagram"))
             let linkURLData = request.frontCard.linkURL.data(using: .utf8) ?? Data()
-            multiPartData.append(MultipartFormData(provider: .data(linkURLData), name: "card.linkName"))
+            multiPartData.append(MultipartFormData(provider: .data(linkURLData), name: "card.link"))
             let descriptionData = request.frontCard.description.data(using: .utf8) ?? Data()
             multiPartData.append(MultipartFormData(provider: .data(descriptionData), name: "card.description"))
             let isMinchoData = Bool(request.backCard.isMincho).description.data(using: .utf8) ?? Data()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -196,6 +196,8 @@ extension CardCreationPreviewViewController {
                 
                 guard let presentingVC = self.presentingViewController else { return }
                 
+                NotificationCenter.default.post(name: .reloadMainCardSwiper, object: nil)
+                
                 self.dismiss(animated: true) {
                     if UserDefaults.standard.object(forKey: Const.UserDefaultsKey.isFirstCard) == nil {
                         let nextVC = FirstCardAlertBottomSheetViewController()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
@@ -41,6 +41,7 @@ class CardListViewController: UIViewController {
     
     // MARK: - IBAction Properties
     @IBAction func dismissToPreviousView(_ sender: UIButton) {
+        NotificationCenter.default.post(name: .reloadMainCardSwiper, object: nil)
         self.navigationController?.popViewController(animated: true)
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -28,13 +28,6 @@ class FrontViewController: UIViewController {
         setUserID()
         setDelegate()
         setNotification()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        cardDataList?.removeAll()
-        offset = 0
         cardListFetchWithAPI(userID: userID, isList: false, offset: offset)
     }
     
@@ -72,6 +65,7 @@ extension FrontViewController {
 
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(didRecievePresentCardShare(_:)), name: .presentCardShare, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setReloadMainCardSwiper), name: .reloadMainCardSwiper, object: nil)
     }
     
     private func setUserID() {
@@ -92,6 +86,14 @@ extension FrontViewController {
         
         nextVC.modalPresentationStyle = .overFullScreen
         self.present(nextVC, animated: false, completion: nil)
+    }
+    
+    @objc
+    private func setReloadMainCardSwiper() {
+        cardDataList?.removeAll()
+        offset = 0
+        _ = cardSwiper.scrollToCard(at: 0, animated: false)
+        cardListFetchWithAPI(userID: userID, isList: false, offset: offset)
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#247

🌱 작업한 내용
- 메인뷰 명함리스트조회 로직 변경. 노티를 사용해서 명함생성, 리스트 편집 후에만 메인이 업데이트 되도록 함
-> 다른 탭에서 메인으로 돌아올 때 원래 스크롤했던 곳으로 돌아오는 자연스러움(각 탭에 대한 뎁스가 분리됨이 느껴짐)
- 메인이 업데이트 될 때 맨위로 올라오도록 함.
-> 명함생성 후 새로만든 명함은 2번째이기 때문에 접근성이 편하고 리스트 편집 후에도 내가 핀설정한 명함을 볼 수 있는 자연스러운 플로우.
- 명함생성 url 포함시키기

## 📸 스크린샷
용량이 너무 커서 슬랙에 올려두겠습니다

## 📮 관련 이슈
- Resolved: #247
