### PR TITLE
[FIX] #249 - 재설치 시 메인 명함리스트 비워지는 이슈

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -127,8 +127,6 @@ extension LoginViewController {
                         }
                     }
                 }
-                
-                self.presentToMain()
             }
         }
         
@@ -150,8 +148,6 @@ extension LoginViewController {
                         }
                     }
                 }
-                
-                self.presentToMain()
             }
         }
     }
@@ -211,10 +207,11 @@ extension LoginViewController {
                 print("postUserSignUpWithAPI - success")
                 if let userData = loginData as? UserWithTokenRequest {
                     UserDefaults.standard.set(userData.user.userID, forKey: Const.UserDefaultsKey.userID)
-                    if let tokenData = userData.user.token as? Token {
-                        UserDefaults.standard.set(tokenData.accessToken, forKey: Const.UserDefaultsKey.accessToken)
-                        UserDefaults.standard.set(tokenData.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
-                    }
+                    let tokenData = userData.user.token
+                    UserDefaults.standard.set(tokenData.accessToken, forKey: Const.UserDefaultsKey.accessToken)
+                    UserDefaults.standard.set(tokenData.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
+                    
+                    self.presentToMain()
                 }
             case .requestErr(let message):
                 print("postUserSignUpWithAPI - requestErr: \(message)")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -209,9 +209,8 @@ extension LoginViewController {
                     let tokenData = userData.user.token
                     UserDefaults.standard.set(tokenData.accessToken, forKey: Const.UserDefaultsKey.accessToken)
                     UserDefaults.standard.set(tokenData.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
-                    
+
                     self.presentToMain()
-                }
                 }
             case .requestErr(let message):
                 print("postUserSignUpWithAPI - requestErr: \(message)")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -185,7 +185,6 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
             // print("User Email : \(email ?? "")")
             // print("User Name : \((fullName?.givenName ?? "") + (fullName?.familyName ?? ""))")
             postUserSignUpWithAPI(request: userIdentifier)
-            presentToMain()
             
         default:
             break
@@ -212,6 +211,7 @@ extension LoginViewController {
                     UserDefaults.standard.set(tokenData.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
                     
                     self.presentToMain()
+                }
                 }
             case .requestErr(let message):
                 print("postUserSignUpWithAPI - requestErr: \(message)")


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#249

🌱 작업한 내용
- 재설치라기 보다 로그인 후(명함이 있는 계정) 메인리스트가 보이지 않는 경우가 존재
- postUserSignUpWithAPI() 메서드에서 성공적으로 토큰들을 가져오면 메인으로 화면전환하도록 하였다
- 기존에는 카톡의 경우 이메일 애플의 경우 userIdentifier 를 가져오는 메서드와 같은 층에 선언이 되서 화면전환이 되는 경우에 토큰없이 메인으로 넘어가는 경우에 메인 명함리스트가 비워져서 로직 수정했습니당 @mini-min

## 📮 관련 이슈
- Resolved: #249
