### PR TITLE
[FIX] #253 - 카카오톡 로그인 post 서버 통신 시, oauthToken을 사용하도록 변경 

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Const.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Const.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct Const {
-    
+    static let headerToken: String = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? ""
 }

--- a/NADA-iOS-forRelease/Resouces/Constants/Header.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Header.swift
@@ -8,10 +8,11 @@
 import Foundation
 
 extension Const {
+    
     struct Header {
         static var bearerHeader = ["Authorization": "Bearer " + UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken)!]
         
         static var basicHeader = ["Content-Type": "application/json",
-                                  "Authorization": "Bearer " + UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken)!]
+                                  "Authorization": "Bearer " + headerToken]
     }
 }

--- a/NADA-iOS-forRelease/Resouces/Constants/UserDefaults.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/UserDefaults.swift
@@ -16,5 +16,8 @@ extension Const {
         static let isFirstCard = "isFirstCard"
         static let isOnboarding = "isOnboarding"
         static let firstCardID = "firstCardID"
+        static let isAppleLogin = "isAppleLogin"
+        static let isKakaoLogin = "isKakaoLogin"
+        static let hasBeenLaunchedBeforeFlag = "hasBeenLaunchedBeforeFlag"
     }
 }

--- a/NADA-iOS-forRelease/Resouces/Constants/UserDefaults.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/UserDefaults.swift
@@ -18,6 +18,5 @@ extension Const {
         static let firstCardID = "firstCardID"
         static let isAppleLogin = "isAppleLogin"
         static let isKakaoLogin = "isKakaoLogin"
-        static let hasBeenLaunchedBeforeFlag = "hasBeenLaunchedBeforeFlag"
     }
 }

--- a/NADA-iOS-forRelease/Sources/AppDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/AppDelegate.swift
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.isAppleLogin) {
                 // 애플 로그인으로 연동되어 있을 때, -> 애플 ID와의 연동상태 확인 로직
                 let appleIDProvider = ASAuthorizationAppleIDProvider()
-                appleIDProvider.getCredentialState(forUserID: Const.UserDefaultsKey.userID) { (credentialState, error) in
+                appleIDProvider.getCredentialState(forUserID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "") { (credentialState, error) in
                     switch credentialState {
                     case .authorized:
                         print("해당 ID는 연동되어있습니다.")

--- a/NADA-iOS-forRelease/Sources/AppDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/AppDelegate.swift
@@ -85,14 +85,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 }
-
-extension UserDefaults {
-    public static func isFirstLaunch() -> Bool {
-        let isFirstLaunch = !UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.hasBeenLaunchedBeforeFlag)
-        if isFirstLaunch {
-            UserDefaults.standard.set(true, forKey: Const.UserDefaultsKey.hasBeenLaunchedBeforeFlag)
-            UserDefaults.standard.synchronize()
-        }
-        return isFirstLaunch
-    }
-}

--- a/NADA-iOS-forRelease/Sources/AppDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/AppDelegate.swift
@@ -46,6 +46,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
         UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
+        UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.isKakaoLogin)
+        UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.isAppleLogin)
     }
     
     // MARK: UISceneSession Lifecycle

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -96,8 +96,8 @@ extension GroupService: TargetType {
             return Const.Header.bearerHeader
         case .groupAdd, .groupEdit, .cardAddInGroup, .changeCardGroup:
             return Const.Header.bearerHeader
-        case .groupReset(let token):
-            return ["Content-Type": "application/json", "Authorization": "Bearer " + token]
+        case .groupReset:
+            return Const.Header.basicHeader
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
@@ -77,10 +77,8 @@ extension UserSevice: TargetType {
             return Const.Header.bearerHeader
         case .userSignUp, .userSocialSignUp, .userTokenReissue:
             return ["Content-Type": "application/json"]
-        case .userDelete(let token):
-            return ["Content-Type": "application/json", "Authorization": "Bearer " + token]
-        case .userLogout(let token):
-            return ["Content-Type": "application/json", "Authorization": "Bearer " + token]
+        case .userDelete, .userLogout:
+            return Const.Header.basicHeader
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/SceneDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/SceneDelegate.swift
@@ -36,14 +36,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 window.overrideUserInterfaceStyle = .light
             }
         }
-        
-        // 스플래시 지연시간동안 자동 로그인 작업처리
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {
-            let acToken = self.defaults.string(forKey: Const.UserDefaultsKey.accessToken)
-            let rfToken = self.defaults.string(forKey: Const.UserDefaultsKey.refreshToken)
-            
-            self.postUserTokenReissue(request: UserTokenReissueRequset(accessToken: acToken ?? "", refreshToken: rfToken ?? ""))
-        }
+
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -54,52 +47,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
     
-    // MARK: - Network
-    
-    func postUserTokenReissue(request: UserTokenReissueRequset) {
-        UserAPI.shared.userTokenReissue(request: request) { response in
-            switch response {
-            case .success:
-                print("postUserTokenReissue - Success")
-
-                var rootViewController = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil)
-                    .instantiateViewController(identifier: Const.ViewController.Identifier.loginViewController)
-                
-                if self.defaults.string(forKey: Const.UserDefaultsKey.accessToken) != "" {
-                    rootViewController = UIStoryboard(name: Const.Storyboard.Name.tabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.tabBarViewController)
-                } else {
-                    rootViewController = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil)
-                        .instantiateViewController(identifier: Const.ViewController.Identifier.loginViewController)
-                }
-                self.window?.rootViewController = rootViewController
-                self.window?.makeKeyAndVisible()
-            case .requestErr(let message):
-                print("postUserTokenReissue - requestErr: \(message)")
-                
-                self.presentToLoginViewController()
-            case .pathErr:
-                print("postUserTokenReissue - pathErr")
-            case .serverErr:
-                print("postUserTokenReissue - serverErr")
-            case .networkFail:
-                print("postUserTokenReissue - networkFail")
-            }
-        }
-    }
-    
     // MARK: - Methods
-    
-    private func presentToLoginViewController() {
-        if UserDefaults.standard.object(forKey: Const.UserDefaultsKey.isOnboarding) != nil {
-            let rootViewController = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(identifier: Const.ViewController.Identifier.loginViewController)
-            self.window?.rootViewController = rootViewController
-            self.window?.makeKeyAndVisible()
-        } else {
-            let rootViewController = UIStoryboard(name: Const.Storyboard.Name.onboarding, bundle: nil).instantiateViewController(identifier: Const.ViewController.Identifier.onboardingViewController)
-            self.window?.rootViewController = rootViewController
-            self.window?.makeKeyAndVisible()
-        }
-    }
     
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -102,18 +102,18 @@ class LoginViewController: UIViewController {
 // MARK: - KakaoSignIn
 extension LoginViewController {
     func loginWithApp() {
-        UserApi.shared.loginWithKakaoTalk {(_, error) in
+        UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
             if let error = error {
                 print(error)
             } else {
                 print("loginWithKakaoTalk() success.")
                 
-                UserApi.shared.me {(user, error) in
+                UserApi.shared.me {(_, error) in
                     if let error = error {
                         print(error)
                     } else {
-                        if let email = user?.kakaoAccount?.email {
-                            self.postUserSignUpWithAPI(request: email)
+                        if let token = oauthToken?.accessToken {
+                            self.postUserSignUpWithAPI(request: token)
                             UserDefaults.standard.set(false, forKey: Const.UserDefaultsKey.isAppleLogin)
                             UserDefaults.standard.set(true, forKey: Const.UserDefaultsKey.isKakaoLogin)
                         }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -72,9 +72,6 @@ class LoginViewController: UIViewController {
     }
     
     // 카카오 로그인 버튼 클릭 시
-//    @objc
-
-    
     @objc
     func kakaoSignInButtonPress() {
         // 카카오톡 설치 여부 확인
@@ -204,7 +201,6 @@ extension LoginViewController {
                     UserDefaults.standard.set(userData.user.userID, forKey: Const.UserDefaultsKey.userID)
                     UserDefaults.standard.set(userData.user.token.accessToken, forKey: Const.UserDefaultsKey.accessToken)
                     UserDefaults.standard.set(userData.user.token.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
-                    
                 }
             case .requestErr(let message):
                 print("postUserSignUpWithAPI - requestErr: \(message)")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -119,7 +119,6 @@ extension LoginViewController {
                         }
                     }
                 }
-                self.presentToMain()
             }
         }
         
@@ -143,7 +142,6 @@ extension LoginViewController {
                         }
                     }
                 }
-                self.presentToMain()
             }
         }
     }
@@ -177,7 +175,6 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
             postUserSignUpWithAPI(request: userIdentifier)
             UserDefaults.standard.set(true, forKey: Const.UserDefaultsKey.isAppleLogin)
             UserDefaults.standard.set(false, forKey: Const.UserDefaultsKey.isKakaoLogin)
-            presentToMain()
             
         default:
             break
@@ -201,6 +198,7 @@ extension LoginViewController {
                     UserDefaults.standard.set(userData.user.userID, forKey: Const.UserDefaultsKey.userID)
                     UserDefaults.standard.set(userData.user.token.accessToken, forKey: Const.UserDefaultsKey.accessToken)
                     UserDefaults.standard.set(userData.user.token.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
+                    self.presentToMain()
                 }
             case .requestErr(let message):
                 print("postUserSignUpWithAPI - requestErr: \(message)")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -125,18 +125,18 @@ extension LoginViewController {
     }
     
     func loginWithWeb() {
-        UserApi.shared.loginWithKakaoAccount {(_, error) in
+        UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
             if let error = error {
                 print(error)
             } else {
                 print("loginWithKakaoAccount() success.")
                 
-                UserApi.shared.me {(user, error) in
+                UserApi.shared.me {(_, error) in
                     if let error = error {
                         print(error)
                     } else {
-                        if let email = user?.kakaoAccount?.email {
-                            self.postUserSignUpWithAPI(request: email)
+                        if let token = oauthToken?.accessToken {
+                            self.postUserSignUpWithAPI(request: token)
                             UserDefaults.standard.set(false, forKey: Const.UserDefaultsKey.isAppleLogin)
                             UserDefaults.standard.set(true, forKey: Const.UserDefaultsKey.isKakaoLogin)
                         }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -112,7 +112,7 @@ extension MoreViewController {
             self.makeOKAlert(title: "", message: "로그아웃이 완료 되었습니다.") { _ in
                 if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
                     self.logoutUserWithAPI(token: acToken)
-                    self.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                    self.defaults.set(false, forKey: Const.UserDefaultsKey.hasBeenLaunchedBeforeFlag)
                     self.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
                     let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
                     nextVC.modalPresentationStyle = .overFullScreen
@@ -146,7 +146,7 @@ extension MoreViewController {
                     self.makeOKAlert(title: "", message: "모든 명함이 삭제되었습니다.") { _ in
                         if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
                             self.deleteUserWithAPI(token: acToken)
-                            self.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                            self.defaults.set(false, forKey: Const.UserDefaultsKey.hasBeenLaunchedBeforeFlag)
                             self.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
                             let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
                             nextVC.modalPresentationStyle = .overFullScreen

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -112,7 +112,8 @@ extension MoreViewController {
             self.makeOKAlert(title: "", message: "로그아웃이 완료 되었습니다.") { _ in
                 if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
                     self.logoutUserWithAPI(token: acToken)
-                    self.defaults.set(false, forKey: Const.UserDefaultsKey.hasBeenLaunchedBeforeFlag)
+                    self.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                    self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
                     self.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
                     let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
                     nextVC.modalPresentationStyle = .overFullScreen
@@ -146,7 +147,8 @@ extension MoreViewController {
                     self.makeOKAlert(title: "", message: "모든 명함이 삭제되었습니다.") { _ in
                         if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
                             self.deleteUserWithAPI(token: acToken)
-                            self.defaults.set(false, forKey: Const.UserDefaultsKey.hasBeenLaunchedBeforeFlag)
+                            self.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                            self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
                             self.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
                             let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
                             nextVC.modalPresentationStyle = .overFullScreen

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Splash/SplashViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Splash/SplashViewController.swift
@@ -11,15 +11,24 @@ class SplashViewController: UIViewController {
 
     // MARK: - Properties
     private weak var appDelegate = UIApplication.shared.delegate as? AppDelegate
-
-    // MARK: - @IBOutlet Properties
-    
+    let defaults = UserDefaults.standard
+ 
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+         super.viewWillAppear(animated)
         
-        // Do any additional setup after loading the view.
-        // postUserTokenReissue(request: UserTokenReissueRequset(accessToken: UserDefaults.standard.string(forKey: Const.UserDefaults.accessToken)!, refreshToken: UserDefaults.standard.string(forKey: Const.UserDefaults.refreshToken)!))
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {
+            if self.appDelegate?.isLogin == true {
+                self.presentToMain()
+            } else {
+                self.presentToLogin()
+            }
+        }
     }
     
     // MARK: - Functions
@@ -37,26 +46,4 @@ class SplashViewController: UIViewController {
         self.present(loginVC, animated: true, completion: nil)
     }
     
-}
-
-// MARK: - Networks
-extension SplashViewController {
-    
-    func postUserTokenReissue(request: UserTokenReissueRequset) {
-        UserAPI.shared.userTokenReissue(request: request) { response in
-            switch response {
-            case .success:
-                print("postUserTokenReissue - Success")
-            case .requestErr(let message):
-                print("postUserTokenReissue - requestErr: \(message)")
-                self.presentToLogin()
-            case .pathErr:
-                print("postUserTokenReissue - pathErr")
-            case .serverErr:
-                print("postUserTokenReissue - serverErr")
-            case .networkFail:
-                print("postUserTokenReissue - networkFail")
-            }
-        }
-    }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#253

🌱 작업한 내용
- `email` 사용 -> `oauthToken?.accessToken` 사용으로 변경

## 📮 관련 이슈
- Resolved: #253 
