### PR TITLE
[FIX] #255 - 명함생성 후 두번째 명함으로 이동 및 리스트편집 후 첫번째 명함으로 이동

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -18,5 +18,6 @@ extension Notification.Name {
     static let presentCardShare = Notification.Name("presentCardShare")
     static let passDataToGroup = Notification.Name("passDataToGroup")
     static let passDataToDetail = Notification.Name("passDataToDetail")
-    static let reloadMainCardSwiper = Notification.Name("reloadMainCardSwiper")
+    static let listReloadMainCardSwiper = Notification.Name("listReloadMainCardSwiper")
+    static let creationReloadMainCardSwiper = Notification.Name("creationReloadMainCardSwiper")
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -196,7 +196,7 @@ extension CardCreationPreviewViewController {
                 
                 guard let presentingVC = self.presentingViewController else { return }
                 
-                NotificationCenter.default.post(name: .reloadMainCardSwiper, object: nil)
+                NotificationCenter.default.post(name: .creationReloadMainCardSwiper, object: nil)
                 
                 self.dismiss(animated: true) {
                     if UserDefaults.standard.object(forKey: Const.UserDefaultsKey.isFirstCard) == nil {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardList/CardListViewController.swift
@@ -41,7 +41,7 @@ class CardListViewController: UIViewController {
     
     // MARK: - IBAction Properties
     @IBAction func dismissToPreviousView(_ sender: UIButton) {
-        NotificationCenter.default.post(name: .reloadMainCardSwiper, object: nil)
+        NotificationCenter.default.post(name: .listReloadMainCardSwiper, object: nil)
         self.navigationController?.popViewController(animated: true)
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -65,7 +65,8 @@ extension FrontViewController {
 
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(didRecievePresentCardShare(_:)), name: .presentCardShare, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(setReloadMainCardSwiper), name: .reloadMainCardSwiper, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setCreationReloadMainCardSwiper), name: .creationReloadMainCardSwiper, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setListReloadMainCardSwiper), name: .listReloadMainCardSwiper, object: nil)
     }
     
     private func setUserID() {
@@ -89,7 +90,15 @@ extension FrontViewController {
     }
     
     @objc
-    private func setReloadMainCardSwiper() {
+    private func setCreationReloadMainCardSwiper() {
+        cardDataList?.removeAll()
+        offset = 0
+        _ = cardSwiper.scrollToCard(at: 1, animated: false)
+        cardListFetchWithAPI(userID: userID, isList: false, offset: offset)
+    }
+    
+    @objc
+    private func setListReloadMainCardSwiper() {
         cardDataList?.removeAll()
         offset = 0
         _ = cardSwiper.scrollToCard(at: 0, animated: false)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#255

🌱 작업한 내용
- 명함생성 후 두번째 명함으로 이동
- 리스트편집 후 첫번째 명함으로 이동

## 📮 관련 이슈
- Resolved: #255
