### PR TITLE
[FEAT] #257 - 명함 그룹뷰 인파이나이트스크롤 구현

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -18,6 +18,7 @@ extension Notification.Name {
     static let presentCardShare = Notification.Name("presentCardShare")
     static let passDataToGroup = Notification.Name("passDataToGroup")
     static let passDataToDetail = Notification.Name("passDataToDetail")
-    static let listReloadMainCardSwiper = Notification.Name("listReloadMainCardSwiper")
+    static let reloadGroupViewController = Notification.Name("reloadGroupViewController")
     static let creationReloadMainCardSwiper = Notification.Name("creationReloadMainCardSwiper")
+    static let listReloadMainCardSwiper = Notification.Name("listReloadMainCardSwiper")
 }

--- a/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupCell/CardInGroupCollectionViewCell.swift
@@ -26,18 +26,25 @@ class CardInGroupCollectionViewCell: UICollectionViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        setUI()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        backgroundImageView.image = UIImage()
+        titleLabel.text = ""
+        descriptionLabel.text = ""
+        userNameLabel.text = ""
+        birthLabel.text = ""
+        mbtiLabel.text = ""
+        instagramIDLabel.text = ""
+        mbtiLabel.text = ""
+        instagramIcon.image = UIImage()
+        urlIcon.image = UIImage()
     }
     
     static func nib() -> UINib {
         return UINib(nibName: Const.Xib.cardInGroupCollectionViewCell, bundle: Bundle(for: CardInGroupCollectionViewCell.self))
     }
 
-}
-
-extension CardInGroupCollectionViewCell {
-    private func setUI() {
-        
-//        backgroundImageView.alpha = 0.4
-    }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -72,11 +72,13 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     @objc func presentCardInfoViewController() {
         switch status {
         case .detail:
+            NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
             changeGroupWithAPI(request: ChangeGroupRequest(cardID: cardDataModel?.cardID ?? "",
                                                            userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
                                                            groupID: groupId ?? 0,
                                                            newGroupID: selectedGroup))
         case .add, .addWithQR:
+            NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
             cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardId: cardDataModel?.cardID ?? "",
                                                                      userId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
                                                                      groupId: selectedGroup))

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -130,6 +130,7 @@ extension CardDetailViewController {
             self.makeCancelDeleteAlert(title: "명함 삭제",
                                        message: "명함을 정말 삭제하시겠습니까?",
                                        deleteAction: { _ in
+                NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
                 // 명함 삭제 서버통신
                 self.cardDeleteInGroupWithAPI(groupID: self.groupId ?? 0, cardID: self.cardDataModel?.cardID ?? "")
             }) })

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -63,32 +63,22 @@ class GroupViewController: UIViewController {
     
     // 그룹 이름들을 담을 변수 생성
     var serverGroups: Groups?
-    var serverCards: CardsInGroupResponse?
+    var frontCards: [FrontCard]? = []
     var serverCardsWithBack: Card?
     var groupId: Int?
     
     var selectedRow = 0
+    private var offset = 0
+    private var isInfiniteScroll = true
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        registerCell()
-        setUI()
-
-//         그룹 속 명함 조회 테스트
-//        cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: "nada", groupId: 5, offset: 0))
-//         명함 검색 테스트
-//        cardDetailFetchWithAPI(cardID: "cardA")
         
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        // 그룹 리스트 조회 서버 테스트
-        super.viewWillAppear(true)
-        NotificationCenter.default.addObserver(self, selector: #selector(didRecieveDataNotification(_:)), name: Notification.Name.passDataToGroup, object: nil)
+        registerCell()
+        setNotification()
+        setUI()
         groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "")
-
     }
-    
 }
 
 extension GroupViewController {
@@ -107,8 +97,25 @@ extension GroupViewController {
         navigationController?.navigationBar.isHidden = true
     }
     
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(didRecieveDataNotification(_:)), name: Notification.Name.passDataToGroup, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(scrollToTop), name: .reloadGroupViewController, object: nil)
+    }
+    
     @objc func didRecieveDataNotification(_ notification: Notification) {
         selectedRow = notification.object as? Int ?? 0
+    }
+    
+    @objc
+    private func scrollToTop() {
+        offset = 0
+        frontCards?.removeAll()
+        groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "")
+        // FIXME: - 스크롤 탑
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
+        }
+//        cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
     }
 }
 
@@ -123,9 +130,7 @@ extension GroupViewController {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
                     self.groupId = group.groups[self.selectedRow].groupID
-                    if !group.groups.isEmpty {
-                        self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "", groupId: group.groups[self.selectedRow].groupID, offset: 0))
-                    }
+                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "", groupId: group.groups[self.selectedRow].groupID, offset: 0))
                 }
             case .requestErr(let message):
                 print("groupListFetchWithAPI - requestErr: \(message)")
@@ -143,9 +148,11 @@ extension GroupViewController {
         GroupAPI.shared.cardListFetchInGroup(cardListInGroupRequest: cardListInGroupRequest) { response in
             switch response {
             case .success(let data):
+                self.isInfiniteScroll = true
+                
                 if let cards = data as? CardsInGroupResponse {
-                    self.serverCards = cards
-                    if cards.cards.count == 0 {
+                    self.frontCards?.append(contentsOf: cards.cards)
+                    if self.frontCards?.count == 0 {
                         self.emptyView.isHidden = false
                     } else {
                         self.emptyView.isHidden = true
@@ -191,7 +198,16 @@ extension GroupViewController {
 
 // MARK: - UICollectionViewDelegate
 extension GroupViewController: UICollectionViewDelegate {
-    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if cardsCollectionView.contentOffset.y > cardsCollectionView.contentSize.height - cardsCollectionView.bounds.height {
+            if isInfiniteScroll {
+                isInfiniteScroll = false
+                offset += 1
+                
+                cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "", groupId: serverGroups?.groups[self.selectedRow].groupID ?? -1, offset: offset))
+            }
+        }
+    }
 }
 
 // MARK: - UICollectionViewDataSource
@@ -201,7 +217,7 @@ extension GroupViewController: UICollectionViewDataSource {
         case groupCollectionView:
             return serverGroups?.groups.count ?? 0
         case cardsCollectionView:
-            return serverCards?.cards.count ?? 0
+            return frontCards?.count ?? 0
         default:
             return 0
         }
@@ -224,21 +240,21 @@ extension GroupViewController: UICollectionViewDataSource {
             guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.cardInGroupCollectionViewCell, for: indexPath) as? CardInGroupCollectionViewCell else {
                 return UICollectionViewCell()
             }
+            guard let frontCards = frontCards else { return UICollectionViewCell() }
+            cardCell.backgroundImageView.updateServerImage(frontCards[indexPath.row].background)
+            cardCell.cardId = frontCards[indexPath.row].cardID
+            cardCell.titleLabel.text = frontCards[indexPath.row].title
+            cardCell.descriptionLabel.text = frontCards[indexPath.row].cardDescription
+            cardCell.userNameLabel.text = frontCards[indexPath.row].name
+            cardCell.birthLabel.text = frontCards[indexPath.row].birthDate
+            cardCell.mbtiLabel.text = frontCards[indexPath.row].mbti
+            cardCell.instagramIDLabel.text = frontCards[indexPath.row].instagram
+            cardCell.lineURLLabel.text = frontCards[indexPath.row].link
             
-            cardCell.backgroundImageView.updateServerImage(serverCards?.cards[indexPath.row].background ?? "")
-            cardCell.cardId = serverCards?.cards[indexPath.row].cardID 
-            cardCell.titleLabel.text = serverCards?.cards[indexPath.row].title
-            cardCell.descriptionLabel.text = serverCards?.cards[indexPath.row].cardDescription
-            cardCell.userNameLabel.text = serverCards?.cards[indexPath.row].name
-            cardCell.birthLabel.text = serverCards?.cards[indexPath.row].birthDate
-            cardCell.mbtiLabel.text = serverCards?.cards[indexPath.row].mbti
-            cardCell.instagramIDLabel.text = serverCards?.cards[indexPath.row].instagram
-            cardCell.lineURLLabel.text = serverCards?.cards[indexPath.row].link
-            
-            if serverCards?.cards[indexPath.row].instagram == "" {
+            if frontCards[indexPath.row].instagram == "" {
                 cardCell.instagramIcon.isHidden = true
             }
-            if serverCards?.cards[indexPath.row].link == "" {
+            if frontCards[indexPath.row].link == "" {
                 cardCell.urlIcon.isHidden = true
             }
             
@@ -253,14 +269,16 @@ extension GroupViewController: UICollectionViewDataSource {
         case groupCollectionView:
             selectedRow = indexPath.row
             groupId = serverGroups?.groups[indexPath.row].groupID
+            offset = 0
+            frontCards?.removeAll()
             cardListInGroupWithAPI(cardListInGroupRequest:
                                     CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
                                                            groupId: serverGroups?.groups[indexPath.row].groupID ?? 0,
                                                            offset: 0))
         case cardsCollectionView:
-            cardDetailFetchWithAPI(cardID: serverCards?.cards[indexPath.row].cardID ?? "")
+            cardDetailFetchWithAPI(cardID: frontCards?[indexPath.row].cardID ?? "")
         default:
-            print(indexPath.row)
+            return
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
@@ -33,13 +33,12 @@ class QRScanViewController: UIViewController {
         super.viewDidLoad()
         basicSetting()
     }
-    
 }
 
 extension QRScanViewController {
     @objc func dismissQRScanViewController() {
+        NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
         self.dismiss(animated: true, completion: nil)
-        presentingViewController?.viewWillAppear(true)
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
@@ -30,11 +30,11 @@ class GroupEditViewController: UIViewController {
         super.viewWillAppear(animated)
         
         self.groupEditTableView.reloadData()
-        
     }
     
     // MARK: - @IBAction Properties
     @IBAction func dismissToPreviousView(_ sender: UIButton) {
+        NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
         self.navigationController?.popViewController(animated: true)
     }
     


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#257

🌱 작업한 내용
- prepareForReuse 로 셀 초기화
- 명함 추가, 명함큐알 추가, 명함삭제, 큐알스캔 뒤로가기, 그룹 편집 뒤로가기 시에 그룹뷰 갱신 노티 추가
- viewWillAppear 에서 구현하려했지만 컬렉션뷰 맨 위로 올리는 과정이 추가되기 위해서 노티 사용
- 무한스크롤 구현
- 현재 맨 위로 올리기 위해서 scrolltotop 메서드를 사용하는데 컬렉션뷰의 델리게이트가 먼저 실행되서 item 0 으로 이동하지 못하고 에러가 발생해서 현재 1초의 딜레이를 주고 있는데 좀 더 고민해보겠습니당
> 스켈레톤 을 통해서 1초 정도 플레이스홀더 보여주고 자연스럽게 top 으로 이동 등

## 📮 관련 이슈
- Resolved: #257
