### PR TITLE
[FIX] #262 - 명함 모음 리로드 로직 수정

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -72,13 +72,11 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     @objc func presentCardInfoViewController() {
         switch status {
         case .detail:
-            NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
             changeGroupWithAPI(request: ChangeGroupRequest(cardID: cardDataModel?.cardID ?? "",
                                                            userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
                                                            groupID: groupId ?? 0,
                                                            newGroupID: selectedGroup))
         case .add, .addWithQR:
-            NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
             cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardId: cardDataModel?.cardID ?? "",
                                                                      userId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
                                                                      groupId: selectedGroup))

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -16,8 +16,10 @@ class CardDetailViewController: UIViewController {
         case .group:
             self.navigationController?.popViewController(animated: true)
         case .add:
+            NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
             self.dismiss(animated: true, completion: nil)
         case .addWithQR:
+            NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
             self.presentingViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
 
         case .detail:
@@ -28,7 +30,6 @@ class CardDetailViewController: UIViewController {
     @IBAction func presentHarmonyViewController(_ sender: Any) {
         cardHarmonyFetchWithAPI(myCard: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.firstCardID) ?? "",
                                 yourCard: cardDataModel?.cardID ?? "")
-
     }
     
     @IBOutlet weak var optionButton: UIButton!

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -77,6 +77,13 @@ class GroupViewController: UIViewController {
         registerCell()
         setNotification()
         setUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        offset = 0
+        frontCards?.removeAll()
         groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "")
     }
 }
@@ -99,7 +106,12 @@ extension GroupViewController {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(didRecieveDataNotification(_:)), name: Notification.Name.passDataToGroup, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(scrollToTop), name: .reloadGroupViewController, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(relaodCardCollection), name: .reloadGroupViewController, object: nil)
+    }
+    // FIXME: - 스크롤탑
+    private func scrollToTop(completion: () -> Void) {
+        groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "")
+        completion()
     }
     
     @objc func didRecieveDataNotification(_ notification: Notification) {
@@ -107,14 +119,15 @@ extension GroupViewController {
     }
     
     @objc
-    private func scrollToTop() {
+    private func relaodCardCollection() {
         offset = 0
         frontCards?.removeAll()
-        groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "")
+        
         // FIXME: - 스크롤 탑
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
-        }
+//        scrollToTop {
+//            self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
+//        }
+        groupListFetchWithAPI(userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "")
 //        cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
@@ -37,7 +37,6 @@ class QRScanViewController: UIViewController {
 
 extension QRScanViewController {
     @objc func dismissQRScanViewController() {
-        NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
         self.dismiss(animated: true, completion: nil)
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/GroupEditViewController.swift
@@ -34,7 +34,6 @@ class GroupEditViewController: UIViewController {
     
     // MARK: - @IBAction Properties
     @IBAction func dismissToPreviousView(_ sender: UIButton) {
-        NotificationCenter.default.post(name: .reloadGroupViewController, object: nil)
         self.navigationController?.popViewController(animated: true)
     }
     


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#262

🌱 작업한 내용
- 명함 모음 리로드 로직 수정
- 큐알스캔 뒤로가기와 ID 추가 취소를 제외한 모든 경우에서 리로드.
> 이유는 그룹 편집 스와이프에도 리로드를 적용하기 위해서 viewWillAppear 를 사용해서입니다!

## 📮 관련 이슈
- Resolved: #262
