### PR TITLE
[FEAT] #218 - 명함 그룹 뷰 1차 버그 해결

### DIFF
--- a/NADA-iOS-forRelease/Info.plist
+++ b/NADA-iOS-forRelease/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>NADA</string>
+	<string>나다 NADA</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
@@ -119,6 +119,7 @@
                         <outlet property="backButton" destination="ppy-17-v7q" id="mdc-dd-yGB"/>
                         <outlet property="cardView" destination="0P6-1k-dQm" id="qGN-9y-K4Y"/>
                         <outlet property="idLabel" destination="J0e-kR-6Zc" id="4il-d0-UMv"/>
+                        <outlet property="idStackView" destination="yM7-jk-cSi" id="W9m-Jo-mDr"/>
                         <outlet property="optionButton" destination="YU7-vs-utH" id="Jg4-K3-dTV"/>
                     </connections>
                 </viewController>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
@@ -94,8 +94,6 @@ class AddWithIdBottomSheetViewController: CommonBottomSheetViewController, UITex
 
 extension AddWithIdBottomSheetViewController {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
-        // 서버 연결과 더불어... 검색 결과가 없으면 bottomsheet dismiss 하지 말고 hidden 풀어주기
         cardDetailFetchWithAPI(cardID: textField.text ?? "")
         return true
     }
@@ -112,6 +110,7 @@ extension AddWithIdBottomSheetViewController {
                         self.explainLabel.isHidden = false
                         self.explainLabel.text = "자신의 명함은 추가할 수 없습니다."
                     } else {
+                        self.addWithIdTextField.resignFirstResponder()
                         let nextVC = CardResultBottomSheetViewController()
                         nextVC.cardDataModel = card.card
                         self.hideBottomSheetAndPresent(nextBottomSheet: nextVC, title: card.card.name, height: 574)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
@@ -227,7 +227,7 @@ class CommonBottomSheetViewController: UIViewController {
                 guard let presentingVC = self.presentingViewController else { return }
                 self.dismiss(animated: false) {
                     let nextVC = nextViewController
-                    nextVC.modalPresentationStyle = .fullScreen
+                    nextVC.modalPresentationStyle = .overFullScreen
                     presentingVC.present(nextVC, animated: true, completion: nil)
                 }
             }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
@@ -227,7 +227,7 @@ class CommonBottomSheetViewController: UIViewController {
                 guard let presentingVC = self.presentingViewController else { return }
                 self.dismiss(animated: false) {
                     let nextVC = nextViewController
-                    nextVC.modalPresentationStyle = .overFullScreen
+                    nextVC.modalPresentationStyle = .fullScreen
                     presentingVC.present(nextVC, animated: true, completion: nil)
                 }
             }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -156,7 +156,9 @@ extension SelectGroupBottomSheetViewController {
             case .success:
                 NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: self.selectedGroupIndex, userInfo: nil)
                 NotificationCenter.default.post(name: Notification.Name.passDataToDetail, object: self.selectedGroup, userInfo: nil)
-                self.hideBottomSheetAndGoBack()
+                self.makeOKAlert(title: "", message: "그룹이 변경되었습니다.") { _ in
+                    self.hideBottomSheetAndGoBack()
+                }
             case .requestErr(let message):
                 print("changeGroupWithAPI - requestErr: \(message)")
             case .pathErr:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -34,6 +34,7 @@ class CardDetailViewController: UIViewController {
     @IBOutlet weak var optionButton: UIButton!
     @IBOutlet weak var cardView: UIView!
     @IBOutlet weak var backButton: UIButton!
+    @IBOutlet weak var idStackView: UIStackView!
     @IBOutlet weak var idLabel: UILabel!
     
     public var cardDataModel: Card?
@@ -110,6 +111,7 @@ extension CardDetailViewController {
         case .detail:
             return 
         }
+        idStackView.isHidden = true
         idLabel.text = cardDataModel?.cardID
     }
     private func setMenu() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -301,6 +301,8 @@ extension GroupViewController: UICollectionViewDelegateFlowLayout {
     }
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         switch collectionView {
+        case groupCollectionView:
+            return 5
         case cardsCollectionView:
             return collectionView.frame.size.width * 15/327
         default:


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#218

🌱 작업한 내용
- 그룹뷰에서 애니메이션이 풀리지 않도록 하기
- 아이디로 명함 추가했을때 없는 아이디 일때도 키보드가 내려가지 않도록 하기
- CardView 이미지 비율 수정
- 그룹이 변경되었습니다. 알러트
- 그룹 추가 후 붙어버리는 이슈 resolve
- 명함 상세 아이디 없애기

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|파일첨부바람|

## 📮 관련 이슈
- Resolved: #218 
