### PR TITLE
[FEAT] #269 - QR 스캔 재시작 구현

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -21,4 +21,5 @@ extension Notification.Name {
     static let reloadGroupViewController = Notification.Name("reloadGroupViewController")
     static let creationReloadMainCardSwiper = Notification.Name("creationReloadMainCardSwiper")
     static let listReloadMainCardSwiper = Notification.Name("listReloadMainCardSwiper")
+    static let dismissQRCodeCardResult = Notification.Name("dismissQRCodeCardResult")
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
@@ -42,6 +42,12 @@ class CardResultBottomSheetViewController: CommonBottomSheetViewController {
         setupUI()
     }
     
+    override func hideBottomSheetAndGoBack() {
+        super.hideBottomSheetAndGoBack()
+        
+        NotificationCenter.default.post(name: .dismissQRCodeCardResult, object: nil)
+    }
+    
     // MARK: - @Functions
     // UI 세팅 작업
     private func setupUI() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CommonBottomSheetViewController.swift
@@ -157,7 +157,6 @@ class CommonBottomSheetViewController: UIViewController {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: dismissIndicatorView.bottomAnchor, constant: 28),
-//            titleLabel.widthAnchor.constraint(equalToConstant: 100),
             titleLabel.centerXAnchor.constraint(equalTo: bottomSheetView.centerXAnchor)
         ])
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -38,6 +38,17 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
         setupUI()
     }
     
+    override func hideBottomSheetAndGoBack() {
+        super.hideBottomSheetAndGoBack()
+        
+        switch status {
+        case .addWithQR:
+            NotificationCenter.default.post(name: .dismissQRCodeCardResult, object: nil)
+        default:
+            return
+        }
+    }
+    
     // MARK: - @Functions
     // UI 세팅 작업
     private func setupUI() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/QRScanViewController.swift
@@ -31,7 +31,9 @@ class QRScanViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         basicSetting()
+        setNotification()
     }
 }
 
@@ -65,7 +67,7 @@ extension QRScanViewController {
             setGuideLineView(rectOfInterest: rectOfInterest)
             captureSession.startRunning()
         } catch {
-            print("error")
+            print("QRScanViewController - AVCaptureDevice error")
         }
     }
     
@@ -104,6 +106,15 @@ extension QRScanViewController {
             guideImage.heightAnchor.constraint(equalToConstant: 327)
         ])
     }
+    
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(captureSessionStartRunning), name: .dismissQRCodeCardResult, object: nil)
+    }
+    
+    @objc
+    private func captureSessionStartRunning() {
+        captureSession.startRunning()
+    }
 }
 
 extension QRScanViewController: AVCaptureMetadataOutputObjectsDelegate {
@@ -120,8 +131,6 @@ extension QRScanViewController: AVCaptureMetadataOutputObjectsDelegate {
 
             // ✅ qr코드가 가진 문자열이 URL 형태를 띈다면 출력.(아무런 qr코드나 찍는다고 출력시키면 안되니까 여기서 분기처리 가능. )
             if stringValue.hasPrefix("ThisIsTeamNADAQrCode") {
-                print(stringValue)
-
                 self.captureSession.stopRunning()
                 // TODO: 여기서 QR에 있는 ID값으로 명함검색 API통신
                 cardDetailFetchWithAPI(cardID: stringValue.deletingPrefix("ThisIsTeamNADAQrCode"))


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#269

🌱 작업한 내용
- R 스캔 재시작 구현
- cardResult 바텀시트 내릴때와 selectGroup 바텀시트 내릴때 재시작 노티로 구현

## 📮 관련 이슈
- Resolved: #269
