### PR TITLE
[FEAT] #280 -  명함생성 시 activity indicator 추가

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationPreviewViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import NVActivityIndicatorView
+
 class CardCreationPreviewViewController: UIViewController {
     
     public var frontCardDataModel: FrontCardDataModel?
@@ -17,6 +19,23 @@ class CardCreationPreviewViewController: UIViewController {
     private var isFront = true
     private var cardCreationRequest: CardCreationRequest?
     private var isShareable = false
+    
+    lazy var loadingBgView: UIView = {
+        let bgView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height))
+        bgView.backgroundColor = .bottomDimmedBackground
+        
+        return bgView
+    }()
+    
+    lazy var activityIndicator: NVActivityIndicatorView = {
+        let activityIndicator = NVActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 40, height: 40),
+                                                        type: .ballBeat,
+                                                        color: .mainColorNadaMain,
+                                                        padding: .zero)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        
+        return activityIndicator
+    }()
     
     // MARK: - @IBOutlet Properties
     
@@ -43,7 +62,13 @@ class CardCreationPreviewViewController: UIViewController {
         guard let cardCreationRequest = cardCreationRequest,
               let cardBackgroundImage = cardBackgroundImage else { return }
 
-        cardCreationWithAPI(request: cardCreationRequest, image: cardBackgroundImage)
+        DispatchQueue.main.async {
+            self.setActivityIndicator()
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.cardCreationWithAPI(request: cardCreationRequest, image: cardBackgroundImage)
+        }
     }
     @IBAction func touchBackButton(_ sender: Any) {
         navigationController?.popViewController(animated: true)
@@ -135,6 +160,17 @@ extension CardCreationPreviewViewController {
             cardBackgroundImage = UIImage(named: "imgCardBg07")
         }
     }
+    private func setActivityIndicator() {
+        view.addSubview(loadingBgView)
+        loadingBgView.addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        
+        activityIndicator.startAnimating()
+    }
 
     // MARK: - @objc Methods
     
@@ -199,6 +235,9 @@ extension CardCreationPreviewViewController {
                 NotificationCenter.default.post(name: .creationReloadMainCardSwiper, object: nil)
                 
                 self.dismiss(animated: true) {
+                    self.activityIndicator.stopAnimating()
+                    self.loadingBgView.removeFromSuperview()
+                    
                     if UserDefaults.standard.object(forKey: Const.UserDefaultsKey.isFirstCard) == nil {
                         let nextVC = FirstCardAlertBottomSheetViewController()
                             .setTitle("""

--- a/Podfile
+++ b/Podfile
@@ -15,4 +15,5 @@ pod 'KakaoSDKUser'
 pod 'KakaoSDKAuth'
 pod 'IQKeyboardManagerSwift'
 pod 'Kingfisher', '~> 7.0'
+pod 'NVActivityIndicatorView'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,6 +17,9 @@ PODS:
     - Moya/Core (= 14.0.0)
   - Moya/Core (14.0.0):
     - Alamofire (~> 5.0)
+  - NVActivityIndicatorView (5.1.1):
+    - NVActivityIndicatorView/Base (= 5.1.1)
+  - NVActivityIndicatorView/Base (5.1.1)
   - SkeletonView (1.21.2)
   - SwiftLint (0.43.1)
   - VerticalCardSwiper (2.3.1)
@@ -28,6 +31,7 @@ DEPENDENCIES:
   - KakaoSDKUser
   - Kingfisher (~> 7.0)
   - Moya (~> 14.0)
+  - NVActivityIndicatorView
   - SkeletonView
   - SwiftLint
   - VerticalCardSwiper
@@ -41,6 +45,7 @@ SPEC REPOS:
     - KakaoSDKUser
     - Kingfisher
     - Moya
+    - NVActivityIndicatorView
     - SkeletonView
     - SwiftLint
     - VerticalCardSwiper
@@ -53,10 +58,11 @@ SPEC CHECKSUMS:
   KakaoSDKUser: f488aa4699b3fd3a836ab5c7e25e2cb4cea190c1
   Kingfisher: f738f9c4a3415823b8e2985d10aa2d6a9f37bc4d
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
+  NVActivityIndicatorView: 1f6c5687f1171810aa27a3296814dc2d7dec3667
   SkeletonView: a085533443fed0198309f1979780afb6e80eaedd
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   VerticalCardSwiper: 68df635b354500f86934ea044ade37a264c044c6
 
-PODFILE CHECKSUM: a7bc6fadbc7e3f5bb9f8560fb65bb65ef719c5cc
+PODFILE CHECKSUM: ee00f6411308bc32732ea2efc98ad9cb9bd27f5d
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release1.0/#280

🌱 작업한 내용
- NVActivityIndicatorView 라이브러리 추가
- 디스패치큐를 통해서 애니메이션을 main 큐에서 실행
> startAnimating() 후에 서버통신 시작보장
- activity indicator 추가

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src="https://user-images.githubusercontent.com/69136340/147715557-b20c3612-518e-42ab-80e9-2ee6f768eba4.MP4" width ="250">|

## 📮 관련 이슈
- Resolved: #280
