### PR TITLE
[FIX] #301 - 그룹 편집 뷰 그룹명 길이 제한

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/GroupEdit/GroupEditTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,7 +24,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SOPT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gYp-4q-F3G">
-                        <rect key="frame" x="32" y="20" width="37.5" height="19"/>
+                        <rect key="frame" x="32" y="20" width="311" height="19"/>
                         <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="14"/>
                         <color key="textColor" name="secondary"/>
                         <nil key="highlightedColor"/>
@@ -45,6 +45,7 @@
                     <constraint firstItem="gYp-4q-F3G" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="32" id="hj7-Lu-tmZ"/>
                     <constraint firstAttribute="bottom" secondItem="waV-UG-3wC" secondAttribute="bottom" id="plM-na-794"/>
                     <constraint firstItem="gYp-4q-F3G" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="u6L-vR-88A"/>
+                    <constraint firstAttribute="trailing" secondItem="gYp-4q-F3G" secondAttribute="trailing" constant="32" id="w2o-Zf-yRN"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- release/#301

🌱 작업한 내용
- 그룹 편집 뷰에서는 그룹명이 라벨 길이 넘으면 `Truncate Tail`로 보여집니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![simulator_screenshot_181CCE82-D9B4-41B4-B1E5-6296F5E7AF88](https://user-images.githubusercontent.com/69389288/148587913-5c5f6b82-dc16-4022-86a3-2ac2da3f7515.png)|

## 📮 관련 이슈
- Resolved: #301 
