### PR TITLE
[FEAT] #320 - 플러그인에서 토큰 만료여부 판단

### DIFF
--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		3903CC212769F4F40094C458 /* EmptyCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3903CC1F2769F4F40094C458 /* EmptyCardCell.xib */; };
 		390515B82706CEBB00C5F7A5 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 390515B72706CEBB00C5F7A5 /* Colors.xcassets */; };
 		3909242F26FA15E800236C51 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3909242E26FA15E800236C51 /* UIView+Extension.swift */; };
-		3918F66727719C4B00984648 /* UserTokenReissueRequset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3918F66627719C4B00984648 /* UserTokenReissueRequset.swift */; };
+		3918F66727719C4B00984648 /* UserReissueToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3918F66627719C4B00984648 /* UserReissueToken.swift */; };
 		3927A7D7275F2A9B008BCD2A /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3927A7D6275F2A9B008BCD2A /* UserDefaults.swift */; };
 		392BAF792793BAF80013DCB3 /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392BAF782793BAF80013DCB3 /* KeyChain.swift */; };
 		392BAF7B2793E90D0013DCB3 /* KeyChainKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392BAF7A2793E90D0013DCB3 /* KeyChainKey.swift */; };
@@ -157,7 +157,7 @@
 		390515B72706CEBB00C5F7A5 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		3909242E26FA15E800236C51 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		3918F6652771682F00984648 /* NADA-iOS-forRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "NADA-iOS-forRelease.entitlements"; sourceTree = "<group>"; };
-		3918F66627719C4B00984648 /* UserTokenReissueRequset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTokenReissueRequset.swift; sourceTree = "<group>"; };
+		3918F66627719C4B00984648 /* UserReissueToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserReissueToken.swift; sourceTree = "<group>"; };
 		3927A7D6275F2A9B008BCD2A /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		392BAF782793BAF80013DCB3 /* KeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChain.swift; sourceTree = "<group>"; };
 		392BAF7A2793E90D0013DCB3 /* KeyChainKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainKey.swift; sourceTree = "<group>"; };
@@ -471,7 +471,7 @@
 			children = (
 				39D13564273FDB9C00B1A148 /* User.swift */,
 				39D13567273FDCB800B1A148 /* UserWithTokenRequest.swift */,
-				3918F66627719C4B00984648 /* UserTokenReissueRequset.swift */,
+				3918F66627719C4B00984648 /* UserReissueToken.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -1180,7 +1180,7 @@
 				3981148E273BEBB300E28630 /* CardListEditRequest.swift in Sources */,
 				39D88B6B274600B100A72164 /* CommonBottomSheetViewController.swift in Sources */,
 				7734D5B627779EF0004360E4 /* QRCodeView.swift in Sources */,
-				3918F66727719C4B00984648 /* UserTokenReissueRequset.swift in Sources */,
+				3918F66727719C4B00984648 /* UserReissueToken.swift in Sources */,
 				7705CF3E2752C7DB005195DF /* CardView.swift in Sources */,
 				F8FC43BA26C022900033E151 /* ViewController.swift in Sources */,
 				39D13568273FDCB800B1A148 /* UserWithTokenRequest.swift in Sources */,

--- a/NADA-iOS-forRelease/Resouces/Constants/Const.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Const.swift
@@ -9,6 +9,5 @@ import Foundation
 
 struct Const {
     // TODO: - KeyChain 적용
-    static let headerToken: String = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? ""
     //    static var headerToken: String = KeyChain.read(key: Const.KeyChainKey.accessToken) ?? ""
 }

--- a/NADA-iOS-forRelease/Resouces/Constants/Header.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Header.swift
@@ -10,9 +10,22 @@ import Foundation
 extension Const {
     
     struct Header {
-        static var bearerHeader = ["Authorization": "Bearer " + headerToken]
+        static func applicationJsonHeader() -> [String: String] {
+            ["Content-Type": "application/json"]
+        }
         
-        static var basicHeader = ["Content-Type": "application/json",
-                                  "Authorization": "Bearer " + headerToken]
+        static func multipartFormHeader() -> [String: String] {
+            ["Content-Type": "application/json",
+             "Authorization": "Bearer \(UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? "")"]
+        }
+        
+        static func bearerHeader() -> [String: String] {
+            ["Authorization": "Bearer \(UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? "")"]
+        }
+        
+        static func basicHeader() -> [String: String] {
+            ["Content-Type": "application/json",
+             "Authorization": "Bearer \(UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? "")"]
+        }
     }
 }

--- a/NADA-iOS-forRelease/Resouces/Constants/URL.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/URL.swift
@@ -9,7 +9,8 @@ import Foundation
 
 extension Const {
     struct URL {
-        static let baseURL = "https://nada-server.o-r.kr"
+//        static let baseURL = "https://nada-server.o-r.kr"
+        static let baseURL = "http://3.34.197.90"
         static let policyURL = "https://nadaitzme.notion.site/NADA-8385054bc2e44762a62f590534b2a24d"
         static let serviceURL =  "https://nadaitzme.notion.site/NADA-58544bc9f0a1493c94f223cab3a440d0"
         static let moyaURL = "https://github.com/Moya/Moya"

--- a/NADA-iOS-forRelease/Sources/NetworkModel/NetworkResult.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/NetworkResult.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 enum NetworkResult<T> {
-  case success(T)                    // 서버 통신 성공
-  case requestErr(T)            // 요청 에러 발생
-  case pathErr                        // 경로 에러
-  case serverErr                    // 서버의 내부적 에러
-  case networkFail                // 네트워크 연결 실패
+    case success(T)                 // 서버 통신 성공
+    case requestErr(T)              // 요청 에러 발생
+    case pathErr                    // 경로 에러
+    case serverErr                  // 서버의 내부적 에러
+    case networkFail                // 네트워크 연결 실패
 }

--- a/NADA-iOS-forRelease/Sources/NetworkModel/User/UserReissueToken.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/User/UserReissueToken.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserTokenReissueRequset: Codable {
+struct UserReissueToken: Codable {
     var accessToken: String
     var refreshToken: String
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
@@ -111,10 +111,12 @@ extension CardService: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .cardDetailFetch, .cardListFetch, .cardDelete, .cardListEdit:
-            return Const.Header.basicHeader
+        case .cardDetailFetch, .cardListFetch, .cardDelete:
+            return Const.Header.bearerHeader()
+        case .cardListEdit:
+            return Const.Header.basicHeader()
         case .cardCreation:
-            return Const.Header.basicHeader
+            return Const.Header.multipartFormHeader()
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -95,12 +95,10 @@ extension GroupService: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .groupListFetch, .cardListFetchInGroup, .groupDelete, .cardDeleteInGroup:
-            return Const.Header.bearerHeader
+        case .groupListFetch, .cardListFetchInGroup, .groupReset, .groupDelete, .cardDeleteInGroup:
+            return Const.Header.bearerHeader()
         case .groupAdd, .groupEdit, .cardAddInGroup, .changeCardGroup:
-            return Const.Header.bearerHeader
-        case .groupReset:
-            return Const.Header.basicHeader
+            return Const.Header.basicHeader()
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
@@ -9,13 +9,6 @@ import Foundation
 import Moya
 
 final class MoyaLoggerPlugin: PluginType {
-    
-//    private let viewController: UIViewController
-    
-//    init(viewController: UIViewController) {
-//        self.viewController = viewController
-//    }
-
     // Request를 보낼 때 호출
     func willSend(_ request: RequestType, target: TargetType) {
         guard let httpRequest = request.request else {
@@ -100,10 +93,6 @@ extension MoyaLoggerPlugin {
                 }
             case .requestErr(let statusCode):
                 if let statusCode = statusCode as? Int, statusCode == 406 {
-                    print("유저 디폴트 삭제")
-                    print("로그인 뷰로 보내기")
-                    
-                    // root view controller 를 바꾸자
                     let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
                     UIApplication.shared.windows.first {$0.isKeyWindow}?.rootViewController = loginVC
                     

--- a/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
@@ -10,76 +10,81 @@ import Moya
 
 final class MoyaLoggerPlugin: PluginType {
     
-  // Request를 보낼 때 호출
-  func willSend(_ request: RequestType, target: TargetType) {
-    guard let httpRequest = request.request else {
-      print("--> 유효하지 않은 요청")
-      return
-    }
-    let url = httpRequest.description
-    let method = httpRequest.httpMethod ?? "unknown method"
-    var log = "----------------------------------------------------\n[\(method)] \(url)\n----------------------------------------------------\n"
-    log.append("API: \(target)\n")
-    if let headers = httpRequest.allHTTPHeaderFields, !headers.isEmpty {
-      log.append("header: \(headers)\n")
-    }
-    if let body = httpRequest.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
-      log.append("\(bodyString)\n")
-    }
-    log.append("------------------- END \(method) --------------------------")
-    print(log)
-  }
+//    private let viewController: UIViewController
     
-  // Response가 왔을 때
-  func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
-    switch result {
-    case let .success(response):
-      onSuceed(response, target: target, isFromError: false)
-    case let .failure(error):
-      onFail(error, target: target)
+//    init(viewController: UIViewController) {
+//        self.viewController = viewController
+//    }
+
+    // Request를 보낼 때 호출
+    func willSend(_ request: RequestType, target: TargetType) {
+        guard let httpRequest = request.request else {
+            print("--> 유효하지 않은 요청")
+            return
+        }
+        let url = httpRequest.description
+        let method = httpRequest.httpMethod ?? "unknown method"
+        var log = "----------------------------------------------------\n[\(method)] \(url)\n----------------------------------------------------\n"
+        log.append("API: \(target)\n")
+        if let headers = httpRequest.allHTTPHeaderFields, !headers.isEmpty {
+            log.append("header: \(headers)\n")
+        }
+        if let body = httpRequest.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
+            log.append("\(bodyString)\n")
+        }
+        log.append("------------------- END \(method) --------------------------")
+        print(log)
     }
-  }
     
-  func onSuceed(_ response: Response, target: TargetType, isFromError: Bool) {
-    let request = response.request
-    let url = request?.url?.absoluteString ?? "nil"
-    let statusCode = response.statusCode
-    var log = "------------------- 네트워크 통신 성공(isFromError: \(isFromError)) -------------------"
-      switch statusCode {
-      case 401:
-          log.append("메롱 401이지롱")
-          let acessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken)
-          let refreshToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.refreshToken)
-          userTokenReissueWithAPI(request: UserReissueToken(accessToken: acessToken ?? "",
-                                                                   refreshToken: refreshToken ?? ""))
-      default:
-          log.append("메롱 \(statusCode) \(statusCode)이지롱")
-      print(log)
-      
-    log.append("\n[\(statusCode)] \(url)\n----------------------------------------------------\n")
-    log.append("API: \(target)\n")
-    response.response?.allHeaderFields.forEach {
-      log.append("\($0): \($1)\n")
+    // Response가 왔을 때
+    func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
+        switch result {
+        case let .success(response):
+            onSuceed(response, target: target, isFromError: false)
+        case let .failure(error):
+            onFail(error, target: target)
+        }
     }
-    if let reString = String(bytes: response.data, encoding: String.Encoding.utf8) {
-      log.append("\(reString)\n")
-    }
-    log.append("------------------- END HTTP (\(response.data.count)-byte body) -------------------")
-    print(log)
-      }
-  }
     
-  func onFail(_ error: MoyaError, target: TargetType) {
-    if let response = error.response {
-      onSuceed(response, target: target, isFromError: true)
-      return
+    func onSuceed(_ response: Response, target: TargetType, isFromError: Bool) {
+        let request = response.request
+        let url = request?.url?.absoluteString ?? "nil"
+        let statusCode = response.statusCode
+        
+        var log = "------------------- 네트워크 통신 성공(isFromError: \(isFromError)) -------------------"
+        log.append("\n[\(statusCode)] \(url)\n----------------------------------------------------\n")
+        log.append("API: \(target)\n")
+        response.response?.allHeaderFields.forEach {
+            log.append("\($0): \($1)\n")
+        }
+        if let reString = String(bytes: response.data, encoding: String.Encoding.utf8) {
+            log.append("\(reString)\n")
+        }
+        log.append("------------------- END HTTP (\(response.data.count)-byte body) -------------------")
+        print(log)
+        
+        switch statusCode {
+        case 401:
+            let acessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken)
+            let refreshToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.refreshToken)
+            userTokenReissueWithAPI(request: UserReissueToken(accessToken: acessToken ?? "",
+                                                              refreshToken: refreshToken ?? ""))
+        default:
+            return
+        }
     }
-    var log = "네트워크 오류"
-    log.append("<-- \(error.errorCode) \(target)\n")
-    log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
-    log.append("<-- END HTTP")
-    print(log)
-  }
+    
+    func onFail(_ error: MoyaError, target: TargetType) {
+        if let response = error.response {
+            onSuceed(response, target: target, isFromError: true)
+            return
+        }
+        var log = "네트워크 오류"
+        log.append("<-- \(error.errorCode) \(target)\n")
+        log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
+        log.append("<-- END HTTP")
+        print(log)
+    }
 }
 
 extension MoyaLoggerPlugin {
@@ -94,11 +99,15 @@ extension MoyaLoggerPlugin {
                     print("userTokenReissueWithAPI - success")
                 }
             case .requestErr(let statusCode):
-                if let statusCode = statusCode as? Int, statusCode == 401 {
+                // FIXME: - 예원이가 상태코드 정해주면 변경
+                if let statusCode = statusCode as? Int, statusCode == 402 {
                     print("유저 디폴트 삭제")
                     print("로그인 뷰로 보내기")
+                    
                     // root view controller 를 바꾸자
-                    // changeRootViewController
+                    let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
+                    UIApplication.shared.windows.first {$0.isKeyWindow}?.rootViewController = loginVC
+                    
                     UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
                     UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
                     UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.userID)

--- a/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
@@ -99,8 +99,7 @@ extension MoyaLoggerPlugin {
                     print("userTokenReissueWithAPI - success")
                 }
             case .requestErr(let statusCode):
-                // FIXME: - 예원이가 상태코드 정해주면 변경
-                if let statusCode = statusCode as? Int, statusCode == 402 {
+                if let statusCode = statusCode as? Int, statusCode == 406 {
                     print("유저 디폴트 삭제")
                     print("로그인 뷰로 보내기")
                     

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserAPI.swift
@@ -62,7 +62,7 @@ public class UserAPI {
         }
     }
     
-    func userTokenReissue(request: UserTokenReissueRequset, completion: @escaping (NetworkResult<Any>) -> Void) {
+    func userTokenReissue(request: UserReissueToken, completion: @escaping (NetworkResult<Any>) -> Void) {
         userProvider.request(.userTokenReissue(request: request)) { (result) in
             switch result {
             case .success(let response):
@@ -101,7 +101,7 @@ public class UserAPI {
     private func judgeUserTokenReissueStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
         
         let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<UserWithTokenRequest>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<UserReissueToken>.self, from: data)
         else {
             return .pathErr
         }
@@ -110,7 +110,7 @@ public class UserAPI {
         case 200:
             return .success(decodedData.data ?? "None-Data")
         case 400..<500:
-            return .requestErr(decodedData.msg)
+            return .requestErr(statusCode)
         case 500:
             return .serverErr
         default:

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
@@ -61,9 +61,9 @@ extension UserSevice: TargetType {
     var headers: [String: String]? {
         switch self {
         case .userSocialSignUp, .userTokenReissue:
-            return ["Content-Type": "application/json"]
+            return Const.Header.applicationJsonHeader()
         case .userDelete, .userLogout:
-            return Const.Header.basicHeader
+            return Const.Header.bearerHeader()()
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
@@ -12,7 +12,7 @@ enum UserSevice {
     case userDelete(token: String)
     case userSocialSignUp(userID: String)
     case userLogout(token: String)
-    case userTokenReissue(request: UserTokenReissueRequset)
+    case userTokenReissue(request: UserReissueToken)
 }
 
 extension UserSevice: TargetType {

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
@@ -63,7 +63,7 @@ extension UserSevice: TargetType {
         case .userSocialSignUp, .userTokenReissue:
             return Const.Header.applicationJsonHeader()
         case .userDelete, .userLogout:
-            return Const.Header.bearerHeader()()
+            return Const.Header.bearerHeader()
         }
     }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Util/UtilService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Util/UtilService.swift
@@ -54,7 +54,7 @@ extension UtilService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .cardHarmonyFetch:
-            return Const.Header.bearerHeader
+            return Const.Header.bearerHeader()
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#320

🌱 작업한 내용
- 모야 플러그인을 통해서 onSuceed 메서드에서 401 error(액세스 토큰 만료) 일때 액세스 토큰을 갱신한다.
- 406 error(리프래쉬 토큰 만료) 일때 토큰 정보와 userID(홈 카드 리스트를 조회하는데 필요함)를 삭제하고, 로그인뷰로 보낸다.

## 📮 관련 이슈
- Resolved: #320 #252 
