### PR TITLE
add: any,dark/card 색상 추가 (#345)

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Assets/Colors.xcassets/card.colorset/Contents.json
+++ b/NADA-iOS-forRelease/Resouces/Assets/Colors.xcassets/card.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "249",
+          "green" : "247",
+          "red" : "246"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "45",
+          "green" : "40",
+          "red" : "36"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
+++ b/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
@@ -148,6 +148,20 @@ extension UIColor {
         }
     }
     
+    @nonobjc class var card: UIColor {
+        if #available(iOS 13, *) {
+            return UIColor { (traitCollection: UITraitCollection) -> UIColor in
+                if traitCollection.userInterfaceStyle == .light {
+                    return UIColor(red: 246.0 / 255.0, green: 247 / 255.0, blue: 249 / 255.0, alpha: 1.0)
+                } else {
+                    return UIColor(red: 36.0 / 255.0, green: 40 / 255.0, blue: 45 / 255.0, alpha: 1.0)
+                }
+            }
+        } else {
+            return UIColor(red: 246.0 / 255.0, green: 247 / 255.0, blue: 249 / 255.0, alpha: 1.0)
+        }
+    }
+    
     @nonobjc class var harmonyRed: UIColor {
       return UIColor(red: 239.0 / 255.0, green: 115.0 / 255.0, blue: 115.0 / 255.0, alpha: 1.0)
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#345

🌱 작업한 내용
- any,dark/card UIColor Extension 과 에셋 추가하였습니다. 
<img width="381" alt="스크린샷 2023-01-08 오후 8 06 13" src="https://user-images.githubusercontent.com/69136340/211192663-23cc9513-b169-4546-9063-eafc1bc6602e.png">

## 📮 관련 이슈
- Resolved: #345
