### PR TITLE
fix: 기본 명함 생성 뷰 수정 (#351)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -45,9 +45,10 @@ class FrontCardCreationCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var mbtiLabel: UILabel!
     @IBOutlet weak var mbtiView: UIView!
 
-    @IBOutlet weak var instagramIDTextField: UITextField!
-    @IBOutlet weak var linkURLTextField: UITextField!
     @IBOutlet weak var descriptionTextField: UITextField!
+    @IBOutlet weak var instagramIDTextField: UITextField!
+    @IBOutlet weak var phoneNumberTextField: UITextField!
+    @IBOutlet weak var linkURLTextField: UITextField!
     
     @IBOutlet weak var bgView: UIView!
     
@@ -131,6 +132,9 @@ extension FrontCardCreationCollectionViewCell {
         descriptionTextField.attributedPlaceholder = NSAttributedString(string: "동아리 기수 / 파트 (15자)", attributes: [
             NSAttributedString.Key.foregroundColor: UIColor.quaternary
         ])
+        phoneNumberTextField.attributedPlaceholder = NSAttributedString(string: "전화번호", attributes: [
+        NSAttributedString.Key.foregroundColor: UIColor.quaternary
+        ])
         
         _ = requiredTextFieldList.map {
             $0.font = .textRegular04
@@ -164,7 +168,8 @@ extension FrontCardCreationCollectionViewCell {
         optionalTextFieldList.append(contentsOf: [
             instagramIDTextField,
             linkURLTextField,
-            descriptionTextField
+            descriptionTextField,
+            phoneNumberTextField
         ])
     }
     private func registerCell() {
@@ -208,7 +213,8 @@ extension FrontCardCreationCollectionViewCell {
             ], withOptional: [
                 "instagram": instagramIDTextField.text ?? "",
                 "linkURL": linkURLTextField.text ?? "",
-                "description": descriptionTextField.text ?? ""
+                "description": descriptionTextField.text ?? "",
+                "phoneNumber": phoneNumberTextField.text ?? ""
             ])
         }
     }
@@ -268,6 +274,14 @@ extension FrontCardCreationCollectionViewCell {
                         let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
                         let newString = String(text[text.startIndex..<maxIndex])
                         descriptionTextField.text = newString
+                    }
+                }
+            case phoneNumberTextField:
+                if let text = phoneNumberTextField.text {
+                    if text.count > maxLength {
+                        let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
+                        let newString = String(text[text.startIndex..<maxIndex])
+                        phoneNumberTextField.text = newString
                     }
                 }
             default:

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -115,7 +115,7 @@ extension FrontCardCreationCollectionViewCell {
         birthView.backgroundColor = .textBox
         birthLabel.font = .textRegular04
         birthLabel.textColor = .quaternary
-        birthLabel.text = "생년월일"
+        birthLabel.text = "생일"
         
         mbtiView.layer.cornerRadius = 10
         mbtiView.backgroundColor = .textBox

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -129,7 +129,7 @@ extension FrontCardCreationCollectionViewCell {
         linkURLTextField.attributedPlaceholder = NSAttributedString(string: "URL (Github, Blog 등)", attributes: [
             NSAttributedString.Key.foregroundColor: UIColor.quaternary
         ])
-        descriptionTextField.attributedPlaceholder = NSAttributedString(string: "동아리 기수 / 파트 (15자)", attributes: [
+        descriptionTextField.attributedPlaceholder = NSAttributedString(string: "학교 전공/동아리 기수 등 (15자)", attributes: [
             NSAttributedString.Key.foregroundColor: UIColor.quaternary
         ])
         phoneNumberTextField.attributedPlaceholder = NSAttributedString(string: "전화번호", attributes: [

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -204,18 +204,15 @@ extension FrontCardCreationCollectionViewCell {
             frontCardCreationDelegate?.frontCardCreation(requiredInfo: false)
         }
         if let defaultImageIndex = defaultImageIndex {
-            frontCardCreationDelegate?.frontCardCreation(withRequired: [
-                "defaultImageIndex": String(defaultImageIndex),
-                "title": cardTitleTextField.text ?? "",
-                "name": userNameTextField.text ?? "",
-                "birthDate": birthLabel.text ?? "",
-                "mbti": mbtiLabel.text ?? ""
-            ], withOptional: [
-                "instagram": instagramIDTextField.text ?? "",
-                "linkURL": linkURLTextField.text ?? "",
-                "description": descriptionTextField.text ?? "",
-                "phoneNumber": phoneNumberTextField.text ?? ""
-            ])
+            frontCardCreationDelegate?.frontCardCreation(with: FrontCardDataModel(defaultImage: defaultImageIndex,
+                                                                                 title: cardTitleTextField.text ?? "",
+                                                                                 name: userNameTextField.text ?? "",
+                                                                                 birthDate: birthLabel.text ?? "",
+                                                                                 mbti: mbtiLabel.text ?? "",
+                                                                                 instagramID: instagramIDTextField.text ?? "",
+                                                                                 linkURL: linkURLTextField.text ?? "",
+                                                                                 description: descriptionTextField.text ?? "",
+                                                                                 phoneNumber: phoneNumberTextField.text ?? ""))
         }
     }
     static func nib() -> UINib {

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,17 +12,17 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="FrontCardCreationCollectionViewCell" customModule="NADA_iOS_forRelease" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="353" height="678"/>
+            <rect key="frame" x="0.0" y="0.0" width="353" height="711"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="353" height="678"/>
+                <rect key="frame" x="0.0" y="0.0" width="353" height="711"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EMJ-HM-pPN">
-                        <rect key="frame" x="0.0" y="0.0" width="353" height="678"/>
+                        <rect key="frame" x="0.0" y="0.0" width="353" height="711"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rtM-7c-eeD">
-                                <rect key="frame" x="0.0" y="0.0" width="353" height="660"/>
+                                <rect key="frame" x="0.0" y="0.0" width="353" height="714"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ij6-4i-oGx">
                                         <rect key="frame" x="24" y="23" width="42" height="21"/>
@@ -133,15 +133,24 @@
                                             <constraint firstItem="xuR-Ne-hLd" firstAttribute="centerY" secondItem="XZy-Ne-utd" secondAttribute="centerY" id="dJ3-gW-4i6"/>
                                         </constraints>
                                     </view>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Pi-Bo-aPf">
+                                        <rect key="frame" x="24" y="656" width="305" height="44"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="T0U-dk-NHX"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="hYQ-8Z-Bod" firstAttribute="top" secondItem="Ki8-qn-Bo1" secondAttribute="bottom" constant="30" id="0rN-Ck-PwW"/>
                                     <constraint firstItem="d1H-pL-FAS" firstAttribute="top" secondItem="hYQ-8Z-Bod" secondAttribute="bottom" constant="10" id="2uL-Wi-fyP"/>
-                                    <constraint firstAttribute="bottom" secondItem="mxK-gN-Nz2" secondAttribute="bottom" constant="14" id="4Dp-gY-Uak"/>
                                     <constraint firstItem="bnb-dB-y9j" firstAttribute="top" secondItem="VfE-eb-mbT" secondAttribute="bottom" constant="10" id="9EU-Px-08f"/>
                                     <constraint firstItem="ZK4-3D-SM0" firstAttribute="top" secondItem="ldM-3t-32q" secondAttribute="bottom" constant="10" id="9pH-EC-W5x"/>
                                     <constraint firstAttribute="trailing" secondItem="d1H-pL-FAS" secondAttribute="trailing" constant="24" id="BFd-eV-ue0"/>
+                                    <constraint firstItem="8Pi-Bo-aPf" firstAttribute="trailing" secondItem="mxK-gN-Nz2" secondAttribute="trailing" id="BHr-1F-lwd"/>
+                                    <constraint firstItem="8Pi-Bo-aPf" firstAttribute="top" secondItem="mxK-gN-Nz2" secondAttribute="bottom" constant="10" id="ERv-8k-oOm"/>
                                     <constraint firstItem="Ij6-4i-oGx" firstAttribute="top" secondItem="rtM-7c-eeD" secondAttribute="top" constant="23" id="Iog-P0-VBi"/>
                                     <constraint firstItem="l0G-Oe-aZm" firstAttribute="leading" secondItem="hYQ-8Z-Bod" secondAttribute="leading" id="KAR-CA-812"/>
                                     <constraint firstItem="VfE-eb-mbT" firstAttribute="trailing" secondItem="d1H-pL-FAS" secondAttribute="trailing" id="KUY-9m-Aqe"/>
@@ -151,6 +160,7 @@
                                     <constraint firstAttribute="trailing" secondItem="Ki8-qn-Bo1" secondAttribute="trailing" id="NV0-oS-82P"/>
                                     <constraint firstItem="l0G-Oe-aZm" firstAttribute="top" secondItem="d1H-pL-FAS" secondAttribute="bottom" constant="30" id="NnQ-Hr-KPD"/>
                                     <constraint firstItem="bnb-dB-y9j" firstAttribute="trailing" secondItem="VfE-eb-mbT" secondAttribute="trailing" id="TDV-as-jo2"/>
+                                    <constraint firstItem="8Pi-Bo-aPf" firstAttribute="leading" secondItem="mxK-gN-Nz2" secondAttribute="leading" id="WcV-jq-vbK"/>
                                     <constraint firstItem="VfE-eb-mbT" firstAttribute="top" secondItem="l0G-Oe-aZm" secondAttribute="bottom" constant="10" id="Wm7-Xp-BAw"/>
                                     <constraint firstItem="XZy-Ne-utd" firstAttribute="leading" secondItem="VfE-eb-mbT" secondAttribute="leading" id="ZtX-yr-VQj"/>
                                     <constraint firstItem="VfE-eb-mbT" firstAttribute="leading" secondItem="d1H-pL-FAS" secondAttribute="leading" id="bXt-8y-Bv4"/>
@@ -168,6 +178,7 @@
                                     <constraint firstItem="ZK4-3D-SM0" firstAttribute="trailing" secondItem="ldM-3t-32q" secondAttribute="trailing" id="s06-4b-wVs"/>
                                     <constraint firstItem="FC8-TR-MGL" firstAttribute="leading" secondItem="hYQ-8Z-Bod" secondAttribute="leading" id="uFU-Z7-VnJ"/>
                                     <constraint firstItem="XZy-Ne-utd" firstAttribute="top" secondItem="bnb-dB-y9j" secondAttribute="bottom" constant="10" id="unY-Qm-9bx"/>
+                                    <constraint firstAttribute="bottom" secondItem="8Pi-Bo-aPf" secondAttribute="bottom" constant="14" id="vY2-mH-fje"/>
                                     <constraint firstItem="FC8-TR-MGL" firstAttribute="top" secondItem="XZy-Ne-utd" secondAttribute="bottom" constant="30" id="vqH-bf-2fK"/>
                                     <constraint firstItem="ZK4-3D-SM0" firstAttribute="leading" secondItem="ldM-3t-32q" secondAttribute="leading" id="wHb-zY-tv5"/>
                                     <constraint firstItem="mxK-gN-Nz2" firstAttribute="top" secondItem="ZK4-3D-SM0" secondAttribute="bottom" constant="10" id="zxl-yQ-SlX"/>
@@ -192,7 +203,7 @@
                 <constraint firstAttribute="trailing" secondItem="EMJ-HM-pPN" secondAttribute="trailing" id="XhP-5c-TFW"/>
                 <constraint firstItem="EMJ-HM-pPN" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="YLS-ch-6UP"/>
             </constraints>
-            <size key="customSize" width="353" height="678"/>
+            <size key="customSize" width="353" height="711"/>
             <connections>
                 <outlet property="backgroundSettingCollectionView" destination="Ki8-qn-Bo1" id="ztC-tg-hsZ"/>
                 <outlet property="bgView" destination="rtM-7c-eeD" id="z4A-CV-rwk"/>
@@ -200,18 +211,19 @@
                 <outlet property="birthView" destination="bnb-dB-y9j" id="cdd-wn-YbP"/>
                 <outlet property="cardTitleInfoTextLabel" destination="hYQ-8Z-Bod" id="fpo-bj-GPa"/>
                 <outlet property="cardTitleTextField" destination="d1H-pL-FAS" id="bO6-Y8-SBy"/>
-                <outlet property="descriptionTextField" destination="mxK-gN-Nz2" id="dBV-rM-2Gz"/>
-                <outlet property="instagramIDTextField" destination="ldM-3t-32q" id="QNp-NA-Xir"/>
-                <outlet property="linkURLTextField" destination="ZK4-3D-SM0" id="LTF-ja-WmF"/>
+                <outlet property="descriptionTextField" destination="ldM-3t-32q" id="hsk-sg-fvq"/>
+                <outlet property="instagramIDTextField" destination="ZK4-3D-SM0" id="yjI-cq-xWr"/>
+                <outlet property="linkURLTextField" destination="8Pi-Bo-aPf" id="aQL-Hd-HyX"/>
                 <outlet property="mbtiLabel" destination="xuR-Ne-hLd" id="lw4-FA-En4"/>
                 <outlet property="mbtiView" destination="XZy-Ne-utd" id="KTF-cd-oSt"/>
                 <outlet property="optionalInfoTextLabel" destination="FC8-TR-MGL" id="RnF-6K-xml"/>
+                <outlet property="phoneNumberTextField" destination="mxK-gN-Nz2" id="NGX-My-GCa"/>
                 <outlet property="requiredInfoTextLabel" destination="l0G-Oe-aZm" id="7Nt-UG-Ag5"/>
                 <outlet property="scrollView" destination="EMJ-HM-pPN" id="ftT-Ax-WnF"/>
                 <outlet property="setBackgroundTextLabel" destination="Ij6-4i-oGx" id="zfm-hA-GzT"/>
                 <outlet property="userNameTextField" destination="VfE-eb-mbT" id="3lH-L0-Ibv"/>
             </connections>
-            <point key="canvasLocation" x="268.84057971014494" y="180.80357142857142"/>
+            <point key="canvasLocation" x="268.84057971014494" y="191.85267857142856"/>
         </collectionViewCell>
     </objects>
     <resources>

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Card/CardCreationRequest.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Card/CardCreationRequest.swift
@@ -19,7 +19,7 @@ struct CardCreationRequest: Codable {
 struct FrontCardDataModel: Codable {
     let defaultImage: Int
     let title, name, birthDate, mbti: String
-    let instagramID, linkURL, description: String
+    let instagramID, linkURL, description, phoneNumber: String
 }
     
 // MARK: - BackCard

--- a/NADA-iOS-forRelease/Sources/Protocols/CardCreation/FrontCardCreationDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/Protocols/CardCreation/FrontCardCreationDelegate.swift
@@ -10,5 +10,5 @@ import Foundation
 protocol FrontCardCreationDelegate: AnyObject {
     func frontCardCreation(requiredInfo valid: Bool)
     func frontCardCreation(endEditing valid: Bool)
-    func frontCardCreation(withRequired requiredInfo: [String: String], withOptional optionalInfo: [String: String] )
+    func frontCardCreation(with frontCardDataModel: FrontCardDataModel)
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
@@ -327,7 +327,8 @@ extension CardCreationViewController: FrontCardCreationDelegate {
                                        mbti: requiredInfo["mbti"] ?? "",
                                        instagramID: optionalInfo["instagram"] ?? "",
                                        linkURL: optionalInfo["linkURL"] ?? "",
-                                       description: optionalInfo["description"] ?? "")
+                                       description: optionalInfo["description"] ?? "",
+                                       phoneNumber: optionalInfo["phoneNumber"] ?? "")
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/CardCreationViewController.swift
@@ -145,7 +145,6 @@ extension CardCreationViewController {
             }
             completeButton.configurationUpdateHandler = configHandler
         } else {
-            // TODO: - QA/iOS 13 테스트. selected 설정.
             completeButton.layer.cornerRadius = 15
             
             completeButton.setTitle("완료", for: .normal)
@@ -319,16 +318,8 @@ extension CardCreationViewController: FrontCardCreationDelegate {
     func frontCardCreation(endEditing valid: Bool) {
         isEditingMode = valid
     }
-    func frontCardCreation(withRequired requiredInfo: [String: String], withOptional optionalInfo: [String: String]) {
-        frontCard = FrontCardDataModel(defaultImage: Int(requiredInfo["defaultImageIndex"] ?? "-1") ?? -1,
-                                       title: requiredInfo["title"] ?? "",
-                                       name: requiredInfo["name"] ?? "",
-                                       birthDate: requiredInfo["birthDate"] ?? "",
-                                       mbti: requiredInfo["mbti"] ?? "",
-                                       instagramID: optionalInfo["instagram"] ?? "",
-                                       linkURL: optionalInfo["linkURL"] ?? "",
-                                       description: optionalInfo["description"] ?? "",
-                                       phoneNumber: optionalInfo["phoneNumber"] ?? "")
+    func frontCardCreation(with frontCardDataModel: FrontCardDataModel) {
+        frontCard = frontCardDataModel
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #351

🌱 작업한 내용
- 기본 명함 생성 뷰 수정하였습니다.
- FrontCardCreationDelegate 에서 앞면 정보를 전달할 때 딕셔너리로 전달하고 있었습니다. 이를 리펙토링하였습니다.
    - 이를 데이터모델로 처리하여 나중에 항목을 추가할 때 빠뜨리지 않을 수 있게 하였습니다.
    - 그대로 정보를 전달하는데 딕셔너리 -> 데이터모델로 전달할 필요가 없다고 판단하였습니다. 그래서 데이터모델을 전달하였습니다.

### 🚨참고사항
- 기존에 사용하고 있는 셀은 기본 명함으로 사용하고, 덕질/직장 명함 생성뷰(앞면)은 새롭게 만들어서 사용하면 되겠습니다.
- UI 가 종류별로 달라서 세개의 뷰를 만드는 것이 좋겠다고 판단했습니다.
- 서버에서 종류는 달라도 동일한 데이터 모델을 사용하기로 하였기 때문에 추후에 다시 수정은 해야겠지만, 기본 명함 생성 뷰에서 정상작동하도록 구현해두었습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기본 명함생성 뷰|<img src="https://user-images.githubusercontent.com/69136340/215450320-29b71c48-6a3e-40c8-af92-9b087ff00978.png" width ="250">|

## 📮 관련 이슈
- Resolved: #351
