### PR TITLE
fix: 기본 명함 URL 라벨 최대 줄수 변경 (#358)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -75,8 +75,10 @@ extension FrontCardCell {
         phoneNumberLabel.lineBreakMode = .byTruncatingTail
         linkURLLabel.font = .textRegular04
         linkURLLabel.textColor = .white
-        linkURLLabel.numberOfLines = 1
+        linkURLLabel.numberOfLines = 2
         linkURLLabel.lineBreakMode = .byTruncatingTail
+        
+        linkURLStackView.alignment = .center
     }
     private func setTapGesture() {
         instagramIDLabel.isUserInteractionEnabled = true


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #358

🌱 작업한 내용
- 이전에는 쌓여서 타이밍을 못잡았는뎅 지금부터 작업은 fork 한 프로젝트에서 진행하겠습니당!
- URL 라벨의 최대 줄수를 변경하였습니다. 기존에는 1이었는데 2로변경.
- 2로 변경되면서 center 를 기준으로 stackview 를 설정했습니다.
    - 현재 horizontal stackview(이미지+라벨) 세개를 vertical stackview 에 넣은 구조입니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|미리보기|<img src="https://user-images.githubusercontent.com/69136340/215768461-27ebcfcc-3c1d-492a-b4f4-5ffc4793448d.png" width ="250">|

## 📮 관련 이슈
- Resolved: #358
