### PR TITLE
fix: 명함 순서 변경 시 CardReorderInfo 수정 (#402)

### DIFF
--- a/NADA-iOS-forRelease/Sources/NetworkModel/Card/CardReorderInfo.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Card/CardReorderInfo.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - CardReorderInfo
 struct CardReorderInfo: Codable {
-    let cardID: String
+    let cardID: Int
     let isRepresentative: Bool
     let sortOrder: Int
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #402

🌱 작업한 내용
- CardReorderInfo 의 CardID 를 Int 로 변경.

## 📮 관련 이슈
- Resolved: #402 
