### PR TITLE
feat: 업데이트 팝업 뷰 서버통신 통해 비강제, 강제 업데이트를 구현 (#397)

### DIFF
--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2566DBA723D1370275ECE593 /* Pods_NADA_iOS_forRelease.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D86FBA2B7966CFE6EEF0E7E8 /* Pods_NADA_iOS_forRelease.framework */; };
 		39007F2C27080D8200E7143E /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39007F2B27080D8200E7143E /* UIViewController+Extension.swift */; };
 		3903CC202769F4F40094C458 /* EmptyCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3903CC1E2769F4F40094C458 /* EmptyCardCell.swift */; };
 		3903CC212769F4F40094C458 /* EmptyCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3903CC1F2769F4F40094C458 /* EmptyCardCell.xib */; };
@@ -106,7 +107,6 @@
 		77F2C0EB27632A91007641E3 /* CardHarmonyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F2C0EA27632A91007641E3 /* CardHarmonyViewController.swift */; };
 		77F2C0ED27632AA7007641E3 /* CardHarmony.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 77F2C0EC27632AA7007641E3 /* CardHarmony.storyboard */; };
 		77F47D93276C79B600414659 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F47D92276C79B600414659 /* Header.swift */; };
-		DBBB91E1639641F40C5B4416 /* Pods_NADA_iOS_forRelease.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A2183AE0E469153221624A0 /* Pods_NADA_iOS_forRelease.framework */; };
 		F805588529C993E7002E8EA3 /* UpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F805588429C993E7002E8EA3 /* UpdateViewController.swift */; };
 		F80975E92990A27400075B93 /* Widgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = F838B66A298E5C5300D84340 /* Widgets.intentdefinition */; };
 		F80975EA2990A27900075B93 /* Widgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = F838B66A298E5C5300D84340 /* Widgets.intentdefinition */; };
@@ -239,7 +239,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1E770167DDA25A2CE063AA5C /* Pods-NADA-iOS-forRelease.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NADA-iOS-forRelease.release.xcconfig"; path = "Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease.release.xcconfig"; sourceTree = "<group>"; };
+		00BC6C525F13C9651D73976F /* Pods-NADA-iOS-forRelease.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NADA-iOS-forRelease.debug.xcconfig"; path = "Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease.debug.xcconfig"; sourceTree = "<group>"; };
 		39007F2B27080D8200E7143E /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		3903CC1E2769F4F40094C458 /* EmptyCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCardCell.swift; sourceTree = "<group>"; };
 		3903CC1F2769F4F40094C458 /* EmptyCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptyCardCell.xib; sourceTree = "<group>"; };
@@ -300,8 +300,6 @@
 		39D88B6A274600B100A72164 /* CommonBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonBottomSheetViewController.swift; sourceTree = "<group>"; };
 		39F5A3CE271461EA00191F94 /* BackCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackCardCell.swift; sourceTree = "<group>"; };
 		39F5A3CF271461EA00191F94 /* BackCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BackCardCell.xib; sourceTree = "<group>"; };
-		3C14FF1DC641D872C3FDD637 /* Pods-NADA-iOS-forRelease.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NADA-iOS-forRelease.beta.xcconfig"; path = "Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease.beta.xcconfig"; sourceTree = "<group>"; };
-		4A2183AE0E469153221624A0 /* Pods_NADA_iOS_forRelease.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NADA_iOS_forRelease.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7705CF3D2752C7DB005195DF /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		7705CF3F2752C844005195DF /* CardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CardView.xib; sourceTree = "<group>"; };
 		770E58852778A78900498C2E /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
@@ -345,7 +343,8 @@
 		77F2C0EA27632A91007641E3 /* CardHarmonyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardHarmonyViewController.swift; sourceTree = "<group>"; };
 		77F2C0EC27632AA7007641E3 /* CardHarmony.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CardHarmony.storyboard; sourceTree = "<group>"; };
 		77F47D92276C79B600414659 /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
-		7F4EE1D042EC783FA8528743 /* Pods-NADA-iOS-forRelease.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NADA-iOS-forRelease.debug.xcconfig"; path = "Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease.debug.xcconfig"; sourceTree = "<group>"; };
+		78FC1ADEA3CAB995C08D47DB /* Pods-NADA-iOS-forRelease.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NADA-iOS-forRelease.release.xcconfig"; path = "Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease.release.xcconfig"; sourceTree = "<group>"; };
+		D86FBA2B7966CFE6EEF0E7E8 /* Pods_NADA_iOS_forRelease.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NADA_iOS_forRelease.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F805588429C993E7002E8EA3 /* UpdateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateViewController.swift; sourceTree = "<group>"; };
 		F81171FF27383097002742CF /* ChangeGroupRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeGroupRequest.swift; sourceTree = "<group>"; };
 		F822E7A82709CEB60020452C /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
@@ -467,7 +466,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DBBB91E1639641F40C5B4416 /* Pods_NADA_iOS_forRelease.framework in Frameworks */,
+				2566DBA723D1370275ECE593 /* Pods_NADA_iOS_forRelease.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -477,9 +476,8 @@
 		186051B2C99DBAECC539DAC9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				7F4EE1D042EC783FA8528743 /* Pods-NADA-iOS-forRelease.debug.xcconfig */,
-				1E770167DDA25A2CE063AA5C /* Pods-NADA-iOS-forRelease.release.xcconfig */,
-				3C14FF1DC641D872C3FDD637 /* Pods-NADA-iOS-forRelease.beta.xcconfig */,
+				00BC6C525F13C9651D73976F /* Pods-NADA-iOS-forRelease.debug.xcconfig */,
+				78FC1ADEA3CAB995C08D47DB /* Pods-NADA-iOS-forRelease.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -700,11 +698,11 @@
 		4D28D444572353D68574D2B0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				4A2183AE0E469153221624A0 /* Pods_NADA_iOS_forRelease.framework */,
 				F838B65F298E5C5300D84340 /* WidgetKit.framework */,
 				F838B661298E5C5300D84340 /* SwiftUI.framework */,
 				F87D2229298ECAFB001A882B /* Intents.framework */,
 				F87D2234298ECAFB001A882B /* IntentsUI.framework */,
+				D86FBA2B7966CFE6EEF0E7E8 /* Pods_NADA_iOS_forRelease.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1430,13 +1428,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F8FC439626C01CDE0033E151 /* Build configuration list for PBXNativeTarget "NADA-iOS-forRelease" */;
 			buildPhases = (
-				651C07EF2315142A685BB6AA /* [CP] Check Pods Manifest.lock */,
+				63B126249E7D65994A592714 /* [CP] Check Pods Manifest.lock */,
 				F8FC437E26C01CDD0033E151 /* Sources */,
 				F8FC437F26C01CDD0033E151 /* Frameworks */,
 				F8FC438026C01CDD0033E151 /* Resources */,
-				AF97E239CC02D3189BC80412 /* [CP] Embed Pods Frameworks */,
 				F8FC43BD26C0244D0033E151 /* ShellScript */,
 				F838B673298E5C5400D84340 /* Embed Foundation Extensions */,
+				2FD8F2B3BF35A3CA09A8E81C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1574,7 +1572,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		651C07EF2315142A685BB6AA /* [CP] Check Pods Manifest.lock */ = {
+		2FD8F2B3BF35A3CA09A8E81C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		63B126249E7D65994A592714 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1594,23 +1609,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AF97E239CC02D3189BC80412 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8FC43BD26C0244D0033E151 /* ShellScript */ = {
@@ -1693,7 +1691,6 @@
 				F8F00C4129DD48A000A15377 /* UpdateService.swift in Sources */,
 				F8D92E0A29D5324E002ACC73 /* Taste.swift in Sources */,
 				F85711A5274A6B2200F59F0B /* CardCreationPreviewViewController.swift in Sources */,
-				39DC069A2778BEFB00C8ECCC /* CardListLookUp.swift in Sources */,
 				77A4D60829BD74BC00367B7C /* getClassName.swift in Sources */,
 				777FF89B27359B7800BF69D3 /* Groups.swift in Sources */,
 				77F47D93276C79B600414659 /* Header.swift in Sources */,

--- a/NADA-iOS-forRelease/Sources/Factory/ModuleFactory.swift
+++ b/NADA-iOS-forRelease/Sources/Factory/ModuleFactory.swift
@@ -41,4 +41,10 @@ final class ModuleFactory: ModuleFactoryProtocol {
         aroundMeVC.modalPresentationStyle = .overFullScreen
         return aroundMeVC
     }
+    
+    func makeUpdateVC() -> UpdateViewController {
+        let updateVC = UpdateViewController()
+        updateVC.modalPresentationStyle = .overFullScreen
+        return updateVC
+    }
 }

--- a/NADA-iOS-forRelease/Sources/Factory/ModuleFactory.swift
+++ b/NADA-iOS-forRelease/Sources/Factory/ModuleFactory.swift
@@ -45,6 +45,7 @@ final class ModuleFactory: ModuleFactoryProtocol {
     func makeUpdateVC() -> UpdateViewController {
         let updateVC = UpdateViewController()
         updateVC.modalPresentationStyle = .overFullScreen
+        updateVC.modalTransitionStyle = .crossDissolve
         return updateVC
     }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Update/UpdateNote.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Update/UpdateNote.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct UpdateNote: Codable {
     let text: String
-    let isForce: String
+    let isForce: Bool
     let latestVersion: String
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Update/UpdateService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Update/UpdateService.swift
@@ -26,9 +26,9 @@ extension UpdateService: TargetType {
     var path: String {
         switch self {
         case .updateUserInfoFetch:
-            return "/app/update/note"
-        case .updateNoteFetch:
             return "/app/update"
+        case .updateNoteFetch:
+            return "/app/update/note"
         }
     }
     
@@ -46,7 +46,7 @@ extension UpdateService: TargetType {
         }
     }
     
-    var headers: [String : String]? {
+    var headers: [String: String]? {
         switch self {
         case .updateUserInfoFetch, .updateNoteFetch:
             return Const.Header.bearerHeader()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -155,3 +155,44 @@ extension HomeViewController {
             }.disposed(by: self.disposeBag)
     }
 }
+
+// MARK: - Network
+extension HomeViewController {
+    func updateUserInfoFetchWithAPI(completion: @escaping (Bool) -> Void) {
+        UpdateAPI.shared.updateUserInfoFetch { response in
+            switch response {
+            case .success(let data):
+                guard let updateUserInfo = data as? UpdateUserInfo else { return }
+                completion(updateUserInfo.forceUpdateAgreement)
+                print("getUpdateNoteFetchWithAPI - success")
+            case .requestErr(let message):
+                print("getUpdateUserInfoFetchWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("getUpdateUserInfoFetchWithAPI - pathErr")
+            case .serverErr:
+                print("getUpdateUserInfoFetchWithAPI - serverErr")
+            case .networkFail:
+                print("getUpdateUserInfoFetchWithAPI - networkFail")
+            }
+        }
+    }
+    func updateNoteFetchWithAPI(completion: @escaping (UpdateNote) -> Void) {
+        UpdateAPI.shared.updateNoteFetch { response in
+            switch response {
+            case .success(let data):
+                guard let updateNote = data as? UpdateNote else { return }
+                completion(updateNote)
+                print("getUpdateNoteFetchWithAPI - success")
+            case .requestErr(let message):
+                print("getUpdateNoteFetchWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("getUpdateNoteFetchWithAPI - pathErr")
+            case .serverErr:
+                print("getUpdateNoteFetchWithAPI - serverErr")
+            case .networkFail:
+                print("getUpdateNoteFetchWithAPI - networkFail")
+            }
+            
+        }
+    }
+}

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -63,8 +63,8 @@ final class HomeViewController: UIViewController {
         setUI()
         setLayout()
         bindActions()
+        checkUpdateVersion()
     }
-
 }
 
 extension HomeViewController {
@@ -168,6 +168,24 @@ extension HomeViewController {
         } else {
             return currentVersionArray[1] < appStoreVersionArray[1] ? true : false
         }
+    }
+    
+    private func checkUpdateVersion() {
+        updateUserInfoFetchWithAPI { [weak self] forceUpdateAgreement in
+            if !forceUpdateAgreement {
+                self?.updateNoteFetchWithAPI { [weak self] updateNote in
+                    if self?.checkUpdateAvailable(updateNote.latestVersion) ?? false {
+                        self?.presentToUpdateVC(with: updateNote)
+                    }
+                }
+            }
+        }
+    }
+
+    private func presentToUpdateVC(with updateNote: UpdateNote?) {
+        let updateVC = ModuleFactory.shared.makeUpdateVC()
+        updateVC.updateNote = updateNote
+        self.present(updateVC, animated: true)
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -154,6 +154,21 @@ extension HomeViewController {
                 owner.present(aroundMeVC, animated: true)
             }.disposed(by: self.disposeBag)
     }
+    
+    private func checkUpdateAvailable(_ latestVersion: String) -> Bool {
+        var latestVersion = latestVersion
+        latestVersion.removeFirst()
+        
+        guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return false }
+        let currentVersionArray = currentVersion.split(separator: ".").map { $0 }
+        let appStoreVersionArray = latestVersion.split(separator: ".").map { $0 }
+        
+        if currentVersionArray[0] < appStoreVersionArray[0] {
+            return true
+        } else {
+            return currentVersionArray[1] < appStoreVersionArray[1] ? true : false
+        }
+    }
 }
 
 // MARK: - Network

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -118,7 +118,6 @@ extension UpdateViewController {
     
     @objc
     private func touchCheckBox(_ sender: UIButton) {
-        // TODO: - 체크하게 되면 다시 띄어주지 않음
         checkBoxButton.isSelected.toggle()
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -114,6 +114,7 @@ extension UpdateViewController {
     @objc
     private func touchCheckBox(_ sender: UIButton) {
         checkBoxButton.isSelected.toggle()
+        forceUpdateAgreement.toggle()
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -22,6 +22,9 @@ class UpdateViewController: UIViewController {
     private let checkLabel = UILabel()
     private let updateButton = UIButton()
     
+    var updateNote: UpdateNote?
+    var forceUpdateAgreement: Bool = false
+    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -89,7 +89,16 @@ extension UpdateViewController {
     
     @objc
     private func touchCancelButton() {
-        // TODO: - 비강제 업데이트는 창 닫기. 강제 업데이트는 앱 종료.
+        guard let updateNote else { return }
+        if updateNote.isForce {
+            UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                exit(0)
+            }
+        } else {
+            // TODO: - 확인했어요 API 통신
+            self.dismiss(animated: true)
+        }
     }
     
     @objc

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -60,17 +60,9 @@ extension UpdateViewController {
         updateContentLabel.font = .textRegular04
         updateContentLabel.textColor = .secondary
         updateContentLabel.lineBreakMode = .byCharWrapping
-        updateContentLabel.text = """
-                                안녕하세요, 나다입니다.
-                                이번 업데이트에서는 아래와 같은 내용이 개선되었습니다.
-                                안녕하세융
-                                나다에요
-                                -명함을 위젯으로 추가할 수 있어요
-                                -내 주변의 명함을 검색할 수 있어요
-                                ㅇㅇㅇ
-                                앱스토어에서 최신 버전을 확인해 보세요!
-                                이정도면 10줄!
-                                """
+        var updateText = updateNote?.text.replacingOccurrences(of: "\\n", with: "\n")
+        updateText = updateText?.replacingOccurrences(of: "\\t", with: " ")
+        updateContentLabel.text = updateText
         
         checkBoxButton.setImage(UIImage(named: "icnCheckboxUnfilled"), for: .normal)
         checkBoxButton.setImage(UIImage(named: "icnCheckboxFilled"), for: .selected)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -22,8 +22,9 @@ class UpdateViewController: UIViewController {
     private let checkLabel = UILabel()
     private let updateButton = UIButton()
     
+    private lazy var forceUpdateAgreement: Bool = false
+    
     var updateNote: UpdateNote?
-    var forceUpdateAgreement: Bool = false
     
     // MARK: - View Life Cycle
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -103,7 +103,17 @@ extension UpdateViewController {
     
     @objc
     private func touchUpdateButton() {
-        // TODO: - 앱스토어로 연결 혹은 홈으로 연결하는 액션 구현.
+        let appID = "1600711887"
+        guard let url = URL(string: "itms-apps://itunes.apple.com/app/\(appID)") else { return }
+        guard let updateNote else { return }
+        
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+        
+        if !updateNote.isForce {
+            // TODO: - 확인했어요 API 통신
+        }
     }
     
     @objc

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Update/VC/UpdateViewController.swift
@@ -144,5 +144,11 @@ extension UpdateViewController {
                 flex.addItem(updateButton).marginBottom(16).marginHorizontal(17)
             }
         }
+        
+        guard let updateNote else { return }
+        if updateNote.isForce {
+            checkBoxButton.flex.display(.none)
+            checkLabel.flex.display(.none)
+        }
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - Alamofire (5.6.4)
-  - Firebase/CoreOnly (10.7.0):
-    - FirebaseCore (= 10.7.0)
-  - Firebase/DynamicLinks (10.7.0):
+  - Firebase/CoreOnly (10.8.0):
+    - FirebaseCore (= 10.8.0)
+  - Firebase/DynamicLinks (10.8.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.7.0)
-  - FirebaseCore (10.7.0):
+    - FirebaseDynamicLinks (~> 10.8.0)
+  - FirebaseCore (10.8.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.7.0):
+  - FirebaseCoreInternal (10.8.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseDynamicLinks (10.7.0):
+  - FirebaseDynamicLinks (10.8.0):
     - FirebaseCore (~> 10.0)
-  - FlexLayout (1.3.30)
+  - FlexLayout (1.3.31)
   - GoogleUtilities/Environment (7.11.1):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.11.1):
@@ -113,11 +113,11 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: 4e95d97098eacb88856099c4fc79b526a299e48c
-  Firebase: 0219acf760880eeec8ce479895bd7767466d9f81
-  FirebaseCore: e317665b9d744727a97e623edbbed009320afdd7
-  FirebaseCoreInternal: 8845798510aae74703467480f71ac613788d0696
-  FirebaseDynamicLinks: 16a8fae3697fba66fed7a1d646fe59f30d42aa31
-  FlexLayout: 6651ad721f521c29d50bc724788488c84e0bc32a
+  Firebase: b49ef44e5ec9a3d0c1f6450f410337e97872279c
+  FirebaseCore: e78636a990b54be427ce300aa09a0e359f4e0e87
+  FirebaseCoreInternal: fa2899eb1f340054858d289e5a0fb935a0a74e52
+  FirebaseDynamicLinks: 8c7e16503fd057c44727b6bc8dc8e7ff2a667955
+  FlexLayout: 8010187077ecf09710cdf0e9c8ffe2c9b92ec5db
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   IQKeyboardManagerSwift: c7955c0bdbf7b2eb29bb7daaa44e3d90f55a9a85
   KakaoSDKAuth: 8fca87815de22062a23297983f327613b087b8bb


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #397

🌱 작업한 내용
- 다음과 같이 에러로 프로젝트를 빌드할 수 없어서 pods 를 다시 만들어주었심더..

<img width="283" alt="스크린샷 2023-04-13 오후 7 26 42" src="https://user-images.githubusercontent.com/69136340/231951365-ec309be1-77a9-4173-ab0a-c6ba97e1f935.png">

- 그리고 url path 를 잘못 넣어놔서 수정했습니다
- HomeViewController 에서 업데이트에 대해서 판단하고 UpdateViewController 로 화면전환해주었습니다.

---

- 업데이트 내용 조회 API 구현
- 사용자 업데이트 정보 조회 API 구현
- 강제업데이트 여부를 통해서 "확인했어요"라벨과 체크 박스 표시 결정.
- 강제 여부를 통해서 cancel button 의 액션 결정.(강제-앱 종료 / 비강제-뷰 dismiss)
- update button 은 앱스토어로 이동하도록 액션 구현
- 업데이트 텍스트 표시(`\\n` 으로 줄바꿈, `\\t`으로 탭을 보내주기 때문에 텍스트 다루는 로직 설정)

### 🚨참고사항
- 앱 종료 구현 : 강제종료는 앱 심사시에 리젝을 받을 수 있다고 해서 suspend 단계로 보낸 후에 강제 종료시켜주었습니다.
> 참고: https://zeddios.tistory.com/1252

- 확인했어요 API 는 서버에서 전달받는대로 구현 예정입니당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|업데이트 뷰|<img src="https://user-images.githubusercontent.com/69136340/231951085-6658fa88-4da6-411f-b182-6da961e4f1fe.PNG" width ="250">|

## 📮 관련 이슈
- Resolved: #397
