### PR TITLE
fix: 취향 조회 path 와 데이터 모델 Taste 수정 (#415)

### DIFF
--- a/NADA-iOS-forRelease/Sources/NetworkModel/Card/Taste.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Card/Taste.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 struct Taste: Codable {
-    let careType: CardType
+    let cardType: String
     let tasteInfos: [TasteInfo]
 }
 
-enum CardType: String, Codable {
+enum CardType: String {
     case basic = "BASIC"
     case company = "COMPANY"
     case fan = "FAN"

--- a/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Card/CardService.swift
@@ -42,7 +42,7 @@ extension CardService: TargetType {
         case .imageUpload:
             return "/image"
         case .tasteFetch(let cardType):
-            return "/card/\(cardType)/taste"
+            return "/card/\(cardType.rawValue)/taste"
         }
     }
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -41,8 +41,9 @@ class CardCreationViewController: UIViewController {
     private var mbtiText: String?
     private var birthText: String?
     private var newImage: UIImage?
-    private var cardType: CardType = .basic
     private var tasteInfo: [TasteInfo]?
+    
+    private let cardType: CardType = .basic
     
     // MARK: - @IBOutlet Properties
     
@@ -63,7 +64,7 @@ class CardCreationViewController: UIViewController {
         registerCell()
         setTextLabelGesture()
         setNotification()
-        tasteFetchWithAPI()
+        tasteFetchWithAPI(cardType: cardType)
     }
     
     // MARK: - @IBAction Properties
@@ -355,7 +356,7 @@ extension CardCreationViewController: UIImagePickerControllerDelegate, UINavigat
 // MARK: - API methods
 
 extension CardCreationViewController {
-    func tasteFetchWithAPI() {
+    func tasteFetchWithAPI(cardType: CardType) {
         CardAPI.shared.tasteFetch(cardType: cardType) { response in
             switch response {
             case .success(let data):


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #415

🌱 작업한 내용
- 취향 조회 path 가 CardType 이라는 구조체로 되어있어서 `rawValue` 를 사용하여 수정하였습니다.
- 데이터 모델 Taste 수정하였습니당 CardType 이라는 구조체로 되어있어서 디코딩도 되지 않아서 String 으로 수정하였습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|뒷면|<img src="https://user-images.githubusercontent.com/69136340/231978046-47f9eaf3-354a-4d67-9908-c2b5b094ab75.jpeg" width ="200">|


## 📮 관련 이슈
- Resolved: #415
