### PR TITLE
feat: 명함 생성 시 내 명함 탭으로 이동 (#424)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
@@ -230,11 +230,13 @@ extension CardCreationPreviewViewController {
             case .success:
                 print("cardCreationWithAPI - success")
                 
-                guard let presentingVC = self.presentingViewController else { return }
-                
                 NotificationCenter.default.post(name: .creationReloadMainCardSwiper, object: nil)
                 
+                guard let presentingTabBarVC = self.presentingViewController as? TabBarViewController,
+                      let presentingNavigationVC = presentingTabBarVC.selectedViewController as? UINavigationController else { return }
+                
                 self.dismiss(animated: true) {
+                    presentingNavigationVC.popToRootViewController(animated: true)
                     self.activityIndicator.stopAnimating()
                     self.loadingBgView.removeFromSuperview()
                     
@@ -247,7 +249,7 @@ extension CardCreationPreviewViewController {
                             .setHeight(587)
                         nextVC.modalPresentationStyle = .overFullScreen
                         
-                        presentingVC.present(nextVC, animated: true) {
+                        presentingTabBarVC.present(nextVC, animated: true) {
                             UserDefaults.standard.set(false, forKey: Const.UserDefaultsKey.isFirstCard)
                         }
                     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #424

🌱 작업한 내용
- 명함 생성 시 내 명함 탭으로 이동 후에 
- presentingViewController가 TabBarViewController이기 때문에 다운캐스팅해서 사용.
- presentingTabBarVC 의 선택된 뷰컨을 네비뷰컨으로 다운캐스팅하여 사용.

> 참고 : https://gyuios.tistory.com/123

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함 생성 후 이동|<img src="https://user-images.githubusercontent.com/69136340/232206985-656c073c-8a3a-441f-b115-6a4693300e34.mp4" width ="200">|

## 📮 관련 이슈
- Resolved: #424
