### PR TITLE
design: 명함 만들기 뷰 레이아웃 수정 (#418)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationCategoryViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationCategoryViewController.swift
@@ -201,7 +201,6 @@ extension CardCreationCategoryViewController {
             .disposed(by: disposeBag)
     }
     
-    // TODO: - 화면전환 메서드 작성.
     private func presentToBasicCardCreationViewController() {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.cardCreation, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardCreationViewController) as? CardCreationViewController else { return }
         let navigationController = UINavigationController(rootViewController: nextVC)
@@ -210,11 +209,11 @@ extension CardCreationCategoryViewController {
     }
     
     private func presentToJobCardCreationViewController() {
-        
+        // TODO: - 화면전환 메서드 작성.
     }
     
     private func presentToDiggingCardCreationViewController() {
-        
+        // TODO: - 화면전환 메서드 작성.
     }
     
     // MARK: - @objc methods
@@ -271,7 +270,7 @@ extension CardCreationCategoryViewController {
         diggingBackgroundView.snp.makeConstraints { make in
             make.top.equalTo(basicBackgroundView.snp.bottom).offset(12)
             make.leading.trailing.equalToSuperview().inset(24)
-            make.height.equalTo(basicBackgroundView.snp.width).multipliedBy(117.0 / 327.0)
+            make.height.equalTo(diggingBackgroundView.snp.width).multipliedBy(117.0 / 327.0)
         }
         
         diggingTextlabel.snp.makeConstraints { make in
@@ -286,9 +285,9 @@ extension CardCreationCategoryViewController {
         }
         
         jobBackgroundView.snp.makeConstraints { make in
-            make.top.equalTo(jobBackgroundView.snp.bottom).offset(12)
+            make.top.equalTo(diggingBackgroundView.snp.bottom).offset(12)
             make.leading.trailing.equalToSuperview().inset(24)
-            make.height.equalTo(basicBackgroundView.snp.width).multipliedBy(117.0 / 327.0)
+            make.height.equalTo(jobBackgroundView.snp.width).multipliedBy(117.0 / 327.0)
         }
         
         jobTextlabel.snp.makeConstraints { make in
@@ -303,7 +302,7 @@ extension CardCreationCategoryViewController {
         }
         
         checkMarkImageView.snp.makeConstraints { make in
-            make.top.equalTo(diggingBackgroundView.snp.bottom).offset(10)
+            make.top.equalTo(jobBackgroundView.snp.bottom).offset(10)
             make.leading.equalToSuperview().inset(24)
         }
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
@@ -230,11 +230,13 @@ extension CardCreationPreviewViewController {
             case .success:
                 print("cardCreationWithAPI - success")
                 
-                guard let presentingVC = self.presentingViewController else { return }
-                
                 NotificationCenter.default.post(name: .creationReloadMainCardSwiper, object: nil)
                 
+                guard let presentingTabBarVC = self.presentingViewController as? TabBarViewController,
+                      let presentingNavigationVC = presentingTabBarVC.selectedViewController as? UINavigationController else { return }
+                
                 self.dismiss(animated: true) {
+                    presentingNavigationVC.popToRootViewController(animated: true)
                     self.activityIndicator.stopAnimating()
                     self.loadingBgView.removeFromSuperview()
                     
@@ -247,7 +249,7 @@ extension CardCreationPreviewViewController {
                             .setHeight(587)
                         nextVC.modalPresentationStyle = .overFullScreen
                         
-                        presentingVC.present(nextVC, animated: true) {
+                        presentingTabBarVC.present(nextVC, animated: true) {
                             UserDefaults.standard.set(false, forKey: Const.UserDefaultsKey.isFirstCard)
                         }
                     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #418

🌱 작업한 내용
- 기존에서 덕질과 직장 순서를 바꿔주면서 레이아웃 대응을 못해줘서 해줬습니당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함 만들기 뷰|<img src="https://user-images.githubusercontent.com/69136340/232207801-1ffca6dd-d719-4cbc-b866-59706db2c77c.png" width ="200">|

## 📮 관련 이슈
- Resolved: #418
