### PR TITLE
fix: 명함 앞면 선택사항 없을 시 아이콘 없애기 (#429)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -140,18 +140,19 @@ extension FrontCardCell {
         mbtiLabel.text = cardData.mbti
         instagramIDLabel.text = cardData.instagram
         phoneNumberLabel.text = cardData.phoneNumber
-        if let urls = cardData.urls {
-            linkURLLabel.text = urls[0]
-        }
         
-        if cardData.instagram == nil {
+        if let urls = cardData.urls {
+            if urls[0].isEmpty {
+                linkURLStackView.isHidden = true
+            } else {
+                linkURLLabel.text = urls[0]
+            }
+        }
+        if cardData.instagram?.isEmpty ?? false {
             instagramStackView.isHidden = true
         }
-        if cardData.phoneNumber == nil {
+        if cardData.phoneNumber?.isEmpty ?? false {
             phoneNumberStackView.isHidden = true
-        }
-        if cardData.urls == nil {
-            linkURLStackView.isHidden = true
         }
         
         shareButton.isHidden = !isShareable


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #429

🌱 작업한 내용
- 서버에서 빈문자열로 넘어와서 대응해줬습니당~

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함|<img src="https://user-images.githubusercontent.com/69136340/232210391-487babb8-8a39-4de3-a140-d8b34744c269.png" width ="250">|

## 📮 관련 이슈
- Resolved: #429
