### PR TITLE
feat: 명함 선택 시 사진 영역 수정 (#333)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import YPImagePicker
+
 class CardCreationViewController: UIViewController {
 
     // MARK: - Properties

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -261,6 +261,18 @@ extension CardCreationViewController {
     }
 }
 
+// MARK: - YPImagePickerDelegate
+extension CardCreationViewController: YPImagePickerDelegate {
+    func imagePickerHasNoItemsInLibrary(_ picker: YPImagePicker) {
+        self.makeOKAlert(title: "", message: "가져올 수 있는 사진이 없습니다.")
+    }
+    
+    func shouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool {
+        // false 로 설정하면 선택해도 다음으로 갈 수 없다. 즉, 추가할 수 없음.
+        return true
+    }
+}
+
 // MARK: - UICollectionViewDelegate
 extension CardCreationViewController: UICollectionViewDelegate {
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
@@ -382,22 +394,6 @@ extension CardCreationViewController: BackCardCreationDelegate {
     }
     func backCardCreation(withRequired requiredInfo: [String], withOptional optionalInfo: String?) {
         backCard = BackCardDataModel(tastes: requiredInfo, tmi: optionalInfo)
-    }
-}
-
-extension CardCreationViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        if let editedImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
-            newImage = editedImage
-        }
-        NotificationCenter.default.post(name: .sendNewImage, object: newImage)
-        
-        picker.dismiss(animated: true, completion: nil)
-    }
-    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        NotificationCenter.default.post(name: .cancelImagePicker, object: nil)
-        
-        dismiss(animated: true, completion: nil)
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -208,41 +208,17 @@ extension CardCreationViewController {
     @objc
     private func presentToImagePicker() {
         var config = YPImagePickerConfiguration()
-        
-//        주요 설정해야하는 default 값.
-//        config.library.mediaType = .photo
-//        config.library.defaultMultipleSelection = false
-//        config.library.maxNumberOfItems = 1
-        
         config.screens = [.library]
         config.startOnScreen = .library
-        
-        // cropping style 을 square or not 으로 지정.
         config.library.isSquareByDefault = false
-        
-        // 필터 단계 스킵.
         config.showsPhotoFilters = false
-        
-        // 새 이미지를 사진 라이브러리에 저장하지 않음.
-        // 👉 저장하지 않으면 selectedImage 에 담긴 이미지가 사진 라이브러리에서 찾을 수가 없어서 가장 앞에 이미지를 선택함.
-        // selectedImage 사용 못함.
         config.shouldSaveNewPicturesToAlbum = false
-        
-        // crop overlay 의 default 색상.
-//        config.colors.cropOverlayColor = .ypSystemBackground.withAlphaComponent(0.4)
-        // 327 * 540 비율로 crop 희망.
         config.showsCrop = .rectangle(ratio: 0.6)
-        
-        // 이전에 선택한 이미지가 pre-selected 되어 있음.
-//        config.library.preselectedItems = selectedImage
-        
         config.colors.tintColor = .mainColorNadaMain
         
         let imagePicker = YPImagePicker(configuration: config)
         imagePicker.imagePickerDelegate = self
         
-//        imagePicker.didFinishPicking(completion: YPImagePicker.DidFinishPickingCompletion)
-//        public typealias DidFinishPickingCompletion = (_ items: [YPMediaItem], _ cancelled: Bool) -> Void
         imagePicker.didFinishPicking { [weak self] items, cancelled in
             guard let self = self else { return }
             
@@ -250,7 +226,6 @@ extension CardCreationViewController {
                 NotificationCenter.default.post(name: .cancelImagePicker, object: nil)
             }
             
-//            selectedImage = items
             if let photo = items.singlePhoto {
                 backgroundImage = photo.image
                 NotificationCenter.default.post(name: .sendNewImage, object: backgroundImage)
@@ -270,7 +245,6 @@ extension CardCreationViewController: YPImagePickerDelegate {
     }
     
     func shouldAddToSelection(indexPath: IndexPath, numSelections: Int) -> Bool {
-        // false 로 설정하면 선택해도 다음으로 갈 수 없다. 즉, 추가할 수 없음.
         return true
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -239,6 +239,22 @@ extension CardCreationViewController {
         let imagePicker = YPImagePicker(configuration: config)
         imagePicker.imagePickerDelegate = self
         
+//        imagePicker.didFinishPicking(completion: YPImagePicker.DidFinishPickingCompletion)
+//        public typealias DidFinishPickingCompletion = (_ items: [YPMediaItem], _ cancelled: Bool) -> Void
+        imagePicker.didFinishPicking { [weak self] items, cancelled in
+            guard let self = self else { return }
+            
+            if cancelled {
+                NotificationCenter.default.post(name: .cancelImagePicker, object: nil)
+            }
+            
+//            selectedImage = items
+            if let photo = items.singlePhoto {
+                backgroundImage = photo.image
+                NotificationCenter.default.post(name: .sendNewImage, object: backgroundImage)
+            }
+            imagePicker.dismiss(animated: true)
+        }
         
         imagePicker.modalPresentationStyle = .overFullScreen
         present(imagePicker, animated: true, completion: nil)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -236,6 +236,8 @@ extension CardCreationViewController {
         // 이전에 선택한 이미지가 pre-selected 되어 있음.
 //        config.library.preselectedItems = selectedImage
         
+        config.colors.tintColor = .mainColorNadaMain
+        
         let imagePicker = YPImagePicker(configuration: config)
         imagePicker.imagePickerDelegate = self
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -42,8 +42,10 @@ class CardCreationViewController: UIViewController {
     private var backCard: BackCardDataModel?
     private var mbtiText: String?
     private var birthText: String?
-    private var newImage: UIImage?
+    private var backgroundImage: UIImage?
     private var tasteInfo: [TasteInfo]?
+    
+//    private lazy var selectedImage: [YPMediaItem] = []
     
     private let cardType: CardType = .basic
     
@@ -85,7 +87,7 @@ class CardCreationViewController: UIViewController {
 
         nextVC.frontCardDataModel = frontCard
         nextVC.backCardDataModel = backCard
-        nextVC.cardBackgroundImage = newImage
+        nextVC.cardBackgroundImage = backgroundImage
         nextVC.tasteInfo = tasteInfo
         navigationController?.pushViewController(nextVC, animated: true)
     }
@@ -205,12 +207,40 @@ extension CardCreationViewController {
     }
     @objc
     private func presentToImagePicker() {
-        let imagePicker = UIImagePickerController()
-        imagePicker.sourceType = .photoLibrary
-        imagePicker.allowsEditing = true
-        imagePicker.delegate = self
-        imagePicker.modalPresentationStyle = .overFullScreen
+        var config = YPImagePickerConfiguration()
         
+//        주요 설정해야하는 default 값.
+//        config.library.mediaType = .photo
+//        config.library.defaultMultipleSelection = false
+//        config.library.maxNumberOfItems = 1
+        
+        config.screens = [.library]
+        config.startOnScreen = .library
+        
+        // cropping style 을 square or not 으로 지정.
+        config.library.isSquareByDefault = false
+        
+        // 필터 단계 스킵.
+        config.showsPhotoFilters = false
+        
+        // 새 이미지를 사진 라이브러리에 저장하지 않음.
+        // 👉 저장하지 않으면 selectedImage 에 담긴 이미지가 사진 라이브러리에서 찾을 수가 없어서 가장 앞에 이미지를 선택함.
+        // selectedImage 사용 못함.
+        config.shouldSaveNewPicturesToAlbum = false
+        
+        // crop overlay 의 default 색상.
+//        config.colors.cropOverlayColor = .ypSystemBackground.withAlphaComponent(0.4)
+        // 327 * 540 비율로 crop 희망.
+        config.showsCrop = .rectangle(ratio: 0.6)
+        
+        // 이전에 선택한 이미지가 pre-selected 되어 있음.
+//        config.library.preselectedItems = selectedImage
+        
+        let imagePicker = YPImagePicker(configuration: config)
+        imagePicker.imagePickerDelegate = self
+        
+        
+        imagePicker.modalPresentationStyle = .overFullScreen
         present(imagePicker, animated: true, completion: nil)
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -25,5 +25,6 @@ target 'NADA-iOS-forRelease' do
   pod 'Moya/RxSwift'
   pod 'FlexLayout'
   pod 'PinLayout'
-pod 'RxGesture'
+  pod 'RxGesture'
+  pod 'YPImagePicker'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,17 +20,17 @@ PODS:
     - GoogleUtilities/Environment
   - "GoogleUtilities/NSData+zlib (7.11.1)"
   - IQKeyboardManagerSwift (6.5.11)
-  - KakaoSDKAuth (2.14.0):
-    - KakaoSDKCommon (= 2.14.0)
-  - KakaoSDKCommon (2.14.0):
-    - KakaoSDKCommon/Common (= 2.14.0)
-    - KakaoSDKCommon/Network (= 2.14.0)
-  - KakaoSDKCommon/Common (2.14.0)
-  - KakaoSDKCommon/Network (2.14.0):
+  - KakaoSDKAuth (2.15.0):
+    - KakaoSDKCommon (= 2.15.0)
+  - KakaoSDKCommon (2.15.0):
+    - KakaoSDKCommon/Common (= 2.15.0)
+    - KakaoSDKCommon/Network (= 2.15.0)
+  - KakaoSDKCommon/Common (2.15.0)
+  - KakaoSDKCommon/Network (2.15.0):
     - Alamofire (~> 5.1)
-    - KakaoSDKCommon/Common (= 2.14.0)
-  - KakaoSDKUser (2.14.0):
-    - KakaoSDKAuth (= 2.14.0)
+    - KakaoSDKCommon/Common (= 2.15.0)
+  - KakaoSDKUser (2.15.0):
+    - KakaoSDKAuth (= 2.15.0)
   - Kingfisher (7.6.2)
   - lottie-ios (4.1.3)
   - Moya (15.0.0):
@@ -45,6 +45,7 @@ PODS:
   - NVActivityIndicatorView/Base (5.1.1)
   - PinLayout (1.10.4)
   - PromisesObjC (2.2.0)
+  - PryntTrimmerView (4.0.2)
   - RxCocoa (6.5.0):
     - RxRelay (= 6.5.0)
     - RxSwift (= 6.5.0)
@@ -56,9 +57,13 @@ PODS:
   - RxSwift (6.5.0)
   - SkeletonView (1.30.4)
   - SnapKit (5.6.0)
+  - SteviaLayout (4.7.3)
   - SwiftLint (0.51.0)
   - Then (3.0.0)
   - VerticalCardSwiper (2.3.1)
+  - YPImagePicker (5.2.1):
+    - PryntTrimmerView (= 4.0.2)
+    - SteviaLayout (= 4.7.3)
 
 DEPENDENCIES:
   - Firebase/DynamicLinks
@@ -81,6 +86,7 @@ DEPENDENCIES:
   - SwiftLint
   - Then
   - VerticalCardSwiper
+  - YPImagePicker
 
 SPEC REPOS:
   trunk:
@@ -101,15 +107,18 @@ SPEC REPOS:
     - NVActivityIndicatorView
     - PinLayout
     - PromisesObjC
+    - PryntTrimmerView
     - RxCocoa
     - RxGesture
     - RxRelay
     - RxSwift
     - SkeletonView
     - SnapKit
+    - SteviaLayout
     - SwiftLint
     - Then
     - VerticalCardSwiper
+    - YPImagePicker
 
 SPEC CHECKSUMS:
   Alamofire: 4e95d97098eacb88856099c4fc79b526a299e48c
@@ -120,25 +129,28 @@ SPEC CHECKSUMS:
   FlexLayout: 8010187077ecf09710cdf0e9c8ffe2c9b92ec5db
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   IQKeyboardManagerSwift: c7955c0bdbf7b2eb29bb7daaa44e3d90f55a9a85
-  KakaoSDKAuth: 8fca87815de22062a23297983f327613b087b8bb
-  KakaoSDKCommon: 0ce638f7a2e49704943c0b74a087a9f8067bba1c
-  KakaoSDKUser: 2ca18314ce72e6690f76cb1f6f9fbc771d31a803
+  KakaoSDKAuth: 0fe5cf1756e8a9f66f8fc77826061aafa93034f3
+  KakaoSDKCommon: 89d863b7f34398e6fb93a0acb28a204908551a39
+  KakaoSDKUser: a997ca5c4c18ece2ab30646ff74841bc29d4399d
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   lottie-ios: d0954d3150061f662ed0adf96ef98d7421864c47
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   NVActivityIndicatorView: 1f6c5687f1171810aa27a3296814dc2d7dec3667
   PinLayout: f8a677ce0cd1cfe96b58435d029b4ceb4ce9c04c
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
+  PryntTrimmerView: 6a43cc90df5d99addeabd33d4ba09b1365322130
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
   RxGesture: f3efb47ed2d26a8082f7b660d4a59970e275a7f8
   RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
   RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
   SkeletonView: 5a050f6411e697abd4cda0a8d767013399dccd69
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
+  SteviaLayout: c2ecdcff57d44e38fd2f65e54ad52aeae28ca0c4
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
   Then: 844265ae87834bbe1147d91d5d41a404da2ec27d
   VerticalCardSwiper: 68df635b354500f86934ea044ade37a264c044c6
+  YPImagePicker: f36043210c10b0783034eb1947d6e06e31c461e4
 
-PODFILE CHECKSUM: 4f8083405fc2c8c3395baf17cf92037c6ff0eab7
+PODFILE CHECKSUM: 6aac9570b93049853d9fa383fd5b608dbdbcd63d
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
#333

🌱 작업한 내용
- YPImagePicker 를 사용하였습니다.
- 다음의 기능 구현을 목표했고, 구현하였습니다.
    - 사진 라이브러리에서만 이미지를 가져온다.
    - 하나의 사진만 선택할 수 있도록 한다.
    - 이전에 고른 사진이 선택된다. **→ 이미지를 사진 라이브러리에 저장하지 않기 때문에 이전 사진은 고를 수 없음.**
    - crop 할 수 있는 비율을 커스텀한다.
    - 필터는 사용하지 않는다.
    - 이미지를 사진 라이브러리에 저장하지 않는다.
    - 이미지 선택 시와 취소 시에 notification 을 post 한다.

### 🚨 참고사항
- 주석보시고 참고하시공 코드리뷰 끝나면 주석을 깔쌈하게 지우겠습니당

- 사용한 이유
이전에는 crop 에 대한 기능을 기대하며 UIImagePicker 를 사용하였는데 크기를 커스텀할 수 없었습니다.
많은 개발자들의 아쉬움을 여러 글들에서 읽을 수 있었고 다음의 이유로 YPImagePicker 를 선택하였습니다.
원하는 사이즈로 crop 할 수 있는 이미지 라이브러리는 많이 없었고, 그 중 많은 사람들의 사용기가 있으며 가장 최근까지 관리되고 있는 라이브러리를 선택하였습니다.
이외에도 image picker 에 전반적인 text, font, color 등 프로젝트의 톤과 맞는 UI 로 구현할 수 있을 것이라고 기대하였습니다.

- 사용 후 느낀점
YPImagePicker 를 처음 접했던 때는 iOS 에서 이미지의 다중 선택을 지원하지 않는 것 때문이었습니다. 그러던 중 iOS 14 부터 사용할 수 있는 PHPicker 가 생겨서 이후에는 많은 사용자들이 옮겨갈 수 있었습니다.
하지만, 아직까지 crop 에 대한 기능은 제공하지 않고 있기 때문에 해당 라이브러리를 사용하게 되었습니다.
사용해보니 리드미와 example 파일의 주석이 친절하였습니다. 또한, 프로퍼티의 기본값이 잘 설정되어 있어서 적은 줄의 코드로 범용성있는 기능을 구현할 수 있었습니다.
기존의 UIImagePicker 와 달리 선택 후의 동작을 delegate method 에서 구현하는 것이 아니라 `didFinishPicking` 로 따로 구현할 수 있어서 코드의 흐름을 읽는데 같은 문맥에 둘 수 있었습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|사진 선택|<img src="https://user-images.githubusercontent.com/69136340/232369042-8bb9774a-b51a-4902-a672-becfa447263c.mov" width ="250">|
|미리보기|<img src="https://user-images.githubusercontent.com/69136340/232369098-19f6a5d1-a303-4e32-b5ab-f75cf9ee4cea.mov" width ="250">|

## 📮 관련 이슈
- Resolved: #333
