### PR TITLE
fix: 명함 뒷면 다크모드 대응 (#444)

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
+++ b/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
@@ -211,6 +211,6 @@ extension UIColor {
     }
     
     @nonobjc class var tasteLabel: UIColor {
-        return UIColor(red: 19.0 / 255.0, green: 20.0 / 255.0, blue: 22.0, alpha: 1.0)
+        return UIColor(red: 19.0 / 255.0, green: 20.0 / 255.0, blue: 22.0 / 255.0, alpha: 1.0)
     }
 }

--- a/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
+++ b/NADA-iOS-forRelease/Resouces/Extensions/UIColor+Extension.swift
@@ -209,5 +209,8 @@ extension UIColor {
     @nonobjc class var harmonyYellow: UIColor {
       return UIColor(red: 253.0 / 255.0, green: 209.0 / 255.0, blue: 0.0, alpha: 1.0)
     }
-
+    
+    @nonobjc class var tasteLabel: UIColor {
+        return UIColor(red: 19.0 / 255.0, green: 20.0 / 255.0, blue: 22.0, alpha: 1.0)
+    }
 }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -46,15 +46,15 @@ extension BackCardCell {
         backgroundImageView.image = UIImage(named: "backCardBg")
         
         tasteTitleLabel.font = .title02
-        tasteTitleLabel.textColor = .background
+        tasteTitleLabel.textColor = .white
         
         for index in 0..<tasteLabels.count {
             tasteLabels[index].font = .button02
-            tasteLabels[index].textColor = .primary
+            tasteLabels[index].textColor = .tasteLabel
         }
         
         tmiTitleLabel.font = .title02
-        tmiTitleLabel.textColor = .background
+        tmiTitleLabel.textColor = .white
         
         tmiLabel.font = .textRegular04
         tmiLabel.textColor = .background
@@ -74,6 +74,7 @@ extension BackCardCell {
         
         for index in 0..<tasteLabels.count {
             tasteLabels[index].text = cardTasteInfo[index].cardTasteName
+            tasteLabels[index].textColor = cardTasteInfo[index].isChoose ? .tasteLabel :  .tasteLabel.withAlphaComponent(0.5)
         }
         
         if let tmi {

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -36,14 +35,14 @@
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FfP-9G-1a3">
                         <rect key="frame" x="24" y="74.5" width="279" height="1"/>
-                        <color key="backgroundColor" name="background"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="Qid-DD-84g"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bNI-yG-96K">
                         <rect key="frame" x="24" y="371.5" width="279" height="1"/>
-                        <color key="backgroundColor" name="background"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="6Db-Js-vCb"/>
                         </constraints>
@@ -230,8 +229,5 @@
     </objects>
     <resources>
         <image name="iconShare" width="24" height="24"/>
-        <namedColor name="background">
-            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #444

🌱 작업한 내용
- 명함 뒷면 타이틀 라벨 색상, 구분선, 취향 라벨 색상 수정

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함 뒷면|<img src="https://user-images.githubusercontent.com/69136340/232543291-b35e4b62-889f-40a4-bb93-90c615f4ce9c.png" width ="250">|

## 📮 관련 이슈
- Resolved: #444
