### PR TITLE
fix: 사용자 업데이트 정보 조회 데이터 모델 수정 (#451)

### DIFF
--- a/NADA-iOS-forRelease/Sources/NetworkModel/Update/UpdateUserInfo.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Update/UpdateUserInfo.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct UpdateUserInfo: Codable {
-    let forceUpdateAgreement: Bool
+    let checkUpdateNote: Bool
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -215,7 +215,7 @@ extension HomeViewController {
             switch response {
             case .success(let data):
                 guard let updateUserInfo = data as? UpdateUserInfo else { return }
-                completion(updateUserInfo.forceUpdateAgreement)
+                completion(updateUserInfo.checkUpdateNote)
                 print("getUpdateNoteFetchWithAPI - success")
             case .requestErr(let message):
                 print("getUpdateUserInfoFetchWithAPI - requestErr: \(message)")


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #451

🌱 작업한 내용
- 사용자 업데이트 정보 조회 데이터 모델(UpdateUserInfo) 수정하였습니다.
- API 문서 수정에 따른 키값 수정.
## 📮 관련 이슈
- Resolved: #451
