### PR TITLE
feat: 마이페이지 회원탈퇴, 받은 명함 초기화 구현 (#460)

### DIFF
--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
@@ -127,8 +127,8 @@ public class GroupAPI {
         }
     }
     
-    func groupReset(token: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        groupProvider.request(.groupReset(token: token)) { (result) in
+    func groupReset(completion: @escaping (NetworkResult<Any>) -> Void) {
+        groupProvider.request(.groupReset) { (result) in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode
@@ -144,47 +144,7 @@ public class GroupAPI {
     }
     
     // MARK: - JudgeStatus methods
-    
-    private func judgeGroupListFetchStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
-
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<Groups>.self, from: data)
-        else {
-            return .pathErr
-        }
-
-        switch statusCode {
-        case 200:
-            return .success(decodedData.data ?? "None-Data")
-        case 400..<500:
-            return .requestErr(decodedData.message ?? "error message")
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    private func judgeCardListFetchInGroupStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
-        
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<CardsInGroupResponse>.self, from: data)
-        else {
-            return .pathErr
-        }
-        
-        switch statusCode {
-        case 200:
-            return .success(decodedData.data ?? "None-Data")
-        case 400..<500:
-            return .requestErr(decodedData.message ?? "error message")
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
+  
     private func judgeStatus<T: Codable>(by statusCode: Int, data: Data, type: T.Type) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<T>.self, from: data)

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -16,7 +16,7 @@ enum GroupService {
     case cardAddInGroup(cardRequest: CardAddInGroupRequest)
     case cardListFetchInGroup(cardListInGroupRequest: CardListInGroupRequest)
     case cardDeleteInGroup(groupID: Int, cardID: String)
-    case groupReset(token: String)
+    case groupReset
 }
 
 extension GroupService: TargetType {
@@ -35,8 +35,10 @@ extension GroupService: TargetType {
     
     var path: String {
         switch self {
-        case .groupListFetch, .groupReset:
+        case .groupListFetch:
             return "/card-group/list"
+        case .groupReset:
+            return "/card-group/clear"
         case .groupDelete(let groupID, _):
             return "/group/\(groupID)"
         case .groupAdd, .groupEdit:
@@ -54,9 +56,9 @@ extension GroupService: TargetType {
         switch self {
         case .groupListFetch, .cardListFetchInGroup:
             return .get
-        case .groupDelete, .cardDeleteInGroup, .groupReset:
+        case .groupDelete, .cardDeleteInGroup:
             return .delete
-        case .groupAdd, .cardAddInGroup:
+        case .groupAdd, .cardAddInGroup, .groupReset:
             return .post
         case .groupEdit:
             return .put

--- a/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Plugin/MoyaLoggerPlugin.swift
@@ -56,15 +56,15 @@ final class MoyaLoggerPlugin: PluginType {
         log.append("------------------- END HTTP (\(response.data.count)-byte body) -------------------")
         print(log)
         
-        switch statusCode {
-        case 401:
-            let acessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken)
-            let refreshToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.refreshToken)
-            userTokenReissueWithAPI(request: UserReissueToken(accessToken: acessToken ?? "",
-                                                              refreshToken: refreshToken ?? ""))
-        default:
-            return
-        }
+//        switch statusCode {
+//        case 401:
+//            let acessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken)
+//            let refreshToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.refreshToken)
+//            userTokenReissueWithAPI(request: UserReissueToken(accessToken: acessToken ?? "",
+//                                                              refreshToken: refreshToken ?? ""))
+//        default:
+//            return
+//        }
     }
     
     func onFail(_ error: MoyaError, target: TargetType) {
@@ -88,32 +88,32 @@ final class MoyaLoggerPlugin: PluginType {
 
 extension MoyaLoggerPlugin {
     func userTokenReissueWithAPI(request: UserReissueToken) {
-        UserAPI.shared.userTokenReissue(request: request) { response in
-            switch response {
-            case .success(let data):
-                if let tokenData = data as? UserReissueToken {
-                    UserDefaults.standard.set(tokenData.accessToken, forKey: Const.UserDefaultsKey.accessToken)
-                    UserDefaults.standard.set(tokenData.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
-                    
-                    print("userTokenReissueWithAPI - success")
-                }
-            case .requestErr(let statusCode):
-                if let statusCode = statusCode as? Int, statusCode == 406 {
-                    let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
-                    UIApplication.shared.windows.first {$0.isKeyWindow}?.rootViewController = loginVC
-                    
-                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
-                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
-                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.userID)
-                }
-                print("userTokenReissueWithAPI - requestErr: \(statusCode)")
-            case .pathErr:
-                print("userTokenReissueWithAPI - pathErr")
-            case .serverErr:
-                print("userTokenReissueWithAPI - serverErr")
-            case .networkFail:
-                print("userTokenReissueWithAPI - networkFail")
-            }
-        }
+//        UserAPI.shared.userTokenReissue(request: request) { response in
+//            switch response {
+//            case .success(let data):
+//                if let tokenData = data as? UserReissueToken {
+//                    UserDefaults.standard.set(tokenData.accessToken, forKey: Const.UserDefaultsKey.accessToken)
+//                    UserDefaults.standard.set(tokenData.refreshToken, forKey: Const.UserDefaultsKey.refreshToken)
+//
+//                    print("userTokenReissueWithAPI - success")
+//                }
+//            case .requestErr(let statusCode):
+//                if let statusCode = statusCode as? Int, statusCode == 406 {
+//                    let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
+//                    UIApplication.shared.windows.first {$0.isKeyWindow}?.rootViewController = loginVC
+//
+//                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+//                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
+//                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.userID)
+//                }
+//                print("userTokenReissueWithAPI - requestErr: \(statusCode)")
+//            case .pathErr:
+//                print("userTokenReissueWithAPI - pathErr")
+//            case .serverErr:
+//                print("userTokenReissueWithAPI - serverErr")
+//            case .networkFail:
+//                print("userTokenReissueWithAPI - networkFail")
+//            }
+//        }
     }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserAPI.swift
@@ -15,14 +15,14 @@ public class UserAPI {
     
     public init() { }
     
-    func userDelete(token: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        userProvider.request(.userDelete(token: token)) { (result) in
+    func userDelete(completion: @escaping (NetworkResult<Any>) -> Void) {
+        userProvider.request(.userDelete) { (result) in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
                 
-                let networkResult = self.judgeStatus(by: statusCode, data)
+                let networkResult = self.judgeStatus(by: statusCode, data: data, type: String.self)
                 completion(networkResult)
                 
             case .failure(let err):
@@ -37,7 +37,7 @@ public class UserAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                let networkResult = self.judgeUserSocialSignUpStatus(by: statusCode, data)
+                let networkResult = self.judgeStatus(by: statusCode, data: data, type: AccessToken.self)
                 completion(networkResult)
 
             case .failure(let err):
@@ -46,102 +46,11 @@ public class UserAPI {
         }
     }
     
-    func userLogout(token: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        userProvider.request(.userLogout(token: token)) { (result) in
-            switch result {
-            case .success(let response):
-                let statusCode = response.statusCode
-                let data = response.data
-                
-                let networkResult = self.judgeStatus(by: statusCode, data)
-                completion(networkResult)
-                
-            case .failure(let err):
-                print(err)
-            }
-        }
-    }
-    
-    func userTokenReissue(request: UserReissueToken, completion: @escaping (NetworkResult<Any>) -> Void) {
-        userProvider.request(.userTokenReissue(request: request)) { (result) in
-            switch result {
-            case .success(let response):
-                let statusCode = response.statusCode
-                let data = response.data
-                
-                let networkResult = self.judgeUserTokenReissueStatus(by: statusCode, data)
-                completion(networkResult)
-                
-            case .failure(let err):
-                print(err)
-            }
-        }
-    }
-    
     // MARK: - JudgeStatus methods
     
-    private func judgeUserSocialSignUpStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+    private func judgeStatus<T: Codable>(by statusCode: Int, data: Data, type: T.Type) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<AccessToken>.self, from: data)
-        else {
-            return .pathErr
-        }
-        
-        switch statusCode {
-        case 200:
-            return .success(decodedData.data ?? "None-Data")
-        case 400..<500:
-            return .requestErr(decodedData.message ?? "error message")
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    private func judgeUserTokenFetchStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
-        
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<UserWithTokenRequest>.self, from: data)
-        else {
-            return .pathErr
-        }
-        
-        switch statusCode {
-        case 200:
-            return .success(decodedData.data ?? "None-Data")
-        case 400..<500:
-            return .requestErr(decodedData.message ?? "error message")
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    private func judgeUserTokenReissueStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
-        
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<UserReissueToken>.self, from: data)
-        else {
-            return .pathErr
-        }
-        
-        switch statusCode {
-        case 200:
-            return .success(decodedData.data ?? "None-Data")
-        case 400..<500:
-            return .requestErr(statusCode)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<T>.self, from: data)
         else { return .pathErr }
         
         switch statusCode {

--- a/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/User/UserSevice.swift
@@ -9,10 +9,8 @@ import Foundation
 import Moya
 
 enum UserSevice {
-    case userDelete(token: String)
+    case userDelete
     case userSocialSignUp(socialID: String, socialType: String)
-    case userLogout(token: String)
-    case userTokenReissue(request: UserReissueToken)
 }
 
 extension UserSevice: TargetType {
@@ -24,21 +22,17 @@ extension UserSevice: TargetType {
     var path: String {
         switch self {
         case .userDelete:
-            return "/user"
+            return "/member"
         case .userSocialSignUp:
             return "/auth/signup"
-        case .userLogout:
-            return "auth/logout"
-        case .userTokenReissue:
-            return "auth/reissue"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .userSocialSignUp, .userTokenReissue:
+        case .userSocialSignUp:
             return .post
-        case .userDelete, .userLogout:
+        case .userDelete:
             return .delete
         }
     }
@@ -49,22 +43,20 @@ extension UserSevice: TargetType {
     
     var task: Task {
         switch self {
-        case .userDelete, .userLogout:
+        case .userDelete:
             return .requestPlain
         case .userSocialSignUp(let socialID, let socialType):
             return .requestParameters(parameters: ["socialId": socialID,
                                                    "socialType": socialType],
                                       encoding: JSONEncoding.default)
-        case .userTokenReissue(let request):
-            return .requestJSONEncodable(request)
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .userSocialSignUp, .userTokenReissue:
+        case .userSocialSignUp:
             return Const.Header.applicationJsonHeader()
-        case .userDelete, .userLogout:
+        case .userDelete:
             return Const.Header.bearerHeader()
         }
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -126,7 +126,9 @@ extension MoreViewController {
     func setResetClicked() {
         makeOKCancelAlert(title: "", message: "받은 명함과 명함 모음 그룹이 모두 초기화됩니다. 정말 초기화하시겠습니까?", okAction: { [weak self] _ in
             self?.groupResetWithAPI {
-                self?.makeOKAlert(title: "", message: "받은 명함이 초기화 되었습니다.")
+                self?.makeOKAlert(title: "", message: "받은 명함이 초기화 되었습니다.") { _ in
+                    self?.tabBarController?.selectedIndex = 2
+                }
             }
         })
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -137,12 +137,10 @@ extension MoreViewController {
         makeOKCancelAlert(title: "", message: "정말 탈퇴하시겠습니까?\n앱 내 정보가 모두 삭제되며, 이후 복구는 불가합니다.", okAction: { [weak self ]_ in
             self?.deleteUserWithAPI {
                 self?.makeOKAlert(title: "", message: "나다를 이용해주셔서 감사합니다.\n다음에 또 뵈어요! 🥹") { _ in
-                    if let _ = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
-                        self?.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                    self?.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
 //                        self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
-                        self?.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
-                        
-                    }
+                    self?.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
+                    
                     let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
                     nextVC.modalPresentationStyle = .overFullScreen
                     self?.navigationController?.changeRootViewController(nextVC)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -135,7 +135,7 @@ extension MoreViewController {
         makeOKCancelAlert(title: "", message: "정말 탈퇴하시겠습니까?\n앱 내 정보가 모두 삭제되며, 이후 복구는 불가합니다.", okAction: { [weak self ]_ in
             self?.deleteUserWithAPI {
                 self?.makeOKAlert(title: "", message: "나다를 이용해주셔서 감사합니다.\n다음에 또 뵈어요! 🥹") { _ in
-                    if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
+                    if let _ = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
                         self?.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
 //                        self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
                         self?.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/More/MoreViewController.swift
@@ -14,7 +14,7 @@ class MoreViewController: UIViewController {
     let defaults = UserDefaults.standard
     
     var firstItems = ["개인정보 처리방침", "서비스 이용약관", "Team NADA", "오픈소스 라이브러리"]
-    var secondItems = ["로그아웃", "받은 명함 초기화", "모든 명함 삭제하기"]
+    var secondItems = ["로그아웃", "받은 명함 초기화", "회원탈퇴"]
     
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var moreListTableView: UITableView!
@@ -111,10 +111,8 @@ extension MoreViewController {
         makeOKCancelAlert(title: "", message: "로그아웃 하시겠습니까?", okAction: { _ in
             self.makeOKAlert(title: "", message: "로그아웃이 완료 되었습니다.") { _ in
                 if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
-                    self.logoutUserWithAPI(token: acToken)
-                    
                     self.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
-                    self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
+//                    self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
                     self.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
                     
                     let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
@@ -126,39 +124,26 @@ extension MoreViewController {
     }
     
     func setResetClicked() {
-        makeOKCancelAlert(title: "", message: "받은 명함과 그룹이 모두 초기화됩니다. 정말 초기화하시겠습니까?", okAction: { _ in
-            UserApi.shared.logout { (error) in
-                if let error = error {
-                    print(error)
-                } else {
-                    self.makeOKAlert(title: "", message: "받은 명함이 초기화 되었습니다.")
-                    if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
-                    }
-                }
+        makeOKCancelAlert(title: "", message: "받은 명함과 명함 모음 그룹이 모두 초기화됩니다. 정말 초기화하시겠습니까?", okAction: { [weak self] _ in
+            self?.groupResetWithAPI {
+                self?.makeOKAlert(title: "", message: "받은 명함이 초기화 되었습니다.")
             }
         })
     }
     
     func setDeleteCicked() {
-        makeOKCancelAlert(title: "", message: "내 명함과 받은 명함이 모두 삭제됩니다. 삭제 하시겠습니까?", okAction: { _ in
-            UserApi.shared.logout { (error) in
-                if let error = error {
-                    print(error)
-                } else {
-                    self.makeOKAlert(title: "", message: "모든 명함이 삭제되었습니다.") { _ in
-                        // TODO: - KeyChain 적용
-                        if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
-                            self.deleteUserWithAPI(token: acToken)
-                            
-                            self.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
-                            self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
-                            self.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
-                            
-                            let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
-                            nextVC.modalPresentationStyle = .overFullScreen
-                            self.navigationController?.changeRootViewController(nextVC)
-                        }
+        makeOKCancelAlert(title: "", message: "정말 탈퇴하시겠습니까?\n앱 내 정보가 모두 삭제되며, 이후 복구는 불가합니다.", okAction: { [weak self ]_ in
+            self?.deleteUserWithAPI {
+                self?.makeOKAlert(title: "", message: "나다를 이용해주셔서 감사합니다.\n다음에 또 뵈어요! 🥹") { _ in
+                    if let acToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) {
+                        self?.defaults.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+//                        self.defaults.removeObject(forKey: Const.UserDefaultsKey.refreshToken)
+                        self?.defaults.removeObject(forKey: Const.UserDefaultsKey.darkModeState)
+                        
                     }
+                    let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController)
+                    nextVC.modalPresentationStyle = .overFullScreen
+                    self?.navigationController?.changeRootViewController(nextVC)
                 }
             }
         })
@@ -203,11 +188,12 @@ extension MoreViewController: UITableViewDataSource {
 
 // MARK: - Network
 extension MoreViewController {
-    func deleteUserWithAPI(token: String) {
-        UserAPI.shared.userDelete(token: token) { response in
+    func deleteUserWithAPI(completion: @escaping () -> Void) {
+        UserAPI.shared.userDelete { response in
             switch response {
             case .success:
                 print("deleteUserWithAPI - success")
+                completion()
             case .requestErr(let message):
                 print("deleteUserWithAPI - requestErr: \(message)")
             case .pathErr:
@@ -220,11 +206,12 @@ extension MoreViewController {
         }
     }
     
-    func groupResetWithAPI(token: String) {
-        GroupAPI.shared.groupReset(token: token) { response in
+    func groupResetWithAPI(completion: @escaping () -> Void) {
+        GroupAPI.shared.groupReset { response in
             switch response {
             case .success:
                 print("groupResetWithAPI - success")
+                completion()
             case .requestErr(let message):
                 print("groupResetWithAPI - requestErr: \(message)")
             case .pathErr:
@@ -236,22 +223,4 @@ extension MoreViewController {
             }
         }
     }
-    
-    func logoutUserWithAPI(token: String) {
-        UserAPI.shared.userLogout(token: token) { response in
-            switch response {
-            case .success:
-                print("logoutUserWithAPI - success")
-            case .requestErr(let message):
-                print("logoutUserWithAPI - requestErr: \(message)")
-            case .pathErr:
-                print("logoutUserWithAPI - pathErr")
-            case .serverErr:
-                print("logoutUserWithAPI - serverErr")
-            case .networkFail:
-                print("logoutUserWithAPI - networkFail")
-            }
-        }
-    }
-    
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #460

🌱 작업한 내용
- 회원 탈퇴, 받은 명함 초기화 마이페이지에 연결
- 사용하지 않지만 개발 의향이 있는 토큰 재발급 코드 주석 처리
- 회원 탈퇴, 받은 명함 초기화 문구 변경. 피그마 참고.

## 📮 관련 이슈
- Resolved: #460
