### PR TITLE
fix: 명함 그룹 관련 수정된 API 반영 #464

### DIFF
--- a/IntentsExtension/IntentsExtension.entitlements
+++ b/IntentsExtension/IntentsExtension.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:itznada.page.link</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.YJC.NADA-iOS-forRelease</string>

--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		77703156275005AA002CBD19 /* CardResultBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardResultBottomSheetViewController.swift; sourceTree = "<group>"; };
 		7770315827500C49002CBD19 /* QRScan.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = QRScan.storyboard; sourceTree = "<group>"; };
 		7770315A27500C7B002CBD19 /* QRScanViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScanViewController.swift; sourceTree = "<group>"; };
+		777B2C202A00BEB300A6AB27 /* IntentsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IntentsExtension.entitlements; sourceTree = "<group>"; };
 		777FF89A27359B7800BF69D3 /* Groups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Groups.swift; sourceTree = "<group>"; };
 		777FF89C2735B16B00BF69D3 /* GroupAddRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupAddRequest.swift; sourceTree = "<group>"; };
 		777FF89E27364B7B00BF69D3 /* GroupEditRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupEditRequest.swift; sourceTree = "<group>"; };
@@ -1090,6 +1091,7 @@
 		F87D222B298ECAFB001A882B /* IntentsExtension */ = {
 			isa = PBXGroup;
 			children = (
+				777B2C202A00BEB300A6AB27 /* IntentsExtension.entitlements */,
 				F87D222C298ECAFB001A882B /* IntentHandler.swift */,
 				F87D222E298ECAFB001A882B /* Info.plist */,
 			);
@@ -2040,6 +2042,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = IntentsExtension/IntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
@@ -2072,6 +2075,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = IntentsExtension/IntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
@@ -103,7 +103,7 @@ extension CompanyFrontCardCell {
         let widths = [birthdayImageWidth, mbtiImageWidth, mailImageWidth, phoneImageWidth, urlImageWidth]
         
         constraints.forEach {
-            $0?.constant = ($0?.constant ?? 0) * (258/540)
+            $0?.constant = ($0?.constant ?? 0) * 0.6
         }
         labels.forEach {
             $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.6)

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
@@ -106,7 +106,7 @@ extension CompanyFrontCardCell {
             $0?.constant = ($0?.constant ?? 0) * (258/540)
         }
         labels.forEach {
-            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.65)
+            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.6)
         }
         widths.forEach {
             $0?.constant = 12

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
@@ -37,6 +37,21 @@ class CompanyFrontCardCell: CardCell {
     @IBOutlet weak var linkURLStackView: UIStackView!
     @IBOutlet weak var totalStackView: UIStackView!
     
+    @IBOutlet weak var titleLabelTop: NSLayoutConstraint!
+    @IBOutlet weak var titleLabelLeading: NSLayoutConstraint!
+    @IBOutlet weak var descLabelTop: NSLayoutConstraint!
+    @IBOutlet weak var userNameLabelTop: NSLayoutConstraint!
+    @IBOutlet weak var birthdayImageTop: NSLayoutConstraint!
+    @IBOutlet weak var birthdayImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var mbtiImageLeading: NSLayoutConstraint!
+    @IBOutlet weak var mbtiImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var mailImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var phoneImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var urlImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var totalStackviewBottom: NSLayoutConstraint!
+    @IBOutlet weak var totalStackviewLeading: NSLayoutConstraint!
+    @IBOutlet weak var totalStackviewTrailing: NSLayoutConstraint!
+    
     // MARK: - Life Cycle
     
     override func awakeFromNib() {
@@ -80,6 +95,24 @@ extension CompanyFrontCardCell {
         linkURLLabel.lineBreakMode = .byTruncatingTail
         
         linkURLStackView.alignment = .center
+    }
+    func setConstraints() {
+        let constraints = [titleLabelTop, titleLabelLeading, descLabelTop,
+                           userNameLabelTop, birthdayImageTop, mbtiImageLeading, totalStackviewBottom, totalStackviewLeading, totalStackviewTrailing]
+        let labels = [titleLabel, descriptionLabel, userNameLabel, birthLabel, mbtiLabel, phoneNumberLabel, linkURLLabel, mailLabel]
+        let widths = [birthdayImageWidth, mbtiImageWidth, mailImageWidth, phoneImageWidth, urlImageWidth]
+        
+        constraints.forEach {
+            $0?.constant = ($0?.constant ?? 0) * (258/540)
+        }
+        labels.forEach {
+            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.65)
+        }
+        widths.forEach {
+            $0?.constant = 12
+        }
+        totalStackView.spacing = 5
+        print("✅✅")
     }
     private func setTapGesture() {
         mailLabel.isUserInteractionEnabled = true

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
@@ -55,7 +55,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="CMJ-4p-lae"/>
-                                            <constraint firstAttribute="height" constant="24" id="Xxs-9N-RXe"/>
+                                            <constraint firstAttribute="width" secondItem="TXF-fP-7YQ" secondAttribute="height" multiplier="1:1" id="LZD-pZ-Hl1"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8oi-jO-fkf">
@@ -73,7 +73,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="cuA-Eh-TkP"/>
-                                            <constraint firstAttribute="height" constant="24" id="e3W-4o-uT7"/>
+                                            <constraint firstAttribute="width" secondItem="GXK-3x-QiF" secondAttribute="height" multiplier="1:1" id="jnT-97-i0t"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="63p-qi-OcL">
@@ -90,8 +90,8 @@
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUrl" translatesAutoresizingMaskIntoConstraints="NO" id="el0-x0-WD9">
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
+                                            <constraint firstAttribute="width" secondItem="el0-x0-WD9" secondAttribute="height" multiplier="1:1" id="AHE-jU-tw4"/>
                                             <constraint firstAttribute="width" constant="24" id="DaP-OT-lYg"/>
-                                            <constraint firstAttribute="height" constant="24" id="cpk-TF-9yb"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqW-bV-yHr">
@@ -113,7 +113,7 @@
                         <rect key="frame" x="95.5" y="273.5" width="18" height="18"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="18" id="6KF-To-yWi"/>
-                            <constraint firstAttribute="height" constant="18" id="IeI-qi-pnl"/>
+                            <constraint firstAttribute="width" secondItem="SXl-Ls-Qsz" secondAttribute="height" multiplier="1:1" id="fpt-UP-kDc"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VDj-1w-jyf">
@@ -146,7 +146,7 @@
                         <rect key="frame" x="24" y="273.5" width="18" height="18"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="18" id="4So-UZ-W8E"/>
-                            <constraint firstAttribute="height" constant="18" id="hHE-FG-uuR"/>
+                            <constraint firstAttribute="width" secondItem="Bkm-gK-Pca" secondAttribute="height" multiplier="1:1" id="iJ2-hP-Nvk"/>
                         </constraints>
                     </imageView>
                 </subviews>
@@ -187,21 +187,35 @@
             <connections>
                 <outlet property="backgroundImageView" destination="D6t-Nc-4xH" id="qAU-7F-EMV"/>
                 <outlet property="birthLabel" destination="aik-Vi-yux" id="QTx-yd-LoY"/>
+                <outlet property="birthdayImageTop" destination="fn8-0D-X5B" id="AIc-r8-s4G"/>
+                <outlet property="birthdayImageWidth" destination="4So-UZ-W8E" id="T6M-HV-jJY"/>
+                <outlet property="descLabelTop" destination="W5z-RH-cOC" id="qEx-Zt-AP6"/>
                 <outlet property="descriptionLabel" destination="VDj-1w-jyf" id="YqY-uP-XQV"/>
                 <outlet property="linkURLImageView" destination="el0-x0-WD9" id="kWS-T3-Urt"/>
                 <outlet property="linkURLLabel" destination="LqW-bV-yHr" id="vD7-qs-hSc"/>
                 <outlet property="linkURLStackView" destination="7Qd-rb-YOy" id="6Xj-PV-blN"/>
                 <outlet property="mailImageView" destination="TXF-fP-7YQ" id="CVp-bU-T3I"/>
+                <outlet property="mailImageWidth" destination="CMJ-4p-lae" id="xFF-Bs-Ch9"/>
                 <outlet property="mailLabel" destination="8oi-jO-fkf" id="eIE-ch-cCT"/>
                 <outlet property="mailStackView" destination="D6j-Cz-d99" id="1ZU-Be-asB"/>
+                <outlet property="mbtiImageLeading" destination="m7i-2Q-RNF" id="gw7-1Z-Muu"/>
+                <outlet property="mbtiImageWidth" destination="6KF-To-yWi" id="bUf-Ag-REx"/>
                 <outlet property="mbtiLabel" destination="eyB-c0-PQB" id="waJ-j4-tRM"/>
+                <outlet property="phoneImageWidth" destination="cuA-Eh-TkP" id="rJJ-qI-RCn"/>
                 <outlet property="phoneNumberImageView" destination="GXK-3x-QiF" id="Tyz-f0-Cy3"/>
                 <outlet property="phoneNumberLabel" destination="63p-qi-OcL" id="iYB-x9-hze"/>
                 <outlet property="phoneNumberStackView" destination="32s-jO-RgD" id="hmB-xr-kck"/>
                 <outlet property="shareButton" destination="aAt-PF-ce3" id="tNu-aM-Dsc"/>
                 <outlet property="titleLabel" destination="OeE-mZ-GcL" id="NIa-Yu-Bit"/>
+                <outlet property="titleLabelLeading" destination="kch-bF-wdy" id="wcr-Hc-5JJ"/>
+                <outlet property="titleLabelTop" destination="4yZ-WV-dW5" id="PQ5-4z-Qly"/>
                 <outlet property="totalStackView" destination="AFF-gP-nt6" id="rwP-ON-N2U"/>
+                <outlet property="totalStackviewBottom" destination="NGu-mr-hGB" id="Ola-l0-VQb"/>
+                <outlet property="totalStackviewLeading" destination="0o3-TT-y9X" id="Cfw-gQ-g4f"/>
+                <outlet property="totalStackviewTrailing" destination="TlW-CK-hkZ" id="w4E-Ly-nCB"/>
+                <outlet property="urlImageWidth" destination="DaP-OT-lYg" id="dIG-fr-0e5"/>
                 <outlet property="userNameLabel" destination="cO6-DY-EUn" id="8AO-3c-DDH"/>
+                <outlet property="userNameLabelTop" destination="025-5i-Sid" id="jXj-oi-mVK"/>
             </connections>
             <point key="canvasLocation" x="281.8840579710145" y="226.33928571428569"/>
         </collectionViewCell>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
@@ -9,7 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="CompanyFrontCardCell" reuseIdentifier="FrontCardCell" id="gTV-IL-0wX" userLabel="CompanyFrontCardCell" customClass="CompanyFrontCardCell" customModule="NADA_iOS_forRelease" customModuleProvider="target">
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="CompanyFrontCardCell" reuseIdentifier="CompanyFrontCardCell" id="gTV-IL-0wX" userLabel="CompanyFrontCardCell" customClass="CompanyFrontCardCell" customModule="NADA_iOS_forRelease" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="327" height="540"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -98,7 +98,7 @@ extension FanFrontCardCell {
             $0?.constant = ($0?.constant ?? 0) * (258/540)
         }
         labels.forEach {
-            $0?.font = $0?.font.withSize(12)
+            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.65)
         }
         widths.forEach {
             $0?.constant = 12

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -104,6 +104,7 @@ extension FanFrontCardCell {
             $0?.constant = 12
         }
         totalStackView.spacing = 5
+        print("✅✅")
     }
     private func setTapGesture() {
         snsLabel.isUserInteractionEnabled = true

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -95,7 +95,7 @@ extension FanFrontCardCell {
         let labels = [titleLabel, userNameLabel, birthLabel, snsLabel, firstURLLabel, secondURLLabel]
         let widths = [birthImageViewWidth, snsImageViewWidth, firstUrlWidth, secondUrlWidth]
         constraints.forEach {
-            $0?.constant = ($0?.constant ?? 0) * (258/540)
+            $0?.constant = ($0?.constant ?? 0) * 0.6
         }
         labels.forEach {
             $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.6)

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -98,7 +98,7 @@ extension FanFrontCardCell {
             $0?.constant = ($0?.constant ?? 0) * (258/540)
         }
         labels.forEach {
-            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.65)
+            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.6)
         }
         widths.forEach {
             $0?.constant = 12

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -34,6 +34,19 @@ class FanFrontCardCell: CardCell {
     @IBOutlet weak var secondURLStackView: UIStackView!
     @IBOutlet weak var totalStackView: UIStackView!
     
+    @IBOutlet weak var titleLabelTop: NSLayoutConstraint!
+    @IBOutlet weak var titleLabelBottom: NSLayoutConstraint!
+    @IBOutlet weak var titleLabelLeading: NSLayoutConstraint!
+    @IBOutlet weak var userNameBottom: NSLayoutConstraint!
+    @IBOutlet weak var totalStackviewBottom: NSLayoutConstraint!
+    @IBOutlet weak var totalStackviewLeading: NSLayoutConstraint!
+    @IBOutlet weak var totalStackviewTrailing: NSLayoutConstraint!
+    
+    @IBOutlet weak var birthImageViewWidth: NSLayoutConstraint!
+    @IBOutlet weak var snsImageViewWidth: NSLayoutConstraint!
+    @IBOutlet weak var firstUrlWidth: NSLayoutConstraint!
+    @IBOutlet weak var secondUrlWidth: NSLayoutConstraint!
+    
     // MARK: - Life Cycle
     
     override func awakeFromNib() {
@@ -75,6 +88,22 @@ extension FanFrontCardCell {
         
         firstURLStackView.alignment = .center
         secondURLStackView.alignment = .center
+    }
+    func setConstraints() {
+        let constraints = [titleLabelTop, titleLabelBottom, titleLabelLeading,
+                           userNameBottom, totalStackviewBottom, totalStackviewLeading, totalStackviewTrailing]
+        let labels = [titleLabel, userNameLabel, birthLabel, snsLabel, firstURLLabel, secondURLLabel]
+        let widths = [birthImageViewWidth, snsImageViewWidth, firstUrlWidth, secondUrlWidth]
+        constraints.forEach {
+            $0?.constant = ($0?.constant ?? 0) * (258/540)
+        }
+        labels.forEach {
+            $0?.font = $0?.font.withSize(12)
+        }
+        widths.forEach {
+            $0?.constant = 12
+        }
+        totalStackView.spacing = 5
     }
     private func setTapGesture() {
         snsLabel.isUserInteractionEnabled = true

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
@@ -9,7 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="FanFrontCardCell" reuseIdentifier="FrontCardCell" id="gTV-IL-0wX" userLabel="FanFrontCardCell" customClass="FanFrontCardCell" customModule="NADA_iOS_forRelease" customModuleProvider="target">
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="FanFrontCardCell" reuseIdentifier="FanFrontCardCell" id="gTV-IL-0wX" userLabel="FanFrontCardCell" customClass="FanFrontCardCell" customModule="NADA_iOS_forRelease" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="327" height="540"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -49,7 +49,6 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="CMJ-4p-lae"/>
-                                            <constraint firstAttribute="height" constant="24" id="Xxs-9N-RXe"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8oi-jO-fkf">
@@ -67,7 +66,6 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="cuA-Eh-TkP"/>
-                                            <constraint firstAttribute="height" constant="24" id="e3W-4o-uT7"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="63p-qi-OcL">
@@ -85,7 +83,6 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="DaP-OT-lYg"/>
-                                            <constraint firstAttribute="height" constant="24" id="cpk-TF-9yb"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqW-bV-yHr">
@@ -127,7 +124,7 @@
                         <rect key="frame" x="24" y="272" width="18" height="18"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="18" id="4So-UZ-W8E"/>
-                            <constraint firstAttribute="height" constant="18" id="hHE-FG-uuR"/>
+                            <constraint firstAttribute="width" secondItem="Bkm-gK-Pca" secondAttribute="height" multiplier="1:1" id="g5C-A9-xED"/>
                         </constraints>
                     </imageView>
                 </subviews>
@@ -160,19 +157,30 @@
             <size key="customSize" width="307" height="444"/>
             <connections>
                 <outlet property="backgroundImageView" destination="D6t-Nc-4xH" id="qAU-7F-EMV"/>
+                <outlet property="birthImageViewWidth" destination="4So-UZ-W8E" id="Dbu-xT-67I"/>
                 <outlet property="birthLabel" destination="aik-Vi-yux" id="QTx-yd-LoY"/>
                 <outlet property="firstURLImageView" destination="GXK-3x-QiF" id="Tyz-f0-Cy3"/>
                 <outlet property="firstURLLabel" destination="63p-qi-OcL" id="iYB-x9-hze"/>
                 <outlet property="firstURLStackView" destination="32s-jO-RgD" id="hmB-xr-kck"/>
+                <outlet property="firstUrlWidth" destination="cuA-Eh-TkP" id="gBY-If-8No"/>
                 <outlet property="secondURLImageView" destination="el0-x0-WD9" id="kWS-T3-Urt"/>
                 <outlet property="secondURLLabel" destination="LqW-bV-yHr" id="vD7-qs-hSc"/>
                 <outlet property="secondURLStackView" destination="7Qd-rb-YOy" id="6Xj-PV-blN"/>
+                <outlet property="secondUrlWidth" destination="DaP-OT-lYg" id="PA7-kG-kbY"/>
                 <outlet property="shareButton" destination="aAt-PF-ce3" id="tNu-aM-Dsc"/>
                 <outlet property="snsImageView" destination="TXF-fP-7YQ" id="CVp-bU-T3I"/>
+                <outlet property="snsImageViewWidth" destination="CMJ-4p-lae" id="Few-fM-6Zx"/>
                 <outlet property="snsLabel" destination="8oi-jO-fkf" id="eIE-ch-cCT"/>
                 <outlet property="snsStackView" destination="D6j-Cz-d99" id="1ZU-Be-asB"/>
                 <outlet property="titleLabel" destination="OeE-mZ-GcL" id="NIa-Yu-Bit"/>
+                <outlet property="titleLabelBottom" destination="wFZ-9I-KWi" id="rfb-5v-dAf"/>
+                <outlet property="titleLabelLeading" destination="kch-bF-wdy" id="NMB-ot-aRQ"/>
+                <outlet property="titleLabelTop" destination="4yZ-WV-dW5" id="BRG-SV-kVi"/>
                 <outlet property="totalStackView" destination="AFF-gP-nt6" id="rwP-ON-N2U"/>
+                <outlet property="totalStackviewBottom" destination="NGu-mr-hGB" id="9Bb-t0-AB7"/>
+                <outlet property="totalStackviewLeading" destination="0o3-TT-y9X" id="NDR-MN-1vd"/>
+                <outlet property="totalStackviewTrailing" destination="TlW-CK-hkZ" id="Bil-hy-b0d"/>
+                <outlet property="userNameBottom" destination="fn8-0D-X5B" id="bKk-BU-2CP"/>
                 <outlet property="userNameLabel" destination="cO6-DY-EUn" id="8AO-3c-DDH"/>
             </connections>
             <point key="canvasLocation" x="281.8840579710145" y="226.33928571428569"/>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
@@ -49,6 +49,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="CMJ-4p-lae"/>
+                                            <constraint firstAttribute="width" secondItem="TXF-fP-7YQ" secondAttribute="height" multiplier="1:1" id="gMj-uy-dHx"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8oi-jO-fkf">
@@ -65,6 +66,7 @@
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconUrl" translatesAutoresizingMaskIntoConstraints="NO" id="GXK-3x-QiF">
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
+                                            <constraint firstAttribute="width" secondItem="GXK-3x-QiF" secondAttribute="height" multiplier="1:1" id="519-Vh-oAu"/>
                                             <constraint firstAttribute="width" constant="24" id="cuA-Eh-TkP"/>
                                         </constraints>
                                     </imageView>
@@ -83,6 +85,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="DaP-OT-lYg"/>
+                                            <constraint firstAttribute="width" secondItem="el0-x0-WD9" secondAttribute="height" multiplier="1:1" id="U92-BY-Vpz"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqW-bV-yHr">

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -36,6 +36,20 @@ class FrontCardCell: CardCell {
     @IBOutlet weak var linkURLStackView: UIStackView!
     @IBOutlet weak var totalStackView: UIStackView!
     
+    @IBOutlet weak var titleLabelTop: NSLayoutConstraint!
+    @IBOutlet weak var titleLabelLeading: NSLayoutConstraint!
+    @IBOutlet weak var descLabelTop: NSLayoutConstraint!
+    @IBOutlet weak var usernameLabelTop: NSLayoutConstraint!
+    @IBOutlet weak var birthdayImageTop: NSLayoutConstraint!
+    @IBOutlet weak var birthdayImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var mbtiImageLeading: NSLayoutConstraint!
+    @IBOutlet weak var instagramImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var phoneImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var urlImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var totalStackViewBottom: NSLayoutConstraint!
+    @IBOutlet weak var totalStackViewLeading: NSLayoutConstraint!
+    @IBOutlet weak var totalStackViewTrailing: NSLayoutConstraint!
+    
     // MARK: - Life Cycle
     
     override func awakeFromNib() {
@@ -79,6 +93,23 @@ extension FrontCardCell {
         linkURLLabel.lineBreakMode = .byTruncatingTail
         
         linkURLStackView.alignment = .center
+    }
+    func setConstraints() {
+        let constraints = [titleLabelTop, titleLabelLeading, descLabelTop,
+                           usernameLabelTop, birthdayImageTop, mbtiImageLeading, totalStackViewBottom, totalStackViewLeading, totalStackViewTrailing]
+        let labels = [titleLabel, descriptionLabel, userNameLabel, birthLabel, mbtiLabel, instagramIDLabel, phoneNumberLabel, linkURLLabel]
+        let widths = [birthdayImageWidth, phoneImageWidth, urlImageWidth]
+        constraints.forEach {
+            $0?.constant = ($0?.constant ?? 0) * (258/540)
+        }
+        labels.forEach {
+            $0?.font = $0?.font.withSize(12)
+        }
+        widths.forEach {
+            $0?.constant = 12
+        }
+        totalStackView.spacing = 5
+        print("✅✅")
     }
     private func setTapGesture() {
         instagramIDLabel.isUserInteractionEnabled = true

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -46,6 +46,7 @@ class FrontCardCell: CardCell {
     @IBOutlet weak var instagramImageWidth: NSLayoutConstraint!
     @IBOutlet weak var phoneImageWidth: NSLayoutConstraint!
     @IBOutlet weak var urlImageWidth: NSLayoutConstraint!
+    @IBOutlet weak var mbtiImageWidth: NSLayoutConstraint!
     @IBOutlet weak var totalStackViewBottom: NSLayoutConstraint!
     @IBOutlet weak var totalStackViewLeading: NSLayoutConstraint!
     @IBOutlet weak var totalStackViewTrailing: NSLayoutConstraint!
@@ -98,12 +99,12 @@ extension FrontCardCell {
         let constraints = [titleLabelTop, titleLabelLeading, descLabelTop,
                            usernameLabelTop, birthdayImageTop, mbtiImageLeading, totalStackViewBottom, totalStackViewLeading, totalStackViewTrailing]
         let labels = [titleLabel, descriptionLabel, userNameLabel, birthLabel, mbtiLabel, instagramIDLabel, phoneNumberLabel, linkURLLabel]
-        let widths = [birthdayImageWidth, phoneImageWidth, urlImageWidth]
+        let widths = [birthdayImageWidth, phoneImageWidth, urlImageWidth, mbtiImageWidth]
         constraints.forEach {
             $0?.constant = ($0?.constant ?? 0) * (258/540)
         }
         labels.forEach {
-            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.65)
+            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.6)
         }
         widths.forEach {
             $0?.constant = 12

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -101,7 +101,7 @@ extension FrontCardCell {
         let labels = [titleLabel, descriptionLabel, userNameLabel, birthLabel, mbtiLabel, instagramIDLabel, phoneNumberLabel, linkURLLabel]
         let widths = [birthdayImageWidth, phoneImageWidth, urlImageWidth, mbtiImageWidth]
         constraints.forEach {
-            $0?.constant = ($0?.constant ?? 0) * (258/540)
+            $0?.constant = ($0?.constant ?? 0) * 0.6
         }
         labels.forEach {
             $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.6)

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -103,7 +103,7 @@ extension FrontCardCell {
             $0?.constant = ($0?.constant ?? 0) * (258/540)
         }
         labels.forEach {
-            $0?.font = $0?.font.withSize(12)
+            $0?.font = $0?.font.withSize(($0?.font.pointSize ?? 0) * 0.65)
         }
         widths.forEach {
             $0?.constant = 12

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
@@ -55,7 +55,6 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="CMJ-4p-lae"/>
-                                            <constraint firstAttribute="height" constant="24" id="Xxs-9N-RXe"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8oi-jO-fkf">
@@ -73,7 +72,6 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="cuA-Eh-TkP"/>
-                                            <constraint firstAttribute="height" constant="24" id="e3W-4o-uT7"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="63p-qi-OcL">
@@ -91,7 +89,6 @@
                                         <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="24" id="DaP-OT-lYg"/>
-                                            <constraint firstAttribute="height" constant="24" id="cpk-TF-9yb"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqW-bV-yHr">
@@ -113,7 +110,7 @@
                         <rect key="frame" x="95.5" y="273.5" width="18" height="18"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="18" id="6KF-To-yWi"/>
-                            <constraint firstAttribute="height" constant="18" id="IeI-qi-pnl"/>
+                            <constraint firstAttribute="width" secondItem="SXl-Ls-Qsz" secondAttribute="height" multiplier="1:1" id="fx5-zr-XdG"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VDj-1w-jyf">
@@ -146,7 +143,7 @@
                         <rect key="frame" x="24" y="273.5" width="18" height="18"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="18" id="4So-UZ-W8E"/>
-                            <constraint firstAttribute="height" constant="18" id="hHE-FG-uuR"/>
+                            <constraint firstAttribute="width" secondItem="Bkm-gK-Pca" secondAttribute="height" multiplier="1:1" id="d6q-Kk-QX9"/>
                         </constraints>
                     </imageView>
                 </subviews>
@@ -187,21 +184,34 @@
             <connections>
                 <outlet property="backgroundImageView" destination="D6t-Nc-4xH" id="qAU-7F-EMV"/>
                 <outlet property="birthLabel" destination="aik-Vi-yux" id="QTx-yd-LoY"/>
+                <outlet property="birthdayImageTop" destination="fn8-0D-X5B" id="amS-gL-5xK"/>
+                <outlet property="birthdayImageWidth" destination="4So-UZ-W8E" id="94j-k2-dJK"/>
+                <outlet property="descLabelTop" destination="W5z-RH-cOC" id="xj8-gL-2u3"/>
                 <outlet property="descriptionLabel" destination="VDj-1w-jyf" id="YqY-uP-XQV"/>
                 <outlet property="instagramIDLabel" destination="8oi-jO-fkf" id="eIE-ch-cCT"/>
                 <outlet property="instagramImageView" destination="TXF-fP-7YQ" id="CVp-bU-T3I"/>
+                <outlet property="instagramImageWidth" destination="CMJ-4p-lae" id="dKg-R6-HQW"/>
                 <outlet property="instagramStackView" destination="D6j-Cz-d99" id="1ZU-Be-asB"/>
                 <outlet property="linkURLImageView" destination="el0-x0-WD9" id="kWS-T3-Urt"/>
                 <outlet property="linkURLLabel" destination="LqW-bV-yHr" id="vD7-qs-hSc"/>
                 <outlet property="linkURLStackView" destination="7Qd-rb-YOy" id="6Xj-PV-blN"/>
+                <outlet property="mbtiImageLeading" destination="m7i-2Q-RNF" id="Z1w-VQ-5fY"/>
                 <outlet property="mbtiLabel" destination="eyB-c0-PQB" id="waJ-j4-tRM"/>
+                <outlet property="phoneImageWidth" destination="cuA-Eh-TkP" id="rVv-jC-y39"/>
                 <outlet property="phoneNumberImageView" destination="GXK-3x-QiF" id="Tyz-f0-Cy3"/>
                 <outlet property="phoneNumberLabel" destination="63p-qi-OcL" id="iYB-x9-hze"/>
                 <outlet property="phoneNumberStackView" destination="32s-jO-RgD" id="hmB-xr-kck"/>
                 <outlet property="shareButton" destination="aAt-PF-ce3" id="tNu-aM-Dsc"/>
                 <outlet property="titleLabel" destination="OeE-mZ-GcL" id="NIa-Yu-Bit"/>
+                <outlet property="titleLabelLeading" destination="kch-bF-wdy" id="Z0K-Pr-5lE"/>
+                <outlet property="titleLabelTop" destination="4yZ-WV-dW5" id="3V4-3L-GH1"/>
                 <outlet property="totalStackView" destination="AFF-gP-nt6" id="rwP-ON-N2U"/>
+                <outlet property="totalStackViewBottom" destination="NGu-mr-hGB" id="hHi-sL-Qrf"/>
+                <outlet property="totalStackViewLeading" destination="0o3-TT-y9X" id="ecD-8J-M2a"/>
+                <outlet property="totalStackViewTrailing" destination="TlW-CK-hkZ" id="7gj-eC-bN9"/>
+                <outlet property="urlImageWidth" destination="DaP-OT-lYg" id="BAp-0g-2tP"/>
                 <outlet property="userNameLabel" destination="cO6-DY-EUn" id="8AO-3c-DDH"/>
+                <outlet property="usernameLabelTop" destination="025-5i-Sid" id="7uz-Tx-JPp"/>
             </connections>
             <point key="canvasLocation" x="281.8840579710145" y="226.33928571428569"/>
         </collectionViewCell>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
@@ -196,6 +196,7 @@
                 <outlet property="linkURLLabel" destination="LqW-bV-yHr" id="vD7-qs-hSc"/>
                 <outlet property="linkURLStackView" destination="7Qd-rb-YOy" id="6Xj-PV-blN"/>
                 <outlet property="mbtiImageLeading" destination="m7i-2Q-RNF" id="Z1w-VQ-5fY"/>
+                <outlet property="mbtiImageWidth" destination="6KF-To-yWi" id="C8c-O4-epP"/>
                 <outlet property="mbtiLabel" destination="eyB-c0-PQB" id="waJ-j4-tRM"/>
                 <outlet property="phoneImageWidth" destination="cuA-Eh-TkP" id="rVv-jC-y39"/>
                 <outlet property="phoneNumberImageView" destination="GXK-3x-QiF" id="Tyz-f0-Cy3"/>

--- a/NADA-iOS-forRelease/Sources/Factory/ModuleFactory.swift
+++ b/NADA-iOS-forRelease/Sources/Factory/ModuleFactory.swift
@@ -25,7 +25,7 @@ protocol ModuleFactoryProtocol {
     func makeAroundMeVC() -> AroundMeViewController
     func makeUpdateVC() -> UpdateViewController
     func makeCardDetailVC() -> CardDetailViewController
-    func makeGroupEditVC(groupList: [Group]) -> GroupEditViewController
+    func makeGroupEditVC(groupList: [String]) -> GroupEditViewController
 }
 
 final class ModuleFactory: ModuleFactoryProtocol {
@@ -58,7 +58,7 @@ final class ModuleFactory: ModuleFactoryProtocol {
         return cardDetailVC
     }
     
-    func makeGroupEditVC(groupList: [Group]) -> GroupEditViewController {
+    func makeGroupEditVC(groupList: [String]) -> GroupEditViewController {
         let viewModel = GroupEditViewModel(groupList: groupList)
         let groupEditVC = GroupEditViewController.controllerFromStoryboard(.groupEdit)
         groupEditVC.viewModel = viewModel

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Group/CardAddInGroupRequest.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Group/CardAddInGroupRequest.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct CardAddInGroupRequest: Codable {
+    var cardGroupName: String?
     var cardUUID: String
-    var cardGroupID: Int
 }

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Group/CardListInGroupRequest.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Group/CardListInGroupRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CardListInGroupRequest: Codable {
-    var cardGroupId: Int
     var pageNo: Int
     var pageSize: Int
+    var groupName: String
 }

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Group/CardsInGroupResponse.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Group/CardsInGroupResponse.swift
@@ -19,18 +19,27 @@ struct CardsInGroupResponse: Codable {
 
 // MARK: - Cards
 struct FrontCard: Codable {
-    let birth: String
-        let cardID: Int
-        let cardImage, cardName, cardType, cardUUID: String
-        let departmentName, instagram, mailAddress, mbti: String
-        let phoneNumber, tmi, twitter, urls: String
-        let userName: String
+    let cardID: Int
+    let cardUUID, cardType, cardName, departmentName: String
+    let userName, birth, mbti, instagram: String
+    let twitter, mailAddress: String?
+    let phoneNumber: String
+    let urls: [String]
+    let cardTastes: [CardTaste]
+    let tmi: String?
+    let cardImage: String
+    let isRepresentative: Bool
 
-        enum CodingKeys: String, CodingKey {
-            case birth
-            case cardID = "cardId"
-            case cardImage, cardName, cardType
-            case cardUUID = "cardUuid"
-            case departmentName, instagram, mailAddress, mbti, phoneNumber, tmi, twitter, urls, userName
-        }
-} 
+    enum CodingKeys: String, CodingKey {
+        case cardID = "cardId"
+        case cardUUID = "cardUuid"
+        case cardType, cardName, departmentName, userName, birth, mbti, instagram, twitter, mailAddress, phoneNumber, urls, cardTastes, tmi, cardImage, isRepresentative
+    }
+}
+
+// MARK: - CardTaste
+struct CardTaste: Codable {
+    let cardTasteName: String
+    let sortOrder: Int
+    let isChoose: Bool
+}

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Group/GroupEditRequest.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Group/GroupEditRequest.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct GroupEditRequest: Codable {
-    var groupId: Int
     var groupName: String
+    var modifyGroupName: String
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
@@ -15,8 +15,8 @@ public class GroupAPI {
 
     public init() { }
     
-    func cardDeleteInGroup(groupID: Int, cardID: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        groupProvider.request(.cardDeleteInGroup(groupID: groupID, cardID: cardID)) { (result) in
+    func cardDeleteInGroup(cardUuid: String, cardGroupName: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        groupProvider.request(.cardDeleteInGroup(cardUuid: cardUuid, cardGroupName: cardGroupName)) { (result) in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
@@ -38,7 +38,7 @@ public class GroupAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 
-                let networkResult = self.judgeStatus(by: statusCode, data: data, type: [Group].self)
+                let networkResult = self.judgeStatus(by: statusCode, data: data, type: [String].self)
                 completion(networkResult)
                 
             case .failure(let err):

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
@@ -15,8 +15,8 @@ public class GroupAPI {
 
     public init() { }
     
-    func cardDeleteInGroup(cardUuid: String, cardGroupName: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        groupProvider.request(.cardDeleteInGroup(cardUuid: cardUuid, cardGroupName: cardGroupName)) { (result) in
+    func cardDeleteInGroup(cardUUID: String, cardGroupName: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        groupProvider.request(.cardDeleteInGroup(cardUUID: cardUUID, cardGroupName: cardGroupName)) { (result) in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
@@ -47,8 +47,8 @@ public class GroupAPI {
         }
     }
     
-    func groupDelete(groupID: Int, defaultGroupId: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
-        groupProvider.request(.groupDelete(groupID: groupID, defaultGroupId: defaultGroupId)) { (result) in
+    func groupDelete(cardGroupName: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        groupProvider.request(.groupDelete(cardGroupName: cardGroupName)) { (result) in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -84,9 +84,9 @@ extension GroupService: TargetType {
             return .requestJSONEncodable(groupRequest)
         case .groupEdit(let groupRequest):
             return .requestJSONEncodable(groupRequest)
-        case .cardAddInGroup(let gorupRequest):
-            return .requestParameters(parameters: ["cardGroupId": gorupRequest.cardGroupID,
-                                                   "cardUUID": gorupRequest.cardUUID],
+        case .cardAddInGroup(let groupRequest):
+            return .requestParameters(parameters: ["cardGroupName": groupRequest.cardGroupName,
+                                                   "cardUUID": groupRequest.cardUUID],
                                       encoding: JSONEncoding.default)
         case .cardListFetchInGroup(let cardListInGroupRequest):
             return .requestParameters(parameters: ["pageNo": cardListInGroupRequest.pageNo,

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -45,8 +45,8 @@ extension GroupService: TargetType {
             return "/card-group"
         case .cardAddInGroup:
             return "/card-group/mapping"
-        case .cardListFetchInGroup(let cardListInGroupRequest):
-            return "/card-group/\(cardListInGroupRequest.cardGroupId)/cards"
+        case .cardListFetchInGroup:
+            return "/card-group/cards"
         case .cardDeleteInGroup(let groupID, let cardID):
             return "/group/\(groupID)/\(cardID)"
         }
@@ -84,11 +84,12 @@ extension GroupService: TargetType {
             return .requestJSONEncodable(groupRequest)
         case .cardAddInGroup(let gorupRequest):
             return .requestParameters(parameters: ["cardGroupId": gorupRequest.cardGroupID,
-                                                   "cardUUID" : gorupRequest.cardUUID],
+                                                   "cardUUID": gorupRequest.cardUUID],
                                       encoding: JSONEncoding.default)
         case .cardListFetchInGroup(let cardListInGroupRequest):
             return .requestParameters(parameters: ["pageNo": cardListInGroupRequest.pageNo,
-                                                   "pageSize": cardListInGroupRequest.pageSize], encoding: URLEncoding.queryString)
+                                                   "pageSize": cardListInGroupRequest.pageSize,
+                                                   "groupName": cardListInGroupRequest.groupName], encoding: URLEncoding.queryString)
         }
     }
     

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -41,8 +41,10 @@ extension GroupService: TargetType {
             return "/card-group/clear"
         case .groupDelete:
             return "/card-group"
-        case .groupAdd, .groupEdit:
+        case .groupAdd:
             return "/card-group"
+        case .groupEdit:
+            return "/card-group/name"
         case .cardAddInGroup:
             return "/card-group/mapping"
         case .cardListFetchInGroup:

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -15,7 +15,7 @@ enum GroupService {
     case groupEdit(groupRequest: GroupEditRequest)
     case cardAddInGroup(cardRequest: CardAddInGroupRequest)
     case cardListFetchInGroup(cardListInGroupRequest: CardListInGroupRequest)
-    case cardDeleteInGroup(groupID: Int, cardID: String)
+    case cardDeleteInGroup(cardUuid: String, cardGroupName: String)
     case groupReset
 }
 
@@ -49,8 +49,8 @@ extension GroupService: TargetType {
             return "/card-group/mapping"
         case .cardListFetchInGroup:
             return "/card-group/cards"
-        case .cardDeleteInGroup(let groupID, let cardID):
-            return "/group/\(groupID)/\(cardID)"
+        case .cardDeleteInGroup(let cardUuid, _):
+            return "/card-group/card/\(cardUuid)"
         }
     }
     
@@ -75,8 +75,11 @@ extension GroupService: TargetType {
         switch self {
         case .groupListFetch:
             return .requestPlain
-        case .cardDeleteInGroup, .groupReset:
+        case .groupReset:
             return .requestPlain
+        case .cardDeleteInGroup(_, let cardGroupName):
+            return .requestParameters(parameters: ["cardGroupName": cardGroupName],
+                                      encoding: URLEncoding.queryString)
         case .groupDelete(let cardGroupName):
             return .requestParameters(parameters: ["cardGroupName": cardGroupName],
                                       encoding: URLEncoding.queryString)

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupService.swift
@@ -10,7 +10,7 @@ import Moya
 
 enum GroupService {
     case groupListFetch
-    case groupDelete(groupID: Int, defaultGroupId: Int)
+    case groupDelete(cardGroupName: String)
     case groupAdd(groupRequest: GroupAddRequest)
     case groupEdit(groupRequest: GroupEditRequest)
     case cardAddInGroup(cardRequest: CardAddInGroupRequest)
@@ -39,8 +39,8 @@ extension GroupService: TargetType {
             return "/card-group/list"
         case .groupReset:
             return "/card-group/clear"
-        case .groupDelete(let groupID, _):
-            return "/card-group/\(groupID)"
+        case .groupDelete:
+            return "/card-group"
         case .groupAdd, .groupEdit:
             return "/card-group"
         case .cardAddInGroup:
@@ -75,8 +75,8 @@ extension GroupService: TargetType {
             return .requestPlain
         case .cardDeleteInGroup, .groupReset:
             return .requestPlain
-        case .groupDelete(_, let defaultGroupId):
-            return .requestParameters(parameters: ["defaultGroupId": defaultGroupId],
+        case .groupDelete(let cardGroupName):
+            return .requestParameters(parameters: ["cardGroupName": cardGroupName],
                                       encoding: URLEncoding.queryString)
         case .groupAdd(let groupRequest):
             return .requestJSONEncodable(groupRequest)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
@@ -118,11 +118,11 @@ extension CardResultBottomSheetViewController {
         GroupAPI.shared.groupListFetch { response in
             switch response {
             case .success(let data):
-                if let group = data as? Groups {
+                if let groups = data as? [String] {
                     let nextVC = SelectGroupBottomSheetViewController()
                     nextVC.status = self.status
                     nextVC.cardDataModel = self.cardDataModel
-                    nextVC.serverGroups = group
+                    nextVC.serverGroups = groups
                     self.hideBottomSheetAndPresent(nextBottomSheet: nextVC, title: "그룹선택", height: 386)
                 }
             case .requestErr(let message):

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
@@ -15,7 +15,7 @@ class GroupNameEditBottomSheetViewController: CommonBottomSheetViewController, U
     // 넘어온 그룹 이름 데이터를 받는 변수 선언
     var text: String = ""
     var returnToGroupEditViewController: (() -> Void)?
-    var nowGroup: Group?
+    var nowGroup: String?
     private var bottomSheetViewTopConstraint: NSLayoutConstraint?
     
     // 그룹 추가 텍스트 필드
@@ -89,7 +89,7 @@ class GroupNameEditBottomSheetViewController: CommonBottomSheetViewController, U
 extension GroupNameEditBottomSheetViewController {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
-        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: nowGroup?.cardGroupId ?? 0, groupName: addGroupTextField.text ?? ""))
+//        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: nowGroup?.cardGroupId ?? 0, groupName: addGroupTextField.text ?? ""))
         nowHideBottomSheetAndGoBack()
         
         return true

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
@@ -90,6 +90,7 @@ extension GroupNameEditBottomSheetViewController {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
 //        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: nowGroup?.cardGroupId ?? 0, groupName: addGroupTextField.text ?? ""))
+        groupEditWithAPI(groupRequest: GroupEditRequest(groupName: nowGroup ?? "", modifyGroupName: addGroupTextField.text ?? ""))
         nowHideBottomSheetAndGoBack()
         
         return true

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
@@ -89,7 +89,6 @@ class GroupNameEditBottomSheetViewController: CommonBottomSheetViewController, U
 extension GroupNameEditBottomSheetViewController {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
-//        groupEditWithAPI(groupRequest: GroupEditRequest(groupId: nowGroup?.cardGroupId ?? 0, groupName: addGroupTextField.text ?? ""))
         groupEditWithAPI(groupRequest: GroupEditRequest(groupName: nowGroup ?? "", modifyGroupName: addGroupTextField.text ?? ""))
         nowHideBottomSheetAndGoBack()
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -82,12 +82,11 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     
     @objc func presentCardInfoViewController() {
         switch status {
-//        case .detail:
-//            changeGroupWithAPI(request: ChangeGroupRequest(cardID: cardDataModel?.cardUUID ?? "",
-//                                                           userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
-//                                                           groupID: groupName ?? 0,
-//                                                           newGroupID: selectedGroup))
-        case .add, .addWithQR, .detail:
+        case .detail:
+            cardDeleteInGroupWithAPI(cardUuid: cardDataModel?.cardUUID ?? "", cardGroupName: groupName ?? "")
+            cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardGroupName: selectedGroup,
+                                                                     cardUUID: cardDataModel?.cardUUID ?? ""))
+        case .add, .addWithQR:
             cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardGroupName: selectedGroup,
                                                                      cardUUID: cardDataModel?.cardUUID ?? ""))
         case .group:
@@ -160,25 +159,22 @@ extension SelectGroupBottomSheetViewController {
         }
     }
     
-    func changeGroupWithAPI(request: ChangeGroupRequest) {
-        // FIXME: - cardAddInGroup 으로 변경.
-//        GroupAPI.shared.changeCardGroup(request: request) { response in
-//            switch response {
-//            case .success:
-//                NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: self.selectedGroupIndex, userInfo: nil)
-//                NotificationCenter.default.post(name: Notification.Name.passDataToDetail, object: self.selectedGroup, userInfo: nil)
-//                self.makeOKAlert(title: "", message: "그룹이 변경되었습니다.") { _ in
-//                    self.hideBottomSheetAndGoBack()
-//                }
-//            case .requestErr(let message):
-//                print("changeGroupWithAPI - requestErr: \(message)")
-//            case .pathErr:
-//                print("changeGroupWithAPI - pathErr")
-//            case .serverErr:
-//                print("changeGroupWithAPI - serverErr")
-//            case .networkFail:
-//                print("changeGroupWithAPI - networkFail")
-//            }
-//        }
+    func cardDeleteInGroupWithAPI(cardUuid: String, cardGroupName: String) {
+        GroupAPI.shared.cardDeleteInGroup(cardUuid: cardUuid, cardGroupName: cardGroupName) { response in
+            switch response {
+            case .success:
+                print("cardDeleteInGroupWithAPI - success")
+                self.navigationController?.popViewController(animated: true)
+            case .requestErr(let message):
+                print("cardDeleteInGroupWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("cardDeleteInGroupWithAPI - pathErr")
+            case .serverErr:
+                print("cardDeleteInGroupWithAPI - serverErr")
+            case .networkFail:
+                print("cardDeleteInGroupWithAPI - networkFail")
+            }
+            
+        }
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/SelectGroupBottomSheetViewController.swift
@@ -11,10 +11,10 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
 
     // MARK: - Properties
     var cardDataModel: Card?
-    var serverGroups: Groups?
-    var selectedGroup = 0
+    var serverGroups: [String]?
+    var selectedGroup = ""
     var selectedGroupIndex = 0
-    var groupId: Int?
+    var groupName: String?
     
     var status: Status = .add
     
@@ -54,7 +54,7 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     private func setupUI() {
         view.addSubview(groupPicker)
         view.addSubview(doneButton)
-        selectedGroup = serverGroups?.groups[0].cardGroupId ?? 0
+        selectedGroup = serverGroups?[0] ?? ""
         groupPicker.delegate = self
         groupPicker.dataSource = self
         setupLayout()
@@ -82,14 +82,14 @@ class SelectGroupBottomSheetViewController: CommonBottomSheetViewController {
     
     @objc func presentCardInfoViewController() {
         switch status {
-        case .detail:
-            changeGroupWithAPI(request: ChangeGroupRequest(cardID: cardDataModel?.cardUUID ?? "",
-                                                           userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
-                                                           groupID: groupId ?? 0,
-                                                           newGroupID: selectedGroup))
-        case .add, .addWithQR:
-            cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardUUID: cardDataModel?.cardUUID ?? "",
-                                                                     cardGroupID: selectedGroup))
+//        case .detail:
+//            changeGroupWithAPI(request: ChangeGroupRequest(cardID: cardDataModel?.cardUUID ?? "",
+//                                                           userID: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "",
+//                                                           groupID: groupName ?? 0,
+//                                                           newGroupID: selectedGroup))
+        case .add, .addWithQR, .detail:
+            cardAddInGroupWithAPI(cardRequest: CardAddInGroupRequest(cardGroupName: selectedGroup,
+                                                                     cardUUID: cardDataModel?.cardUUID ?? ""))
         case .group:
             return
         }
@@ -103,7 +103,7 @@ extension SelectGroupBottomSheetViewController: UIPickerViewDelegate, UIPickerVi
     }
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return serverGroups?.groups.count ?? 1
+        return serverGroups?.count ?? 1
     }
 
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
@@ -112,16 +112,16 @@ extension SelectGroupBottomSheetViewController: UIPickerViewDelegate, UIPickerVi
         label.textAlignment = .center
         
         if pickerView.selectedRow(inComponent: component) == row {
-            label.attributedText = NSAttributedString(string: serverGroups?.groups[row].cardGroupName ?? "", attributes: [NSAttributedString.Key.font: UIFont.textBold01, NSAttributedString.Key.foregroundColor: UIColor.mainColorNadaMain])
+            label.attributedText = NSAttributedString(string: serverGroups?[row] ?? "", attributes: [NSAttributedString.Key.font: UIFont.textBold01, NSAttributedString.Key.foregroundColor: UIColor.mainColorNadaMain])
         } else {
-            label.attributedText = NSAttributedString(string: serverGroups?.groups[row].cardGroupName ?? "", attributes: [NSAttributedString.Key.font: UIFont.textRegular03, NSAttributedString.Key.foregroundColor: UIColor.quaternary])
+            label.attributedText = NSAttributedString(string: serverGroups?[row] ?? "", attributes: [NSAttributedString.Key.font: UIFont.textRegular03, NSAttributedString.Key.foregroundColor: UIColor.quaternary])
         }
         
         return label
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        selectedGroup = serverGroups?.groups[row].cardGroupId ?? 0
+        selectedGroup = serverGroups?[row] ?? ""
         selectedGroupIndex = row
         pickerView.reloadAllComponents()
     }
@@ -143,7 +143,7 @@ extension SelectGroupBottomSheetViewController {
                 guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.cardDetail, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardDetailViewController) as? CardDetailViewController else { return }
                 nextVC.status = self.status
                 nextVC.cardDataModel = self.cardDataModel
-                nextVC.groupId = self.selectedGroup
+                nextVC.groupName = self.selectedGroup
                 nextVC.serverGroups = self.serverGroups
                 NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: self.selectedGroupIndex, userInfo: nil)
                 self.hideBottomSheetAndPresentVC(nextViewController: nextVC)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -43,8 +43,8 @@ class CardDetailViewController: UIViewController {
     
     private var isFront = true
     var status: Status = .group
-    var serverGroups: Groups?
-    var groupId: Int?
+    var serverGroups: [String]?
+    var groupName: String?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -122,7 +122,7 @@ extension CardDetailViewController {
                         .setTitle("그룹선택")
                         .setHeight(386)
             nextVC.status = .detail
-            nextVC.groupId = self.groupId
+            nextVC.groupName = self.groupName
             nextVC.serverGroups = self.serverGroups
             nextVC.cardDataModel = self.cardDataModel
             nextVC.modalPresentationStyle = .overFullScreen
@@ -134,7 +134,7 @@ extension CardDetailViewController {
                                        message: "명함을 정말 삭제하시겠습니까?",
                                        deleteAction: { _ in
                 // 명함 삭제 서버통신
-                self.cardDeleteInGroupWithAPI(groupID: self.groupId ?? 0, cardID: self.cardDataModel?.cardUUID ?? "")
+//                self.cardDeleteInGroupWithAPI(groupID: self.groupId ?? 0, cardID: self.cardDataModel?.cardUUID ?? "")
             }) })
         let options = UIMenu(title: "options", options: .displayInline, children: [changeGroup, deleteCard])
         
@@ -212,7 +212,7 @@ extension CardDetailViewController {
     // MARK: - @objc Methods
     
     @objc func didRecieveDataNotification(_ notification: Notification) {
-        groupId = notification.object as? Int ?? 0
+        groupName = notification.object as? String ?? ""
     }
     
     @objc

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -61,8 +61,8 @@ class CardDetailViewController: UIViewController {
 }
 
 extension CardDetailViewController {
-    func cardDeleteInGroupWithAPI(cardUuid: String, cardGroupName: String) {
-        GroupAPI.shared.cardDeleteInGroup(cardUuid: cardUuid, cardGroupName: cardGroupName) { response in
+    func cardDeleteInGroupWithAPI(cardUUID: String, cardGroupName: String) {
+        GroupAPI.shared.cardDeleteInGroup(cardUUID: cardUUID, cardGroupName: cardGroupName) { response in
             switch response {
             case .success:
                 print("cardDeleteInGroupWithAPI - success")
@@ -135,7 +135,7 @@ extension CardDetailViewController {
                                        message: "명함을 정말 삭제하시겠습니까?",
                                        deleteAction: { _ in
                 // 명함 삭제 서버통신
-                self.cardDeleteInGroupWithAPI(cardUuid: self.cardDataModel?.cardUUID ?? "", cardGroupName: self.groupName ?? "")
+                self.cardDeleteInGroupWithAPI(cardUUID: self.cardDataModel?.cardUUID ?? "", cardGroupName: self.groupName ?? "")
             }) })
         let options = UIMenu(title: "options", options: .displayInline, children: [changeGroup, deleteCard])
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -45,6 +45,7 @@ class CardDetailViewController: UIViewController {
     var status: Status = .group
     var serverGroups: [String]?
     var groupName: String?
+    var cardType: String = ""
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -60,8 +61,8 @@ class CardDetailViewController: UIViewController {
 }
 
 extension CardDetailViewController {
-    func cardDeleteInGroupWithAPI(groupID: Int, cardID: String) {
-        GroupAPI.shared.cardDeleteInGroup(groupID: groupID, cardID: cardID) { response in
+    func cardDeleteInGroupWithAPI(cardUuid: String, cardGroupName: String) {
+        GroupAPI.shared.cardDeleteInGroup(cardUuid: cardUuid, cardGroupName: cardGroupName) { response in
             switch response {
             case .success:
                 print("cardDeleteInGroupWithAPI - success")
@@ -135,6 +136,7 @@ extension CardDetailViewController {
                                        deleteAction: { _ in
                 // 명함 삭제 서버통신
 //                self.cardDeleteInGroupWithAPI(groupID: self.groupId ?? 0, cardID: self.cardDataModel?.cardUUID ?? "")
+                self.cardDeleteInGroupWithAPI(cardUuid: self.cardDataModel?.cardUUID ?? "", cardGroupName: self.groupName ?? "")
             }) })
         let options = UIMenu(title: "options", options: .displayInline, children: [changeGroup, deleteCard])
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -135,7 +135,6 @@ extension CardDetailViewController {
                                        message: "명함을 정말 삭제하시겠습니까?",
                                        deleteAction: { _ in
                 // 명함 삭제 서버통신
-//                self.cardDeleteInGroupWithAPI(groupID: self.groupId ?? 0, cardID: self.cardDataModel?.cardUUID ?? "")
                 self.cardDeleteInGroupWithAPI(cardUuid: self.cardDataModel?.cardUUID ?? "", cardGroupName: self.groupName ?? "")
             }) })
         let options = UIMenu(title: "options", options: .displayInline, children: [changeGroup, deleteCard])

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -134,7 +134,9 @@ extension GroupViewController {
         cardsCollectionView.dataSource = self
          
         groupCollectionView.register(GroupCollectionViewCell.nib(), forCellWithReuseIdentifier: Const.Xib.groupCollectionViewCell)
+        cardsCollectionView.register(FrontCardCell.nib(), forCellWithReuseIdentifier: FrontCardCell.className)
         cardsCollectionView.register(FanFrontCardCell.nib(), forCellWithReuseIdentifier: FanFrontCardCell.className)
+        cardsCollectionView.register(CompanyFrontCardCell.nib(), forCellWithReuseIdentifier: CompanyFrontCardCell.className)
     }
     
     private func setUI() {
@@ -310,34 +312,32 @@ extension GroupViewController: UICollectionViewDataSource {
             }
             return groupCell
         case cardsCollectionView:
-//            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.cardInGroupCollectionViewCell, for: indexPath) as? CardInGroupCollectionViewCell else {
-//                return UICollectionViewCell()
-//            }
-            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FanFrontCardCell.className, for: indexPath) as? FanFrontCardCell else {
+            guard let frontCards = frontCards else { return UICollectionViewCell() }
+            switch frontCards[indexPath.row].cardType {
+            case "BASIC":
+                guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FrontCardCell.className, for: indexPath) as? FrontCardCell else {
+                    return UICollectionViewCell()
+                }
+                cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
+                cardCell.setConstraints()
+                return cardCell
+            case "FAN":
+                guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FanFrontCardCell.className, for: indexPath) as? FanFrontCardCell else {
+                    return UICollectionViewCell()
+                }
+                cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
+                cardCell.setConstraints()
+                return cardCell
+            case "COMPANY":
+                guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: CompanyFrontCardCell.className, for: indexPath) as? CompanyFrontCardCell else {
+                    return UICollectionViewCell()
+                }
+                cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
+//                cardCell.setConstraints()
+                return cardCell
+            default:
                 return UICollectionViewCell()
             }
-            
-            guard let frontCards = frontCards else { return UICollectionViewCell() }
-//            cardCell.backgroundImageView.updateServerImage(frontCards[indexPath.row].cardImage)
-//            cardCell.cardUUID = frontCards[indexPath.row].cardUUID
-//            cardCell.titleLabel.text = frontCards[indexPath.row].cardName
-//            cardCell.descriptionLabel.text = frontCards[indexPath.row].departmentName
-//            cardCell.userNameLabel.text = frontCards[indexPath.row].userName
-//            cardCell.birthLabel.text = frontCards[indexPath.row].birth
-//            cardCell.mbtiLabel.text = frontCards[indexPath.row].mbti
-//            cardCell.instagramIDLabel.text = frontCards[indexPath.row].instagram
-//            cardCell.lineURLLabel.text = frontCards[indexPath.row].urls
-//
-//            if frontCards[indexPath.row].instagram == "" {
-//                cardCell.instagramIcon.isHidden = true
-//            }
-//            if frontCards[indexPath.row].urls == "" {
-//                cardCell.urlIcon.isHidden = true
-//            }
-            cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
-            cardCell.setConstraints()
-            
-            return cardCell
         default:
             return UICollectionViewCell()
         }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -94,7 +94,7 @@ class GroupViewController: UIViewController {
     var serverGroups: [String]? = []
     var frontCards: [FrontCard]? = []
     var serverCardsWithBack: Card?
-    var groupName: String?
+    var groupName: String = ""
     
     var selectedRow = 0
     private var offset = 0
@@ -184,8 +184,8 @@ extension GroupViewController {
                 if let group = data as? [String] {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
-                    self.groupName = group[self.selectedRow]
-                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName ?? "미분류")) {
+                    if group[self.selectedRow] != "미분류" { self.groupName = group[self.selectedRow] }
+                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName)) {
                         if self.frontCards?.count != 0 {
                             self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
                         }
@@ -337,7 +337,7 @@ extension GroupViewController: UICollectionViewDataSource {
         switch collectionView {
         case groupCollectionView:
             selectedRow = indexPath.row
-//            groupId = serverGroups?[indexPath.row].cardGroupId
+            if selectedRow != 0 { self.groupName = serverGroups?[indexPath.row] ?? "" }
             offset = 0
             frontCards?.removeAll()
             
@@ -347,7 +347,7 @@ extension GroupViewController: UICollectionViewDataSource {
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.cardListInGroupWithAPI(cardListInGroupRequest:
-                                                CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName ?? "")) {
+                                                CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName)) {
                     self.isInfiniteScroll = true
                 }
             }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -94,7 +94,7 @@ class GroupViewController: UIViewController {
     var serverGroups: [String]? = []
     var frontCards: [FrontCard]? = []
     var serverCardsWithBack: Card?
-    var groupId: Int?
+    var groupName: String?
     
     var selectedRow = 0
     private var offset = 0
@@ -178,14 +178,14 @@ extension GroupViewController {
 
 extension GroupViewController {
     func groupListFetchWithAPI() {
-        GroupAPI.shared.groupListFetch() { response in
+        GroupAPI.shared.groupListFetch { response in
             switch response {
             case .success(let data):
                 if let group = data as? [String] {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
-//                    self.groupId = group[self.selectedRow].cardGroupId
-                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(cardGroupId: self.groupId ?? 0, pageNo: 1, pageSize: 1)) {
+                    self.groupName = group[self.selectedRow]
+                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName ?? "미분류")) {
                         if self.frontCards?.count != 0 {
                             self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
                         }
@@ -243,7 +243,7 @@ extension GroupViewController {
                     guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.cardDetail, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardDetailViewController) as? CardDetailViewController else { return }
                     
                     nextVC.cardDataModel = card
-                    nextVC.groupId = self.groupId
+//                    nextVC.groupId = self.groupId
                     // nextVC.serverGroups = self.serverGroups
                     // TODO: 고치세요
                     self.navigationController?.pushViewController(nextVC, animated: true)
@@ -347,9 +347,7 @@ extension GroupViewController: UICollectionViewDataSource {
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.cardListInGroupWithAPI(cardListInGroupRequest:
-                                                CardListInGroupRequest(cardGroupId: self.groupId ?? 0,
-                                                                       pageNo: 1,
-                                                                       pageSize: 1)) {
+                                                CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName ?? "")) {
                     self.isInfiniteScroll = true
                 }
             }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -269,11 +269,11 @@ extension GroupViewController: UICollectionViewDelegate {
                 if isInfiniteScroll {
                     isInfiniteScroll = false
                     offset += 1
-                    /*
-                    cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(userId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "", groupId: serverGroups?.groups[self.selectedRow].cardGroupId ?? -1, offset: offset)) {
+                    cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: offset,
+                                                                                          pageSize: 10,
+                                                                                          groupName: serverGroups?[self.selectedRow] ?? "")) {
                         self.isInfiniteScroll = true
                     }
-                     */
                 }
             }
         }
@@ -337,7 +337,11 @@ extension GroupViewController: UICollectionViewDataSource {
         switch collectionView {
         case groupCollectionView:
             selectedRow = indexPath.row
-            if selectedRow != 0 { self.groupName = serverGroups?[indexPath.row] ?? "" }
+            if selectedRow == 0 {
+                self.groupName = ""
+            } else {
+                self.groupName = serverGroups?[indexPath.row] ?? ""
+            }
             offset = 0
             frontCards?.removeAll()
             

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -134,7 +134,7 @@ extension GroupViewController {
         cardsCollectionView.dataSource = self
          
         groupCollectionView.register(GroupCollectionViewCell.nib(), forCellWithReuseIdentifier: Const.Xib.groupCollectionViewCell)
-        cardsCollectionView.register(FrontCardCell.nib(), forCellWithReuseIdentifier: FrontCardCell.className)
+        cardsCollectionView.register(FanFrontCardCell.nib(), forCellWithReuseIdentifier: FanFrontCardCell.className)
     }
     
     private func setUI() {
@@ -313,7 +313,7 @@ extension GroupViewController: UICollectionViewDataSource {
 //            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.cardInGroupCollectionViewCell, for: indexPath) as? CardInGroupCollectionViewCell else {
 //                return UICollectionViewCell()
 //            }
-            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FrontCardCell.className, for: indexPath) as? FrontCardCell else {
+            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FanFrontCardCell.className, for: indexPath) as? FanFrontCardCell else {
                 return UICollectionViewCell()
             }
             
@@ -335,6 +335,7 @@ extension GroupViewController: UICollectionViewDataSource {
 //                cardCell.urlIcon.isHidden = true
 //            }
             cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
+            cardCell.setConstraints()
             
             return cardCell
         default:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -91,7 +91,7 @@ class GroupViewController: UIViewController {
     @IBOutlet weak var emptyView: UIView!
     
     // 그룹 이름들을 담을 변수 생성
-    var serverGroups: [Group]? = []
+    var serverGroups: [String]? = []
     var frontCards: [FrontCard]? = []
     var serverCardsWithBack: Card?
     var groupId: Int?
@@ -181,10 +181,10 @@ extension GroupViewController {
         GroupAPI.shared.groupListFetch() { response in
             switch response {
             case .success(let data):
-                if let group = data as? [Group] {
+                if let group = data as? [String] {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
-                    self.groupId = group[self.selectedRow].cardGroupId
+//                    self.groupId = group[self.selectedRow].cardGroupId
                     self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(cardGroupId: self.groupId ?? 0, pageNo: 1, pageSize: 1)) {
                         if self.frontCards?.count != 0 {
                             self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
@@ -299,7 +299,7 @@ extension GroupViewController: UICollectionViewDataSource {
             guard let groupCell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.groupCollectionViewCell, for: indexPath) as? GroupCollectionViewCell else {
                 return UICollectionViewCell()
             }
-            groupCell.groupName.text = serverGroups?[indexPath.row].cardGroupName
+            groupCell.groupName.text = serverGroups?[indexPath.row]
             
             if indexPath.row == selectedRow {
                 collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .init())
@@ -337,7 +337,7 @@ extension GroupViewController: UICollectionViewDataSource {
         switch collectionView {
         case groupCollectionView:
             selectedRow = indexPath.row
-            groupId = serverGroups?[indexPath.row].cardGroupId
+//            groupId = serverGroups?[indexPath.row].cardGroupId
             offset = 0
             frontCards?.removeAll()
             
@@ -373,7 +373,7 @@ extension GroupViewController: UICollectionViewDelegateFlowLayout {
             guard let cell = groupCollectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.groupCollectionViewCell, for: indexPath) as? GroupCollectionViewCell else {
                 return .zero
             }
-            cell.groupName.text = serverGroups?[indexPath.row].cardGroupName
+            cell.groupName.text = serverGroups?[indexPath.row]
             cell.groupName.sizeToFit()
             width = cell.groupName.frame.width + 30
             height = collectionView.frame.size.height

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -333,7 +333,7 @@ extension GroupViewController: UICollectionViewDataSource {
                     return UICollectionViewCell()
                 }
                 cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
-//                cardCell.setConstraints()
+                cardCell.setConstraints()
                 return cardCell
             default:
                 return UICollectionViewCell()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -92,7 +92,7 @@ class GroupViewController: UIViewController {
     
     // 그룹 이름들을 담을 변수 생성
     var serverGroups: [String]? = []
-    var frontCards: [FrontCard]? = []
+    var frontCards: [Card]? = []
     var serverCardsWithBack: Card?
     var groupName: String = ""
     
@@ -134,7 +134,7 @@ extension GroupViewController {
         cardsCollectionView.dataSource = self
          
         groupCollectionView.register(GroupCollectionViewCell.nib(), forCellWithReuseIdentifier: Const.Xib.groupCollectionViewCell)
-        cardsCollectionView.register(CardInGroupCollectionViewCell.nib(), forCellWithReuseIdentifier: Const.Xib.cardInGroupCollectionViewCell)
+        cardsCollectionView.register(FrontCardCell.nib(), forCellWithReuseIdentifier: FrontCardCell.className)
     }
     
     private func setUI() {
@@ -212,7 +212,7 @@ extension GroupViewController {
                 self.activityIndicator.stopAnimating()
                 self.loadingBgView.removeFromSuperview()
                 
-                if let cards = data as? [FrontCard] {
+                if let cards = data as? [Card] {
                     self.frontCards = cards
                     if self.frontCards?.count == 0 {
                         self.emptyView.isHidden = false
@@ -243,9 +243,9 @@ extension GroupViewController {
                     guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.cardDetail, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.cardDetailViewController) as? CardDetailViewController else { return }
                     
                     nextVC.cardDataModel = card
-//                    nextVC.groupId = self.groupId
-                    // nextVC.serverGroups = self.serverGroups
-                    // TODO: 고치세요
+                    nextVC.groupName = self.groupName
+                    nextVC.serverGroups = self.serverGroups
+//                    nextVC.cardType = card.cardType 
                     self.navigationController?.pushViewController(nextVC, animated: true)
                 }
             case .requestErr(let message):
@@ -306,26 +306,31 @@ extension GroupViewController: UICollectionViewDataSource {
             }
             return groupCell
         case cardsCollectionView:
-            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.cardInGroupCollectionViewCell, for: indexPath) as? CardInGroupCollectionViewCell else {
+//            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.cardInGroupCollectionViewCell, for: indexPath) as? CardInGroupCollectionViewCell else {
+//                return UICollectionViewCell()
+//            }
+            guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FrontCardCell.className, for: indexPath) as? FrontCardCell else {
                 return UICollectionViewCell()
             }
-            guard let frontCards = frontCards else { return UICollectionViewCell() }
-            cardCell.backgroundImageView.updateServerImage(frontCards[indexPath.row].cardImage)
-            cardCell.cardUUID = frontCards[indexPath.row].cardUUID
-            cardCell.titleLabel.text = frontCards[indexPath.row].cardName
-            cardCell.descriptionLabel.text = frontCards[indexPath.row].departmentName
-            cardCell.userNameLabel.text = frontCards[indexPath.row].userName
-            cardCell.birthLabel.text = frontCards[indexPath.row].birth
-            cardCell.mbtiLabel.text = frontCards[indexPath.row].mbti
-            cardCell.instagramIDLabel.text = frontCards[indexPath.row].instagram
-            cardCell.lineURLLabel.text = frontCards[indexPath.row].urls
             
-            if frontCards[indexPath.row].instagram == "" {
-                cardCell.instagramIcon.isHidden = true
-            }
-            if frontCards[indexPath.row].urls == "" {
-                cardCell.urlIcon.isHidden = true
-            }
+            guard let frontCards = frontCards else { return UICollectionViewCell() }
+//            cardCell.backgroundImageView.updateServerImage(frontCards[indexPath.row].cardImage)
+//            cardCell.cardUUID = frontCards[indexPath.row].cardUUID
+//            cardCell.titleLabel.text = frontCards[indexPath.row].cardName
+//            cardCell.descriptionLabel.text = frontCards[indexPath.row].departmentName
+//            cardCell.userNameLabel.text = frontCards[indexPath.row].userName
+//            cardCell.birthLabel.text = frontCards[indexPath.row].birth
+//            cardCell.mbtiLabel.text = frontCards[indexPath.row].mbti
+//            cardCell.instagramIDLabel.text = frontCards[indexPath.row].instagram
+//            cardCell.lineURLLabel.text = frontCards[indexPath.row].urls
+//
+//            if frontCards[indexPath.row].instagram == "" {
+//                cardCell.instagramIcon.isHidden = true
+//            }
+//            if frontCards[indexPath.row].urls == "" {
+//                cardCell.urlIcon.isHidden = true
+//            }
+            cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
             
             return cardCell
         default:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -184,8 +184,9 @@ extension GroupViewController {
                 if let group = data as? [String] {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
+                    print("selectedRow: ", self.selectedRow)
                     if group[self.selectedRow] != "미분류" { self.groupName = group[self.selectedRow] }
-                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName)) {
+                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: 1, pageSize: 6, groupName: self.groupName)) {
                         if self.frontCards?.count != 0 {
                             self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
                         }
@@ -211,6 +212,8 @@ extension GroupViewController {
             case .success(let data):
                 self.activityIndicator.stopAnimating()
                 self.loadingBgView.removeFromSuperview()
+                // TODO: API 수정되면 밑에 리로드 지우기
+                self.cardsCollectionView.reloadData()
                 
                 if let cards = data as? [Card] {
                     self.frontCards = cards
@@ -220,6 +223,7 @@ extension GroupViewController {
                         self.emptyView.isHidden = true
                     }
                     self.cardsCollectionView.reloadData()
+                    print("✅")
                 }
                 // completion()
                 print("cardListInGroupWithAPI - success")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/VC/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/VC/GroupEditViewController.swift
@@ -106,9 +106,6 @@ extension GroupEditViewController: UITableViewDelegate {
                 self.makeCancelDeleteAlert(title: "그룹 삭제", message: "해당 그룹에 있던 명함은\n미분류 그룹으로 이동합니다.", cancelAction: { _ in
                     // 취소 눌렀을 때 액션이 들어갈 부분
                 }, deleteAction: { _ in
-//                    self.groupDeleteWithAPI(
-//                        groupID: self.serverGroups?[indexPath.row].cardGroupId ?? 0,
-//                        defaultGroupId: self.unClass ?? 0)
                     self.groupDeleteWithAPI(cardGroupName: self.serverGroups?[indexPath.row] ?? "")
                     self.groupEditTableView.reloadData()
                     NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: 0, userInfo: nil)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/VC/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/VC/GroupEditViewController.swift
@@ -109,6 +109,7 @@ extension GroupEditViewController: UITableViewDelegate {
 //                    self.groupDeleteWithAPI(
 //                        groupID: self.serverGroups?[indexPath.row].cardGroupId ?? 0,
 //                        defaultGroupId: self.unClass ?? 0)
+                    self.groupDeleteWithAPI(cardGroupName: self.serverGroups?[indexPath.row] ?? "")
                     self.groupEditTableView.reloadData()
                     NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: 0, userInfo: nil)
                 })
@@ -194,8 +195,8 @@ extension GroupEditViewController {
         }
     }
     
-    func groupDeleteWithAPI(groupID: Int, defaultGroupId: Int) {
-        GroupAPI.shared.groupDelete(groupID: groupID, defaultGroupId: defaultGroupId) { response in
+    func groupDeleteWithAPI(cardGroupName: String) {
+        GroupAPI.shared.groupDelete(cardGroupName: cardGroupName) { response in
             switch response {
             case .success:
                 print("groupDeleteWithAPI - success")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/VC/GroupEditViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/VC/GroupEditViewController.swift
@@ -19,8 +19,8 @@ class GroupEditViewController: UIViewController {
     // MARK: - Properties
     var viewModel: GroupEditViewModel!
     private let disposeBag = DisposeBag()
-    var serverGroups: [Group]?
-    var unClass: Int?
+    var serverGroups: [String]?
+    var unClass: String?
     
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var groupEditTableView: UITableView!
@@ -66,12 +66,12 @@ class GroupEditViewController: UIViewController {
             .withUnretained(self)
             .subscribe { owner, list in
                 owner.setData(groupList: list)
-                self.unClass = self.serverGroups?[0].cardGroupId
+                self.unClass = self.serverGroups?[0]
                 self.serverGroups?.remove(at: 0)
             }.disposed(by: self.disposeBag)
     }
     
-    func setData(groupList: [Group]) {
+    func setData(groupList: [String]) {
         self.serverGroups = groupList
         self.groupEditTableView.reloadData()
     }
@@ -106,9 +106,9 @@ extension GroupEditViewController: UITableViewDelegate {
                 self.makeCancelDeleteAlert(title: "그룹 삭제", message: "해당 그룹에 있던 명함은\n미분류 그룹으로 이동합니다.", cancelAction: { _ in
                     // 취소 눌렀을 때 액션이 들어갈 부분
                 }, deleteAction: { _ in
-                    self.groupDeleteWithAPI(
-                        groupID: self.serverGroups?[indexPath.row].cardGroupId ?? 0,
-                        defaultGroupId: self.unClass ?? 0)
+//                    self.groupDeleteWithAPI(
+//                        groupID: self.serverGroups?[indexPath.row].cardGroupId ?? 0,
+//                        defaultGroupId: self.unClass ?? 0)
                     self.groupEditTableView.reloadData()
                     NotificationCenter.default.post(name: Notification.Name.passDataToGroup, object: 0, userInfo: nil)
                 })
@@ -128,7 +128,7 @@ extension GroupEditViewController: UITableViewDelegate {
                 .setTitle("그룹명 변경")
                 .setHeight(184)
             nextVC.modalPresentationStyle = .overFullScreen
-            nextVC.text = serverGroups?[indexPath.row].cardGroupName ?? ""
+            nextVC.text = serverGroups?[indexPath.row] ?? ""
             nextVC.returnToGroupEditViewController = {
                 self.groupListFetchWithAPI()
             }
@@ -156,7 +156,7 @@ extension GroupEditViewController: UITableViewDataSource {
         } else {
             guard let serviceCell = tableView.dequeueReusableCell(withIdentifier: GroupEditTableViewCell.className, for: indexPath) as? GroupEditTableViewCell else { return UITableViewCell() }
             
-            serviceCell.initData(title: serverGroups?[indexPath.row].cardGroupName ?? "")
+            serviceCell.initData(title: serverGroups?[indexPath.row] ?? "")
             return serviceCell
         }
     }
@@ -165,7 +165,7 @@ extension GroupEditViewController: UITableViewDataSource {
 // MARK: - Extensions
 extension GroupEditViewController {
     func serverGroupList() {
-        self.unClass = serverGroups?[0].cardGroupId
+        self.unClass = serverGroups?[0]
         serverGroups?.remove(at: 0)
     }
 }
@@ -176,9 +176,9 @@ extension GroupEditViewController {
         GroupAPI.shared.groupListFetch { response in
             switch response {
             case .success(let data):
-                if let group = data as? [Group] {
+                if let group = data as? [String] {
                     self.serverGroups = group
-                    self.unClass = self.serverGroups?[0].cardGroupId
+                    self.unClass = self.serverGroups?[0]
                     self.serverGroups?.remove(at: 0)
                     self.groupEditTableView.reloadData()
                 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/ViewModel/GroupEditViewModel.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/GroupEdit/ViewModel/GroupEditViewModel.swift
@@ -13,7 +13,7 @@ final class GroupEditViewModel: ViewModelType {
     // MARK: - Properties
     
     private let disposeBag = DisposeBag()
-    var groupList: [Group] = []
+    var groupList: [String] = []
     
     // MARK: - Inputs
     
@@ -24,12 +24,12 @@ final class GroupEditViewModel: ViewModelType {
     // MARK: - Outputs
     
     struct Output {
-        var groupListRelay = PublishRelay<[Group]>()
+        var groupListRelay = PublishRelay<[String]>()
     }
     
     // MARK: - Initialize
     
-    init(groupList: [Group]) {
+    init(groupList: [String]) {
         self.groupList = groupList
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -293,7 +293,7 @@ extension HomeViewController {
         }
     }
     private func cardAddInGroupWithAPI(cardUUID: String, completion: @escaping () -> Void) {
-        GroupAPI.shared.cardAddInGroup(cardRequest: CardAddInGroupRequest(cardUUID: cardUUID, cardGroupID: 1)) { response in
+        GroupAPI.shared.cardAddInGroup(cardRequest: CardAddInGroupRequest(cardGroupName: nil, cardUUID: cardUUID)) { response in
             switch response {
             case .success:
                 completion()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/TabBar/TabBarViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/TabBar/TabBarViewController.swift
@@ -121,7 +121,7 @@ extension TabBarViewController {
         }
     }
     private func cardAddInGroupWithAPI(cardUUID: String, completion: @escaping () -> Void) {
-        GroupAPI.shared.cardAddInGroup(cardRequest: CardAddInGroupRequest(cardUUID: cardUUID, cardGroupID: 1)) { response in
+        GroupAPI.shared.cardAddInGroup(cardRequest: CardAddInGroupRequest(cardGroupName: nil, cardUUID: cardUUID)) { response in
             switch response {
             case .success:
                 completion()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#464

🌱 작업한 내용

- 명함 그룹 관련 수정된 API를 반영했습니다. 반영된 API는 다음과 같습니다.
- 그룹 삭제
- 그룹 안에 명함 삭제
- 명함 그룹 생성
- 명함 그룹에 카드 연결
- 명함 그룹 이름 수정
- 명함에 속한 카드 리스트 조회
- 내가 가진 명함 리스트 조회

- 이제 카드를 추가하고 명함 그룹을 조회할 수 있습니다.
- 명함 그룹 변경이 가능합니다.

- 이슈 List
- 미분류 그룹은 조회가 되지 않습니다. -> 이슈 새로파서 진행하겠습니다 서버 선생님들께도 전달했습니다.
- 그룹 삭제 API 가 살짝 이상해서 서버 선생님들께 전달했습니다.
- 그룹 안 명함 카드 레이아웃 수정중입니다. 계속 진행하겠습니다.

## 📮 관련 이슈
- Resolved: #464 
