### PR TITLE
fix: 명함만들기 뷰 아이콘 크기 수정 (#471)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationCategoryViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationCategoryViewController.swift
@@ -265,6 +265,7 @@ extension CardCreationCategoryViewController {
             make.trailing.equalToSuperview().inset(24)
             make.top.equalToSuperview().inset(11)
             make.bottom.equalToSuperview().inset(9)
+            make.width.equalTo(basicImageView.snp.height).multipliedBy(118.0 / 97.0)
         }
         
         fanBackgroundView.snp.makeConstraints { make in
@@ -282,6 +283,7 @@ extension CardCreationCategoryViewController {
             make.trailing.equalToSuperview().inset(24)
             make.top.equalToSuperview().inset(11)
             make.bottom.equalToSuperview().inset(9)
+            make.width.equalTo(fanImageView.snp.height).multipliedBy(118.0 / 97.0)
         }
         
         companyBackgroundView.snp.makeConstraints { make in
@@ -299,6 +301,7 @@ extension CardCreationCategoryViewController {
             make.trailing.equalToSuperview().inset(24)
             make.top.equalToSuperview().inset(11)
             make.bottom.equalToSuperview().inset(9)
+            make.width.equalTo(companyImageView.snp.height).multipliedBy(118.0 / 97.0)
         }
         
         checkMarkImageView.snp.makeConstraints { make in


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #471
🌱 작업한 내용
- 아이콘이 찌부된다는 qa 해결
- 비율로 대응했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|13 mini|<img src="https://user-images.githubusercontent.com/69136340/235733707-9c819b69-c719-408c-b179-0a1f443f9bf5.png" width ="250">|
|14 pro max|<img src="https://user-images.githubusercontent.com/69136340/235733733-f1efa153-0403-4d0d-b9b1-8af457bde88f.png" width ="250">|
## 📮 관련 이슈
- Resolved: #471
