### PR TITLE
fix: 명함 뒷면 tmi 폰트 색상 변경 (#472)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -57,7 +57,7 @@ extension BackCardCell {
         tmiTitleLabel.textColor = .white
         
         tmiLabel.font = .textRegular04
-        tmiLabel.textColor = .background
+        tmiLabel.textColor = .white
         tmiLabel.numberOfLines = 0
     }
     


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #472

🌱 작업한 내용
- 명함 뒷면 tmi 폰트 색상 변경

## 📮 관련 이슈
- Resolved: #472
