### PR TITLE
fix: 명함 앞면 url 줄 수 변경 (#475)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
@@ -92,7 +92,7 @@ extension CompanyFrontCardCell {
         phoneNumberLabel.lineBreakMode = .byTruncatingTail
         linkURLLabel.font = .textRegular04
         linkURLLabel.textColor = .white
-        linkURLLabel.numberOfLines = 2
+        linkURLLabel.numberOfLines = 1
         linkURLLabel.lineBreakMode = .byTruncatingTail
         
         linkURLStackView.alignment = .center

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
@@ -104,9 +104,9 @@
                             </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D6j-Cz-d99" secondAttribute="trailing" constant="20" id="Frl-ja-0Kb"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D6j-Cz-d99" secondAttribute="trailing" id="Frl-ja-0Kb"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7Qd-rb-YOy" secondAttribute="trailing" id="Oqw-oH-SoH"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="32s-jO-RgD" secondAttribute="trailing" constant="20" id="p6L-xc-Oo3"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="32s-jO-RgD" secondAttribute="trailing" id="p6L-xc-Oo3"/>
                         </constraints>
                     </stackView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconMbti" translatesAutoresizingMaskIntoConstraints="NO" id="SXl-Ls-Qsz">

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -80,11 +80,11 @@ extension FanFrontCardCell {
         snsLabel.lineBreakMode = .byTruncatingTail
         firstURLLabel.font = .textRegular04
         firstURLLabel.textColor = .white
-        firstURLLabel.numberOfLines = 2
+        firstURLLabel.numberOfLines = 1
         firstURLLabel.lineBreakMode = .byTruncatingTail
         secondURLLabel.font = .textRegular04
         secondURLLabel.textColor = .white
-        secondURLLabel.numberOfLines = 2
+        secondURLLabel.numberOfLines = 1
         secondURLLabel.lineBreakMode = .byTruncatingTail
         
         firstURLStackView.alignment = .center

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
@@ -98,9 +98,9 @@
                             </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D6j-Cz-d99" secondAttribute="trailing" constant="20" id="Frl-ja-0Kb"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D6j-Cz-d99" secondAttribute="trailing" id="Frl-ja-0Kb"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7Qd-rb-YOy" secondAttribute="trailing" id="Oqw-oH-SoH"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="32s-jO-RgD" secondAttribute="trailing" constant="20" id="p6L-xc-Oo3"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="32s-jO-RgD" secondAttribute="trailing" id="p6L-xc-Oo3"/>
                         </constraints>
                     </stackView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cO6-DY-EUn">

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -91,7 +91,7 @@ extension FrontCardCell {
         phoneNumberLabel.lineBreakMode = .byTruncatingTail
         linkURLLabel.font = .textRegular04
         linkURLLabel.textColor = .white
-        linkURLLabel.numberOfLines = 2
+        linkURLLabel.numberOfLines = 1
         linkURLLabel.lineBreakMode = .byTruncatingTail
         
         linkURLStackView.alignment = .center

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
@@ -101,9 +101,9 @@
                             </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D6j-Cz-d99" secondAttribute="trailing" constant="20" id="Frl-ja-0Kb"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D6j-Cz-d99" secondAttribute="trailing" id="Frl-ja-0Kb"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7Qd-rb-YOy" secondAttribute="trailing" id="Oqw-oH-SoH"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="32s-jO-RgD" secondAttribute="trailing" constant="20" id="p6L-xc-Oo3"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="32s-jO-RgD" secondAttribute="trailing" id="p6L-xc-Oo3"/>
                         </constraints>
                     </stackView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconMbti" translatesAutoresizingMaskIntoConstraints="NO" id="SXl-Ls-Qsz">


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #475

🌱 작업한 내용
- url 두 줄에서 한 줄로 수정하였습니다.
- stack view 내부의 우측간격은 0이상으로 설정.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함 앞면|<img src="https://user-images.githubusercontent.com/69136340/235737292-e5fb5d7c-a715-4cfd-892d-13790224272a.png" width ="250">|

## 📮 관련 이슈
- Resolved: #475
