### PR TITLE
fix: 명함 앞면으로 다시금 뒤집을 때 선택사항 아이콘이 노출 수정 (#481)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -227,13 +227,7 @@ extension CardDetailViewController {
             cardView.addSubview(backCard)
             isFront = false
         } else {
-            guard let frontCard = FrontCardCell.nib().instantiate(withOwner: self, options: nil).first as? FrontCardCell else { return }
-            
-            frontCard.frame = CGRect(x: 0, y: 0, width: cardView.frame.width, height: cardView.frame.height)
-            guard let cardDataModel = cardDataModel else { return }
-            frontCard.initCellFromServer(cardData: cardDataModel, isShareable: isShareable)
-            
-            cardView.addSubview(frontCard)
+            setFrontCard()
             isFront = true
         }
         if swipeGesture.direction == .right {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #481

🌱 작업한 내용
- 명함 상세 뷰에서 front card 를 뒤집을 때 기본 명함으로 뒤집어서 나오는 에러였습니다!
- setFrontCard 메서드를 사용하였습니다

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함 상세|<img src="https://user-images.githubusercontent.com/69136340/235751772-78daaefc-d08d-4b10-9345-c50ed58f3cd1.mp4" width ="250">|

## 📮 관련 이슈
- Resolved: #481
