### PR TITLE
fix: 온보딩 로티 매번 스크롤마다 재생으로 수정 (#483)

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -22,6 +22,7 @@ extension Notification.Name {
     static let creationReloadMainCardSwiper = Notification.Name("creationReloadMainCardSwiper")
     static let dismissQRCodeCardResult = Notification.Name("dismissQRCodeCardResult")
     static let scrollToSecondIndex = Notification.Name("scrollToSecondIndex")
+    static let scrollToFirstIndex = Notification.Name("scrollToFirstIndex")
     static let presentMail = Notification.Name("presentMail")
     static let presentDynamicLink = Notification.Name("presentDynamicLink")
 }

--- a/NADA-iOS-forRelease/Sources/Cells/Onboarding/OnboardingCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/Onboarding/OnboardingCollectionViewCell.swift
@@ -84,17 +84,21 @@ extension OnboardingCollectionViewCell {
     }
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(playOnboardingSecondLottieView), name: .scrollToSecondIndex, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(playOnboardingFirstLottieView), name: .scrollToFirstIndex, object: nil)
     }
     
     // MARK: - @objc Methods
     
     @objc
+    func playOnboardingFirstLottieView() {
+        onboardingFirstLottieView.stop()
+        onboardingFirstLottieView.play()
+    }
+    
+    @objc
     func playOnboardingSecondLottieView() {
-        if playSecondOnboardingLottie {
-            onboardingSecondLottieView.play()
-        }
-        playSecondOnboardingLottie = false
-        print("playOnboardingSecondLottieView")
+        onboardingSecondLottieView.stop()
+        onboardingSecondLottieView.play()
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -74,6 +74,10 @@ extension OnboardingViewController: UICollectionViewDelegate {
             offset = CGPoint(x: CGFloat.zero, y: currentIndex * (Size.cellHeigth + Size.cellLineSpacing) - Size.topSafeArea)
         }
         
+        if currentIndex == 0 {
+            NotificationCenter.default.post(name: .scrollToFirstIndex, object: nil)
+        }
+        
         if currentIndex == 1 {
             NotificationCenter.default.post(name: .scrollToSecondIndex, object: nil)
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #483 

🌱 작업한 내용
- 온보딩 로티 매번 스크롤마다 재생으로 수정 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|온보딩|<img src= "https://user-images.githubusercontent.com/69136340/235833269-1a604316-5865-4d9e-9df0-a934208295c0.mov" width ="250">|

## 📮 관련 이슈
- Resolved: #483
