### PR TITLE
feat: 위젯 타겟을 15.0으로 낮추고 대응하기(#512)

### DIFF
--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -2007,7 +2007,7 @@
 				INFOPLIST_FILE = Widgets/Resource/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Widgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2041,7 +2041,7 @@
 				INFOPLIST_FILE = Widgets/Resource/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Widgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2073,7 +2073,7 @@
 				INFOPLIST_FILE = IntentsExtensionUI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = IntentsExtensionUI;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2105,7 +2105,7 @@
 				INFOPLIST_FILE = IntentsExtensionUI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = IntentsExtensionUI;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2138,7 +2138,7 @@
 				INFOPLIST_FILE = IntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = IntentsExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2171,7 +2171,7 @@
 				INFOPLIST_FILE = IntentsExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = IntentsExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2322,6 +2322,7 @@
 				DEVELOPMENT_TEAM = T3VFJ764ZC;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T3VFJ764ZC;
 				INFOPLIST_FILE = "NADA-iOS-forRelease/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2351,6 +2352,7 @@
 				DEVELOPMENT_TEAM = T3VFJ764ZC;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T3VFJ764ZC;
 				INFOPLIST_FILE = "NADA-iOS-forRelease/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Widgets/WidgetsBundle/OpenAppLockScreenWidget.swift
+++ b/Widgets/WidgetsBundle/OpenAppLockScreenWidget.swift
@@ -37,6 +37,7 @@ struct OpenAppLockScreenEntry: TimelineEntry {
     let date: Date
 }
 
+@available(iOSApplicationExtension 16.0, *)
 struct OpenAppLockScreenEntryView: View {
     var entry: OpenAppLockScreenProvider.Entry
     @Environment(\.widgetFamily) var widgetFamily
@@ -55,6 +56,7 @@ struct OpenAppLockScreenEntryView: View {
     }
 }
 
+@available(iOSApplicationExtension 16.0, *)
 struct OpenAppLockScreenWidget: Widget {
     let kind: String = "OpenAppLockScreen"
     
@@ -69,6 +71,7 @@ struct OpenAppLockScreenWidget: Widget {
     }
 }
 
+@available(iOSApplicationExtension 16.0, *)
 struct OpenAppLockScreenWidget_Previews: PreviewProvider {
     static var previews: some View {
         OpenAppLockScreenEntryView(entry: OpenAppLockScreenEntry(date: Date()))

--- a/Widgets/WidgetsBundle/QRCodeWidget.swift
+++ b/Widgets/WidgetsBundle/QRCodeWidget.swift
@@ -42,15 +42,22 @@ struct QRCodeEntryView: View {
     @Environment(\.widgetFamily) var widgetFamily
     
     var body: some View {
-        switch widgetFamily {
-        case .accessoryCircular:
-            ZStack {
-                AccessoryWidgetBackground()
-                Image("widgetQrLockscreenWhite")
+        if #available(iOSApplicationExtension 16.0, *) {
+            switch widgetFamily {
+            case .accessoryCircular:
+                ZStack {
+                    AccessoryWidgetBackground()
+                    Image("widgetQrLockscreenWhite")
+                        .resizable()
+                        .widgetURL(URL(string: "openQRCodeWidget"))
+                }
+            default:
+                Image("widgetQr")
                     .resizable()
+                    .scaledToFill()
                     .widgetURL(URL(string: "openQRCodeWidget"))
             }
-        default:
+        } else {
             Image("widgetQr")
                 .resizable()
                 .scaledToFill()
@@ -60,6 +67,14 @@ struct QRCodeEntryView: View {
 }
 
 struct QRCodeWidget: Widget {
+    private let supportedFamilies: [WidgetFamily] = {
+        if #available(iOSApplicationExtension 16.0, *) {
+            return [.systemSmall, .accessoryCircular]
+        } else {
+            return [.systemSmall]
+        }
+    }()
+    
     let kind: String = "QRCodeWidget"
     
     var body: some WidgetConfiguration {
@@ -69,7 +84,7 @@ struct QRCodeWidget: Widget {
         }
         .configurationDisplayName("QR Code 위젯")
         .description("QR Code 를 인식할 수 있도록 카메라로 빠르게 접근합니다.")
-        .supportedFamilies([.systemSmall, .accessoryCircular])
+        .supportedFamilies(supportedFamilies)
     }
 }
 
@@ -77,7 +92,9 @@ struct QRCodeWidget_Previews: PreviewProvider {
     static var previews: some View {
         QRCodeEntryView(entry: QRCodeEntry(date: Date()))
             .previewContext(WidgetPreviewContext(family: .systemSmall))
-        QRCodeEntryView(entry: QRCodeEntry(date: Date()))
-            .previewContext(WidgetPreviewContext(family: .accessoryCircular))
+        if #available(iOSApplicationExtension 16.0, *) {
+            QRCodeEntryView(entry: QRCodeEntry(date: Date()))
+                .previewContext(WidgetPreviewContext(family: .accessoryCircular))
+        }
     }
 }

--- a/Widgets/WidgetsBundle/WidgetsBundle.swift
+++ b/Widgets/WidgetsBundle/WidgetsBundle.swift
@@ -11,10 +11,10 @@ import SwiftUI
 @main
 struct WidgetsBundle: WidgetBundle {
     var body: some Widget {
-        MyCardWidget()
         if #available(iOSApplicationExtension 16.0, *) {
-            OpenAppLockScreenWidget()
+            return WidgetBundleBuilder.buildBlock(MyCardWidget(), OpenAppLockScreenWidget(), QRCodeWidget())
+        } else {
+            return WidgetBundleBuilder.buildBlock(MyCardWidget(), QRCodeWidget())
         }
-        QRCodeWidget()
     }
 }

--- a/Widgets/WidgetsBundle/WidgetsBundle.swift
+++ b/Widgets/WidgetsBundle/WidgetsBundle.swift
@@ -12,8 +12,9 @@ import SwiftUI
 struct WidgetsBundle: WidgetBundle {
     var body: some Widget {
         MyCardWidget()
-        OpenAppLockScreenWidget()
+        if #available(iOSApplicationExtension 16.0, *) {
+            OpenAppLockScreenWidget()
+        }
         QRCodeWidget()
-        WidgetsLiveActivity()
     }
 }

--- a/Widgets/WidgetsBundle/WidgetsLiveActivity.swift
+++ b/Widgets/WidgetsBundle/WidgetsLiveActivity.swift
@@ -9,6 +9,7 @@ import ActivityKit
 import WidgetKit
 import SwiftUI
 
+@available(iOSApplicationExtension 16.2, *)
 struct WidgetsAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
         // Dynamic stateful properties about your activity go here!
@@ -19,6 +20,7 @@ struct WidgetsAttributes: ActivityAttributes {
     var name: String
 }
 
+@available(iOSApplicationExtension 16.2, *)
 struct WidgetsLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: WidgetsAttributes.self) { context in
@@ -56,6 +58,7 @@ struct WidgetsLiveActivity: Widget {
     }
 }
 
+@available(iOSApplicationExtension 16.2, *)
 struct WidgetsLiveActivity_Previews: PreviewProvider {
     static let attributes = WidgetsAttributes(name: "Me")
     static let contentState = WidgetsAttributes.ContentState(value: 3)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #512

🌱 작업한 내용
- 메인 앱 타겟의 최소 버전과 동일하게 widget 최소지원버전 15.0으로 낮추기
    - intents extension 도 낮추었습니다.

@yj607 윤쌤도 오셔서 보세여~
스샷은 상단에 기기의 버전정보가 나옵디다~

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|iOS 버전 별 위젯|<img width="800" alt="3" src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/8d0c44bb-f3e3-45ed-91e7-b1d19709b13d">|


## 📮 관련 이슈
- Resolved: #512
