### PR TITLE
fix: 2차 QA 수정 사항 #501

### DIFF
--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -2318,7 +2318,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = T3VFJ764ZC;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T3VFJ764ZC;
 				INFOPLIST_FILE = "NADA-iOS-forRelease/Info.plist";
@@ -2347,7 +2347,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = T3VFJ764ZC;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T3VFJ764ZC;
 				INFOPLIST_FILE = "NADA-iOS-forRelease/Info.plist";

--- a/NADA-iOS-forRelease/Info.plist
+++ b/NADA-iOS-forRelease/Info.plist
@@ -52,10 +52,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>QR코드를 인식하여 명함을 추가하기 위해 카메라 권한 허용이 필요해요.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>"사용자의 위치를 받아오려고 합니다."</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>"사용자의 위치를 받아오려고 합니다."</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>명함을 이미지로 저장하기 위해 갤러리 권한 허용이 필요해요.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -25,4 +25,5 @@ extension Notification.Name {
     static let scrollToFirstIndex = Notification.Name("scrollToFirstIndex")
     static let presentMail = Notification.Name("presentMail")
     static let presentDynamicLink = Notification.Name("presentDynamicLink")
+    static let backToHome = Notification.Name("backToHome")
 }

--- a/NADA-iOS-forRelease/Sources/NetworkModel/Util/HarmonyResponse.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkModel/Util/HarmonyResponse.swift
@@ -12,16 +12,22 @@ import Lottie
 
 // MARK: - HarmonyResponse
 struct HarmonyResponse: Codable {
-    let harmony: Int
+    let mbtiGrade: Double
+    let constellationGrade: Double
+    let totalGrade: Double
     
     enum CodingKeys: String, CodingKey {
-        case harmony
+        case mbtiGrade
+        case constellationGrade
+        case totalGrade
     }
 }
 
 struct HarmonyData {
     let lottie: Int
-    let score: Double
+    let mbtiGrade: Double
+    let constellationGrade: Double
+    let totalGrade: Double
     let color: UIColor
     let description: String
     let cardtype: String

--- a/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Group/GroupAPI.swift
@@ -152,7 +152,11 @@ public class GroupAPI {
         
         switch statusCode {
         case 200:
-            return .success(decodedData.data ?? "None-Data")
+            if decodedData.status == 400 {
+                return .requestErr(decodedData.message ?? "error message")
+            } else {
+                return .success(decodedData.data ?? "None-Data")
+            }
         case 400..<500:
             return .requestErr(decodedData.message ?? "error message")
         case 500:

--- a/NADA-iOS-forRelease/Sources/NetworkService/Util/UtilAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Util/UtilAPI.swift
@@ -22,7 +22,7 @@ public class UtilAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 
-                let networkResult = self.judgeStatus(by: statusCode, data: data, type: Double.self)
+                let networkResult = self.judgeStatus(by: statusCode, data: data, type: HarmonyResponse.self)
                 completion(networkResult)
                 
             case .failure(let err):

--- a/NADA-iOS-forRelease/Sources/ViewControllers/AroundMe/VC/AroundMeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/AroundMe/VC/AroundMeViewController.swift
@@ -115,17 +115,7 @@ extension AroundMeViewController {
     private func setLocationManager() {
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
-        locationManager.requestWhenInUseAuthorization()
-        
-        DispatchQueue.global().async {
-            if CLLocationManager.locationServicesEnabled() {
-                print("location on")
-                self.locationManager.startUpdatingLocation()
-                print(self.locationManager.location?.coordinate)
-            } else {
-                print("location off")
-            }
-        }
+        locationManager.requestLocation()
     }
     
     private func setDelegate() {
@@ -239,6 +229,8 @@ extension AroundMeViewController {
                     print(cards)
                     if cards.isEmpty {
                         self.aroundMeCollectionView.isHidden = true
+                    } else {
+                        self.aroundMeCollectionView.isHidden = false
                     }
                     self.aroundMeCollectionView.reloadData()
                 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/AroundMe/VC/AroundMeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/AroundMe/VC/AroundMeViewController.swift
@@ -73,6 +73,10 @@ final class AroundMeViewController: UIViewController {
         bindViewModels()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.post(name: .backToHome, object: nil, userInfo: nil)
+    }
 }
 
 extension AroundMeViewController {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/ReceiveCardBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/ReceiveCardBottomSheetViewController.swift
@@ -54,6 +54,10 @@ class ReceiveCardBottomSheetViewController: CommonBottomSheetViewController {
         bindActions()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.post(name: .backToHome, object: nil, userInfo: nil)
+    }
 }
 
 extension ReceiveCardBottomSheetViewController {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -83,7 +83,7 @@ extension CardDetailViewController {
         UtilAPI.shared.cardHarmonyFetch(cardUUID: cardUUID) { response in
             switch response {
             case .success(let data):
-                if let harmony = data as? Double {
+                if let harmony = data as? HarmonyResponse {
                     let nextVC = NewCardHarmonyViewController()
                     nextVC.harmonyData = self.updateHarmony(percentage: harmony, cardtype: self.cardDataModel?.cardType ?? "BASIC")
                     nextVC.modalPresentationStyle = .overFullScreen
@@ -185,25 +185,31 @@ extension CardDetailViewController {
         swipeRightGestureRecognizer.direction = .right
         self.cardView.addGestureRecognizer(swipeRightGestureRecognizer)
     }
-    private func updateHarmony(percentage: Double, cardtype: String) -> HarmonyData {
-        switch percentage {
+    private func updateHarmony(percentage: HarmonyResponse, cardtype: String) -> HarmonyData {
+        switch percentage.totalGrade {
         case 0 ... 20:
-            return HarmonyData(lottie: 0, score: percentage,
+            return HarmonyData(lottie: 0, mbtiGrade: percentage.mbtiGrade, constellationGrade: percentage.constellationGrade,
+                               totalGrade: percentage.totalGrade,
                                color: .harmonyRed, description: "좀 더 친해지길 바라..😅", cardtype: cardtype)
         case 21 ... 40:
-            return HarmonyData(lottie: 21, score: percentage,
+            return HarmonyData(lottie: 21, mbtiGrade: percentage.mbtiGrade, constellationGrade: percentage.constellationGrade,
+                               totalGrade: percentage.totalGrade,
                                color: .harmonyOrange, description: "마음만은 찰떡궁합!🙃", cardtype: cardtype)
         case 41 ... 60:
-            return HarmonyData(lottie: 41, score: percentage,
+            return HarmonyData(lottie: 41, mbtiGrade: percentage.mbtiGrade, constellationGrade: percentage.constellationGrade,
+                               totalGrade: percentage.totalGrade,
                                color: .harmonyGreen, description: "이 정도면 제법 친한 사이😛", cardtype: cardtype)
         case 61 ... 80:
-            return HarmonyData(lottie: 61, score: percentage,
+            return HarmonyData(lottie: 61, mbtiGrade: percentage.mbtiGrade, constellationGrade: percentage.constellationGrade,
+                               totalGrade: percentage.totalGrade,
                                color: .harmonyYellow, description: "우리 사이 척하면 척!😝", cardtype: cardtype)
         case 81 ... 100:
-            return HarmonyData(lottie: 81, score: percentage,
+            return HarmonyData(lottie: 81, mbtiGrade: percentage.mbtiGrade, constellationGrade: percentage.constellationGrade,
+                               totalGrade: percentage.totalGrade,
                                color: .harmonyPurple, description: "더할 나위 없이 완벽한 사이!😍", cardtype: cardtype)
         default:
-            return HarmonyData(lottie: 0, score: percentage,
+            return HarmonyData(lottie: 0, mbtiGrade: percentage.mbtiGrade, constellationGrade: percentage.constellationGrade,
+                               totalGrade: percentage.totalGrade,
                                color: .harmonyRed, description: "", cardtype: "BASIC")
         }
    

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/NewCardHarmonyViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/NewCardHarmonyViewController.swift
@@ -281,11 +281,11 @@ extension NewCardHarmonyViewController {
                     UIView.animate(withDuration: 0.6, delay: 1.0, animations: {
                         self.nadaDescLabel.alpha = 1
                     }, completion: { _ in
-                        UIView.animate(withDuration: 10.0, delay: 1.5, animations: {
+                        UIView.animate(withDuration: 4.0, delay: 1.5, animations: {
                             lottie.isHidden = false
                             lottie.play()
                         }, completion: { _ in
-                            UIView.animate(withDuration: 0.6, delay: 1.0, animations: {
+                            UIView.animate(withDuration: 6.0, delay: 0.5, animations: {
                                 self.scoreTitleLabel.alpha = 1
                                 self.scoreDescLabel.alpha = 1
                             })

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/NewCardHarmonyViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/NewCardHarmonyViewController.swift
@@ -144,7 +144,9 @@ extension NewCardHarmonyViewController {
         nadaHarmonyLottie4160.loopMode = .playOnce
         nadaHarmonyLottie6180.loopMode = .playOnce
         nadaHarmonyLottie81100.loopMode = .playOnce
-        scoreTitleLabel.text = "우리 궁합은 \(harmonyData?.score ?? 00)점!"
+        mbtiScoreLabel.text = "\(harmonyData?.mbtiGrade ?? 00)점"
+        starScoreLabel.text = "\(harmonyData?.constellationGrade ?? 00)점"
+        scoreTitleLabel.text = "우리 궁합은 \(harmonyData?.totalGrade ?? 00)점!"
         switch harmonyData?.lottie {
         case 0:
             scoreTitleLabel.textColor = harmonyData?.color
@@ -279,7 +281,7 @@ extension NewCardHarmonyViewController {
                     UIView.animate(withDuration: 0.6, delay: 1.0, animations: {
                         self.nadaDescLabel.alpha = 1
                     }, completion: { _ in
-                        UIView.animate(withDuration: 3.0, delay: 1.5, animations: {
+                        UIView.animate(withDuration: 10.0, delay: 1.5, animations: {
                             lottie.isHidden = false
                             lottie.play()
                         }, completion: { _ in

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/NewCardHarmonyViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/NewCardHarmonyViewController.swift
@@ -144,8 +144,14 @@ extension NewCardHarmonyViewController {
         nadaHarmonyLottie4160.loopMode = .playOnce
         nadaHarmonyLottie6180.loopMode = .playOnce
         nadaHarmonyLottie81100.loopMode = .playOnce
-        mbtiScoreLabel.text = "\(harmonyData?.mbtiGrade ?? 00)점"
-        starScoreLabel.text = "\(harmonyData?.constellationGrade ?? 00)점"
+        if harmonyData?.cardtype == "FAN" {
+            mbtiScoreLabel.isHidden = true
+        } else {
+            mbtiScoreLabel.isHidden = false
+            mbtiScoreLabel.text = "\(harmonyData?.mbtiGrade ?? 00)점"
+            starScoreLabel.text = "\(harmonyData?.constellationGrade ?? 00)점"
+        }
+        
         scoreTitleLabel.text = "우리 궁합은 \(harmonyData?.totalGrade ?? 00)점!"
         switch harmonyData?.lottie {
         case 0:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -72,6 +72,7 @@ final class HomeViewController: UIViewController {
         setLayout()
         bindActions()
         checkUpdateVersionAndSetting()
+        setNotification()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -297,6 +298,17 @@ extension HomeViewController {
             
             self?.present(nextVC, animated: true)
         }
+    }
+    
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(backToHome), name: .backToHome, object: nil)
+    }
+    
+    // MARK: - @objc Methods
+    
+    @objc
+    private func backToHome(_ notification: Notification) {
+        setUI()
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#501

🌱 작업한 내용
- 2차 QA 사항 수정을 완료했습니다. 수정된 사항들은 다음과 같습니다.

- 메인탭에서 명함 보내기, 명함 받기, 내 근처의 명함을 누르면 클릭된 상태로 계속 남아있네여..?(재현 영상 참고)
- 그룹 생성 시, 기존에 있는 이름으로 만들었을 때 1) 얼럿도 안 뜨고2) 생성도 안되네요
- “사용자의 위치를 받아오려고 합니다.” 워딩 변경이 필요합니다
- 애니메이션 물음표에서 최종 결과 이미지로 전환되기 전에 점수가 등장해요
- 내 근처의 명함 한번만 호출

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|파일첨부바람|

## 📮 관련 이슈
- Resolved: #490 #501 
