### PR TITLE
feat: 로그인했지만 대표 명함이 없을 때 엠티뷰 보여주기 (#523)

### DIFF
--- a/Widgets/WidgetsBundle/MyCardWidget.swift
+++ b/Widgets/WidgetsBundle/MyCardWidget.swift
@@ -61,15 +61,24 @@ struct MyCardProvider: IntentTimelineProvider {
                             let timeline = Timeline(entries: entries, policy: .atEnd)
                             completion(timeline)
                         } else {
-                            // 해당 명함이 삭제되어 없음. -> 대표 명함(첫 번째 명함)을 보여주도록 함
-                            let entry = MyCardEntry(date: entryDate,
-                                                   widgetCard: WidgetCard(cardUUID: data[0].cardUUID,
-                                                                           title: data[0].cardName,
-                                                                           userName: data[0].userName,
-                                                                           backgroundImage: fetchImage(data[0].cardImage)))
-                            entries = [entry]
-                            let timeline = Timeline(entries: entries, policy: .atEnd)
-                            completion(timeline)
+                            if data.isEmpty {
+                                // 대표 명함이 없음.
+                                let entry = MyCardEntry(date: entryDate, widgetCard: nil)
+                                entries = [entry]
+                                let timeline = Timeline(entries: entries, policy: .atEnd)
+                                completion(timeline)
+
+                            } else {
+                                // 해당 명함이 삭제되어 없음. -> 대표 명함(첫 번째 명함)을 보여주도록 함
+                                let entry = MyCardEntry(date: entryDate,
+                                                       widgetCard: WidgetCard(cardUUID: data[0].cardUUID,
+                                                                               title: data[0].cardName,
+                                                                               userName: data[0].userName,
+                                                                               backgroundImage: fetchImage(data[0].cardImage)))
+                                entries = [entry]
+                                let timeline = Timeline(entries: entries, policy: .atEnd)
+                                completion(timeline)
+                            }
                         }
                     }
                 case .failure(let error):
@@ -83,6 +92,7 @@ struct MyCardProvider: IntentTimelineProvider {
             }
         } else {
             // Configuration 로 부터 card 받지 못함.(=로그인 전 위젯 생성 시)
+            print("Configuration")
             let entry = MyCardEntry(date: entryDate, widgetCard: nil)
             entries = [entry]
             let timeline = Timeline(entries: entries, policy: .atEnd)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #523

🌱 작업한 내용
- 로그인했지만 대표 명함이 없을 때 엠티뷰 보여주기
- 구현전에는 빈 배열의 첫 번째 원소에 접근해서 위젯이 종료되었습니다.


## 📮 관련 이슈
- Resolved: #523
