### PR TITLE
fix: 네트워크 실패에 명함 공유 바텀시트 띄우지 않도록 하기 (#529)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -185,38 +185,32 @@ extension HomeViewController {
                         self?.presentToUpdateVC(with: updateNote)
                         UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.dynamicLinkCardUUID)
                     } else {
-                        if let dynamicLinkCardUUID = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.dynamicLinkCardUUID) {
-                            self?.checkDynamicLink(dynamicLinkCardUUID)
-                        }
-                        
                         if UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.openQRCodeWidget) {
                             self?.presentQRScanVC()
-                            UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openQRCodeWidget)
                         }
                         
                         if UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.openMyCardWidget),
                            let widgetCardUUID = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.widgetCardUUID) {
                             self?.presentCardShareBottomSheetVC(with: widgetCardUUID)
-                            UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openMyCardWidget)
-                            UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.widgetCardUUID)
+                        }
+                        
+                        if let dynamicLinkCardUUID = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.dynamicLinkCardUUID) {
+                            self?.checkDynamicLink(dynamicLinkCardUUID)
                         }
                     }
                 }
             } else {
-                if let dynamicLinkCardUUID = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.dynamicLinkCardUUID) {
-                    self?.checkDynamicLink(dynamicLinkCardUUID)
-                }
-                
                 if UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.openQRCodeWidget) {
                     self?.presentQRScanVC()
-                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openQRCodeWidget)
                 }
                 
                 if UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.openMyCardWidget),
                    let widgetCardUUID = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.widgetCardUUID) {
                     self?.presentCardShareBottomSheetVC(with: widgetCardUUID)
-                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openMyCardWidget)
-                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.widgetCardUUID)
+                }
+                
+                if let dynamicLinkCardUUID = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.dynamicLinkCardUUID) {
+                    self?.checkDynamicLink(dynamicLinkCardUUID)
                 }
             }
         }
@@ -263,21 +257,27 @@ extension HomeViewController {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .denied:
             makeOKCancelAlert(title: "카메라 권한이 허용되어 있지 않아요.",
-                        message: "QR코드 인식을 위해 카메라 권한이 필요합니다. 앱 설정으로 이동해 허용해 주세요.",
-                        okAction: { _ in UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)},
-                        cancelAction: nil,
-                        completion: nil)
+                              message: "QR코드 인식을 위해 카메라 권한이 필요합니다. 앱 설정으로 이동해 허용해 주세요.",
+                              okAction: { _ in UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)},
+                              cancelAction: nil,
+                              completion: {
+                UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openQRCodeWidget)
+            })
         case .authorized:
             guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.qrScan, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.qrScanViewController) as? QRScanViewController else { return }
             nextVC.modalPresentationStyle = .overFullScreen
-            self.present(nextVC, animated: true, completion: nil)
+            self.present(nextVC, animated: true) {
+                UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openQRCodeWidget)
+            }
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { granted in
                 if granted {
                     DispatchQueue.main.async {
                         guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.qrScan, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.qrScanViewController) as? QRScanViewController else { return }
                         nextVC.modalPresentationStyle = .overFullScreen
-                        self.present(nextVC, animated: true, completion: nil)
+                        self.present(nextVC, animated: true) {
+                            UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openQRCodeWidget)
+                        }
                     }
                 }
             }
@@ -297,7 +297,10 @@ extension HomeViewController {
                 nextVC.modalPresentationStyle = .overFullScreen
                 nextVC.cardDataModel = cardDataModel
                 
-                self?.present(nextVC, animated: true)
+                self?.present(nextVC, animated: true) {
+                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.openMyCardWidget)
+                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.widgetCardUUID)
+                }
             }
         }
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #529

🌱 작업한 내용
- 완전하게 공유 바텀시트 혹은 카메라가 뜬 다음에 openQRCodeWidget 과 openMyCardWidget, widgetCardUUID userdefaults 값을 지워주었습니다.
- 그리고 코드를 좀 정리해서 반복되는 코드를 지워 리펙토링하고, completion handler 에 useredefaults 지우는 작업을 작성하여서 코드 블럭에 해당 역할이 무엇인지 좀 더 집중해보도록 했습니다.
- 서버통신이 올바르지 않은 경우에(어 뭐야 되게 느리네하고 앱 종료하게 되면 해당 userdefaults 값들을 확인하고 지워주는 코드까지 실행이 안될 수도 있겠다는 생각이 듭니다) 발생하는 버그라서 일단 좀 더 지켜보고 결과적으로 서버가 불안전하면 좀 더 대응해보겠습니다.
- qa 기간동안 팔로우 하는 PR 이 될 수도 있을거 같아여

## 📮 관련 이슈
- Resolved: #529
