### PR TITLE
feat: 내 근처의 명함 로딩 뷰 추가 (#535)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/AroundMe/VC/AroundMeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/AroundMe/VC/AroundMeViewController.swift
@@ -7,8 +7,7 @@
 import UIKit
 import CoreLocation
 
-import UIKit
-
+import NVActivityIndicatorView
 import RxSwift
 import RxRelay
 import RxCocoa
@@ -59,7 +58,22 @@ final class AroundMeViewController: UIViewController {
         $0.clipsToBounds = false
         $0.backgroundColor = .background
     }
+    lazy var loadingBgView: UIView = {
+        let bgView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height))
+        bgView.backgroundColor = .loadingBackground
+        
+        return bgView
+    }()
     
+    lazy var activityIndicator: NVActivityIndicatorView = {
+        let activityIndicator = NVActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 40, height: 40),
+                                                        type: .ballBeat,
+                                                        color: .mainColorNadaMain,
+                                                        padding: .zero)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        
+        return activityIndicator
+    }()
     // MARK: - View Life Cycles
     
     override func viewDidLoad() {
@@ -71,6 +85,7 @@ final class AroundMeViewController: UIViewController {
         setRegister()
         bindActions()
         bindViewModels()
+        setActivityIndicator()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -116,6 +131,18 @@ extension AroundMeViewController {
     
     // MARK: - Methods
     
+    private func setActivityIndicator() {
+        view.addSubview(loadingBgView)
+        loadingBgView.addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        
+        activityIndicator.startAnimating()
+    }
+    
     private func setLocationManager() {
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
@@ -141,6 +168,7 @@ extension AroundMeViewController {
             .withUnretained(self)
             .subscribe { owner, _ in
                 owner.makeVibrate(degree: .medium)
+                owner.setActivityIndicator()
                 owner.cardNearByFetchWithAPI(longitude: self.longitude, latitude: self.latitude)
             }.disposed(by: self.disposeBag)
     }
@@ -228,6 +256,8 @@ extension AroundMeViewController {
         NearbyAPI.shared.cardNearByFetch(longitde: longitude, latitude: latitude) { response in
             switch response {
             case .success(let data):
+                self.activityIndicator.stopAnimating()
+                self.loadingBgView.removeFromSuperview()
                 if let cards = data as? [AroundMeResponse] {
                     self.cardsNearBy = cards
                     print(cards)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#535

🌱 작업한 내용
- 내 근처의 명함 뷰에서 무한으로 불러지는것을 막기 위해 로딩뷰만 추가 했습니다.
- 억울하니까 GIF.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![ezgif com-video-to-gif (3)](https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69078056/5f136a51-193e-4181-9ce2-b1307c537009)|


## 📮 관련 이슈
- Resolved: #535 
