### PR TITLE
feat: ga 세팅 및 온보딩 트래킹 (#516)

### DIFF
--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -147,6 +147,9 @@
 		F838B66E298E5C5400D84340 /* Widgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = F838B66A298E5C5300D84340 /* Widgets.intentdefinition */; };
 		F838B66F298E5C5400D84340 /* Widgets.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = F838B66A298E5C5300D84340 /* Widgets.intentdefinition */; };
 		F838B672298E5C5400D84340 /* WidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F838B65E298E5C5300D84340 /* WidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F84066E72A153274008BCE16 /* Tracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84066E62A153274008BCE16 /* Tracking.swift */; };
+		F84066E92A15333A008BCE16 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84066E82A15333A008BCE16 /* Event.swift */; };
+		F84066EB2A1533DA008BCE16 /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84066EA2A1533DA008BCE16 /* Screen.swift */; };
 		F843DD6D29A5F83000D8D20D /* CardCreationCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F843DD6C29A5F83000D8D20D /* CardCreationCategoryViewModel.swift */; };
 		F8458D6229F5183B000D53A7 /* FanCardCreation.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8458D6129F5183B000D53A7 /* FanCardCreation.storyboard */; };
 		F8458D6429F51870000D53A7 /* FanCardCreationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8458D6329F51870000D53A7 /* FanCardCreationViewController.swift */; };
@@ -423,6 +426,9 @@
 		F838B66A298E5C5300D84340 /* Widgets.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = Widgets.intentdefinition; sourceTree = "<group>"; };
 		F838B66B298E5C5400D84340 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F838B66D298E5C5400D84340 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F84066E62A153274008BCE16 /* Tracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracking.swift; sourceTree = "<group>"; };
+		F84066E82A15333A008BCE16 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
+		F84066EA2A1533DA008BCE16 /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		F843DD6C29A5F83000D8D20D /* CardCreationCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCreationCategoryViewModel.swift; sourceTree = "<group>"; };
 		F8458D6129F5183B000D53A7 /* FanCardCreation.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = FanCardCreation.storyboard; sourceTree = "<group>"; };
 		F8458D6329F51870000D53A7 /* FanCardCreationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FanCardCreationViewController.swift; sourceTree = "<group>"; };
@@ -1027,6 +1033,16 @@
 			path = Widgets;
 			sourceTree = "<group>";
 		};
+		F84066E52A153265008BCE16 /* Tracking */ = {
+			isa = PBXGroup;
+			children = (
+				F84066E62A153274008BCE16 /* Tracking.swift */,
+				F84066EA2A1533DA008BCE16 /* Screen.swift */,
+				F84066E82A15333A008BCE16 /* Event.swift */,
+			);
+			path = Tracking;
+			sourceTree = "<group>";
+		};
 		F84BAF9E26FDB425004CA335 /* CardCreation */ = {
 			isa = PBXGroup;
 			children = (
@@ -1340,6 +1356,7 @@
 				F8562C94296ADC0A00DA1109 /* Lottie */,
 				F8FC43A326C01F420033E151 /* Constants */,
 				F8FC43A426C01F5B0033E151 /* Extensions */,
+				F84066E52A153265008BCE16 /* Tracking */,
 				77A4D5E929AE20A600367B7C /* Utils */,
 				F8FC43A226C01F2B0033E151 /* Storyboards */,
 			);
@@ -1867,6 +1884,7 @@
 				F8F00C3B29DD483000A15377 /* UpdateUserInfo.swift in Sources */,
 				F8562C98296ADD6700DA1109 /* Lottie.swift in Sources */,
 				770E58862778A78900498C2E /* Status.swift in Sources */,
+				F84066E92A15333A008BCE16 /* Event.swift in Sources */,
 				F851805B275D047C006BD5ED /* OnboardingViewController.swift in Sources */,
 				392BAF7B2793E90D0013DCB3 /* KeyChainKey.swift in Sources */,
 				F8B3F40A29F67B1C006586BB /* CompanyCardCreationViewController.swift in Sources */,
@@ -1875,6 +1893,7 @@
 				F8B3F40E29F67B6F006586BB /* CompanyFrontCardCreationCollectionViewCell.swift in Sources */,
 				39C1E88F270EC762006D2089 /* UIColor+Extension.swift in Sources */,
 				F8C83FC9272FA3190009DF0D /* GroupAPI.swift in Sources */,
+				F84066E72A153274008BCE16 /* Tracking.swift in Sources */,
 				F8B3F41129F67F8D006586BB /* CompanyFrontCardCell.swift in Sources */,
 				F8F00C3E29DD489200A15377 /* UpdateAPI.swift in Sources */,
 				F8FC43B826C0227D0033E151 /* Const.swift in Sources */,
@@ -1922,6 +1941,7 @@
 				77A4D60129BD708C00367B7C /* AroundMeResponse.swift in Sources */,
 				7734D5B82777A8E8004360E4 /* String+Extension.swift in Sources */,
 				77A4D60429BD743600367B7C /* ModuleFactory.swift in Sources */,
+				F84066EB2A1533DA008BCE16 /* Screen.swift in Sources */,
 				F8C83FC3272FA17B0009DF0D /* URL.swift in Sources */,
 				392F7FB4274621F1008CDBF5 /* MoreListTableViewCell.swift in Sources */,
 				77AA68EA273E0EC4009C89B0 /* CardAddInGroupRequest.swift in Sources */,

--- a/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
+++ b/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:NADA-iOS-forRelease.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-noFIRAnalyticsDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
          <AdditionalOption
             key = "NSZombieEnabled"

--- a/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
+++ b/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:NADA-iOS-forRelease.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsDebugEnabled"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
          <AdditionalOption
             key = "NSZombieEnabled"

--- a/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
+++ b/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
@@ -50,12 +50,6 @@
             ReferencedContainer = "container:NADA-iOS-forRelease.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-FIRAnalyticsDebugEnabled"
-            isEnabled = "NO">
-         </CommandLineArgument>
-      </CommandLineArguments>
       <AdditionalOptions>
          <AdditionalOption
             key = "NSZombieEnabled"

--- a/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
+++ b/NADA-iOS-forRelease.xcodeproj/xcshareddata/xcschemes/NADA-iOS-forRelease.xcscheme
@@ -50,12 +50,6 @@
             ReferencedContainer = "container:NADA-iOS-forRelease.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-noFIRAnalyticsDebugEnabled"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
       <AdditionalOptions>
          <AdditionalOption
             key = "NSZombieEnabled"

--- a/NADA-iOS-forRelease/Info.plist
+++ b/NADA-iOS-forRelease/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAutomaticScreenReportingEnabled</key>
+	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>내 근처의 명함을 받아오기 위해 위치 권한이 필요합니다. (허용하지 않을 경우 내 근처의 명함 기능을 사용할 수 없습니다.)</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/NADA-iOS-forRelease/Resouces/Tracking/Event.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Event.swift
@@ -1,0 +1,8 @@
+//
+//  Event.swift
+//  NADA-iOS-forRelease
+//
+//  Created by kimhyungyu on 2023/05/18.
+//
+
+import Foundation

--- a/NADA-iOS-forRelease/Resouces/Tracking/Event.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Event.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Tracking {
     struct Event {
+        private init() { }
         static let touchOnboardingStart = "A2.온보딩_시작"
         static let touchKakaoLogin = "A3.로그인_카카오"
         static let touchAppleLogin = "A3.로그인_애플"

--- a/NADA-iOS-forRelease/Resouces/Tracking/Event.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Event.swift
@@ -6,3 +6,11 @@
 //
 
 import Foundation
+
+extension Tracking {
+    struct Event {
+        static let touchOnboardingStart = "A2.온보딩_시작"
+        static let touchKakaoLogin = "A3.로그인_카카오"
+        static let touchAppleLogin = "A3.로그인_애플"
+    }
+}

--- a/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
@@ -1,0 +1,8 @@
+//
+//  Screen.swift
+//  NADA-iOS-forRelease
+//
+//  Created by kimhyungyu on 2023/05/18.
+//
+
+import Foundation

--- a/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
@@ -6,3 +6,11 @@
 //
 
 import Foundation
+
+extension Tracking {
+    struct Screen {
+        static let splash = "A1.스플래시"
+        static let onboarding = "A2.온보딩"
+        static let login = "A3.로그인"
+    }
+}

--- a/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Tracking {
     struct Screen {
+        private init() { }
         static let splash = "A1.스플래시"
         static let onboarding = "A2.온보딩"
         static let login = "A3.로그인"

--- a/NADA-iOS-forRelease/Resouces/Tracking/Tracking.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Tracking.swift
@@ -1,0 +1,8 @@
+//
+//  Tracking.swift
+//  NADA-iOS-forRelease
+//
+//  Created by kimhyungyu on 2023/05/18.
+//
+
+import Foundation

--- a/NADA-iOS-forRelease/Resouces/Tracking/Tracking.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Tracking.swift
@@ -7,4 +7,6 @@
 
 import Foundation
 
-struct Tracking { }
+struct Tracking {
+    private init() { }
+}

--- a/NADA-iOS-forRelease/Resouces/Tracking/Tracking.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Tracking.swift
@@ -6,3 +6,5 @@
 //
 
 import Foundation
+
+struct Tracking { }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -9,6 +9,7 @@ import AuthenticationServices
 import UIKit
 import WidgetKit
 
+import FirebaseAnalytics
 import FirebaseMessaging
 import KakaoSDKCommon
 import KakaoSDKAuth
@@ -26,6 +27,12 @@ class LoginViewController: UIViewController {
         super.viewDidLoad()
         
         setUI()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        setTracking()
     }
 }
     
@@ -69,7 +76,7 @@ extension LoginViewController {
             }
         }
     }
-    
+
     // 메인 화면으로 전환 함수
     private func presentToMain() {
         let nextVC = UIStoryboard(name: Const.Storyboard.Name.tabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.tabBarViewController)
@@ -77,6 +84,13 @@ extension LoginViewController {
         self.present(nextVC, animated: true) {
             UserDefaults.standard.set(false, forKey: Const.UserDefaultsKey.isOnboarding)
         }
+    }
+    
+    private func setTracking() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [
+                            AnalyticsParameterScreenName: Tracking.Screen.login
+                           ])
     }
     
     // MARK: - @objc Mehotds
@@ -109,6 +123,7 @@ extension LoginViewController {
 }
 
 // MARK: - KakaoSignIn
+
 extension LoginViewController {
     private func loginWithApp() {
         UserApi.shared.loginWithKakaoTalk {(_, error) in

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Login/LoginViewController.swift
@@ -93,11 +93,21 @@ extension LoginViewController {
                            ])
     }
     
+    private func touchKakaoEventTraking() {
+        Analytics.logEvent(Tracking.Event.touchKakaoLogin, parameters: nil)
+    }
+    
+    private func touchAppleEventTracking() {
+        Analytics.logEvent(Tracking.Event.touchAppleLogin, parameters: nil)
+    }
+    
     // MARK: - @objc Mehotds
     
     // 카카오 로그인 버튼 클릭 시
     @objc
     private func kakaoSignInButtonPress() {
+        touchKakaoEventTraking()
+        
         // 카카오톡 설치 여부 확인
         if UserApi.isKakaoTalkLoginAvailable() {
             // 카카오톡 로그인. api 호출 결과를 클로저로 전달.
@@ -111,6 +121,8 @@ extension LoginViewController {
     // 애플 로그인 버튼 클릭 시
     @objc
     private func appleSignInButtonPress() {
+        touchAppleEventTracking()
+        
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -65,6 +65,9 @@ extension OnboardingViewController {
                             AnalyticsParameterScreenName: Tracking.Screen.onboarding
                            ])
     }
+    private func touchOnbardingStartEventTracking() {
+        Analytics.logEvent(Tracking.Event.touchOnboardingStart, parameters: nil)
+    }
 }
 
 // MARK: - UICollectionViewDelegate
@@ -113,6 +116,8 @@ extension OnboardingViewController: UICollectionViewDataSource {
         cell.initCell(image: onboardingList[indexPath.item], index: indexPath.item)
         
         if indexPath.item == 4 {
+            touchOnbardingStartEventTracking()
+            
             cell.presentToLoginViewController = {
                 guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController) as? LoginViewController else { return }
                 nextVC.modalTransitionStyle = .crossDissolve

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Onboarding/OnboardingViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Onboarding/OnboardingViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import FirebaseAnalytics
+
 class OnboardingViewController: UIViewController {
 
     // MARK: - Properties
@@ -34,6 +36,12 @@ class OnboardingViewController: UIViewController {
         setUI()
         collectionViewDelegate()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        setTracking()
+    }
 }
 
 // MARK: - Extensions
@@ -50,6 +58,12 @@ extension OnboardingViewController {
         onboardingCollectionView.dataSource = self
         
         onboardingCollectionView.register(OnboardingCollectionViewCell.nib(), forCellWithReuseIdentifier: Const.Xib.onboardingCollectionViewCell)
+    }
+    private func setTracking() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [
+                            AnalyticsParameterScreenName: Tracking.Screen.onboarding
+                           ])
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Splash/SplashViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Splash/SplashViewController.swift
@@ -7,13 +7,17 @@
 
 import UIKit
 
+import FirebaseAnalytics
+
 class SplashViewController: UIViewController {
 
     // MARK: - Properties
+    
     private weak var appDelegate = UIApplication.shared.delegate as? AppDelegate
     let defaults = UserDefaults.standard
  
     // MARK: - View Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -35,26 +39,36 @@ class SplashViewController: UIViewController {
         }
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        setTracking()
+    }
+    
     // MARK: - Functions
+    
     private func presentToMain() {
         guard let mainVC = UIStoryboard(name: Const.Storyboard.Name.tabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.tabBarViewController) as? TabBarViewController else { return }
         mainVC.modalPresentationStyle = .fullScreen
         mainVC.modalTransitionStyle = .crossDissolve
         self.present(mainVC, animated: true, completion: nil)
     }
-    
     private func presentToLogin() {
         guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.loginViewController) as? LoginViewController else { return }
         loginVC.modalPresentationStyle = .fullScreen
         loginVC.modalTransitionStyle = .crossDissolve
         self.present(loginVC, animated: true, completion: nil)
     }
-    
     private func presentToOnboarding() {
         guard let onboardingVC = UIStoryboard(name: Const.Storyboard.Name.onboarding, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.onboardingViewController) as? OnboardingViewController else { return }
         onboardingVC.modalPresentationStyle = .fullScreen
         onboardingVC.modalTransitionStyle = .crossDissolve
         self.present(onboardingVC, animated: true, completion: nil)
     }
-    
+    private func setTracking() {
+        Analytics.logEvent(AnalyticsEventScreenView,
+                           parameters: [
+                            AnalyticsParameterScreenName: Tracking.Screen.splash
+                           ])
+    }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #516

🌱 작업한 내용
- Tracking 구조체를 추가해서 휴먼에러와 유지보수를 위해 static let 으로 관리.
- ga 화면 자동 트래킹 방지(info.plist 설정)
- 테플에는 포함하지 않아도 될 듯합니당!

### 🚨 참고
참고하시라구 노션에 정리해둔거 공유해드립니다! (참고하라고 엌ㅋㅋ)
> https://www.notion.so/iOS-GA-Goole-Analytics-93d6c4287b52421ca5983a795af39f56?pvs=4

그 중 스키마의 매개변수로 `-FIRAnalyticsDebugEnabled` 추가한 커밋이 있는데([5475d30](https://github.com/TeamNADA/NADA-iOS-ForRelease/pull/537/commits/5475d30acc5b3731fd39b6da4f4abdfaf9326804))
해당 매개변수를 통해서 이벤트 로깅을 모니터링하면 이벤트가 올바르게 로깅되는지 확인할 수 있습니다. 여기에는 자동으로 로깅되는 이벤트와 수동으로 로깅되는 이벤트가 모두 포함됩니다. 이를 확인하기 위한 커밋입니당!
올바르게 지금 로깅되고 있는지를 확인할 수 있었어용 근데 너무 많아서 진짜 확인할 때만 유용했었습니당.
그래서 삭제했습니다. 필요하시면 사용해보시는 것도 좋을 듯합니당

근데 삭제한다고 돌아오는게 아니라 `-noFIRAnalyticsDebugEnabled` 를 추가해서 실행해주시면 됩니다.
- 즉, 활성화할때는 `-FIRAnalyticsVerboseLoggingEnabled` , 비활성화할때는 `-noFIRAnalyticsDebugEnabled` 를 사용하고 유지하거나 삭제해야하는 것은 없습니다. 그저 실행 시 전달되는 매개변수이기 때문입니다.

## 📮 관련 이슈
- Resolved: #516
