### PR TITLE
feat: 위젯 기본값 IntentHandler 에서 설정 (#538)

### DIFF
--- a/IntentsExtension/IntentHandler.swift
+++ b/IntentsExtension/IntentHandler.swift
@@ -40,6 +40,35 @@ extension IntentHandler: MyCardIntentHandling {
             }
         }
     }
+    
+    // 위젯 추가할때 호출. 기본값 설정.
+    func defaultMyCard(for intent: MyCardIntent) -> MyCard? {
+        var myCard: MyCard?
+        
+        let group = DispatchGroup()
+        
+        DispatchQueue.global().async(group: group) { [weak self] in
+            group.enter()
+            
+            self?.cardListFetchWithAPI { result in
+                switch result {
+                case .success(let result):
+                    if let card = result?.data {
+                        myCard = MyCard(identifier: card[0].cardUUID, display: card[0].cardName)
+                        myCard?.userName = card[0].userName
+                        myCard?.cardImage = card[0].cardImage
+                    }
+                case .failure(let err):
+                    print(err)
+                }
+                group.leave()
+            }
+        }
+        
+        _ = group.wait(timeout: .now() + 60)
+        
+        return myCard
+    }
 }
 
 // MARK: - Newtwork

--- a/Widgets/WidgetsBundle/MyCardWidget.swift
+++ b/Widgets/WidgetsBundle/MyCardWidget.swift
@@ -15,25 +15,13 @@ struct MyCardProvider: IntentTimelineProvider {
     }
 
     func getSnapshot(for configuration: MyCardIntent, in context: Context, completion: @escaping (MyCardEntry) -> Void) {
-        cardListFetchWithAPI { result in
-            switch result {
-            case .success(let response):
-                if let data = response?.data {
-                    if !data.isEmpty {
-                        let entry = MyCardEntry(date: Date(), widgetCard: WidgetCard(cardUUID: data[0].cardUUID,
-                                                                                     title: data[0].cardName,
-                                                                                     userName: data[0].userName,
-                                                                                     backgroundImage: fetchImage(data[0].cardImage)))
-                        completion(entry)
-                    } else {
-                        completion(MyCardEntry(date: Date(), widgetCard: nil))
-                    }
-                }
-            case .failure(let error):
-                print(error)
-
-                completion(MyCardEntry(date: Date(), widgetCard: nil))
-            }
+        if let myCard = configuration.myCard {
+            completion(MyCardEntry(date: Date(), widgetCard: WidgetCard(cardUUID: myCard.identifier ?? "",
+                                                                        title: myCard.displayString,
+                                                                        userName: myCard.userName ?? "",
+                                                                        backgroundImage: fetchImage(myCard.cardImage ?? ""))))
+        } else {
+            completion(MyCardEntry(date: Date(), widgetCard: nil))
         }
     }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #539

🌱 작업한 내용
- 위젯 기본값 IntentHandler 에서 설정
- snapshot 단계에서 pre-configuration 으로 설정

### 🚨 참고사항
- 현재 IntentHandler 에서의 기본값 설정이 매번 진행되는 것이 아니다보니 고민이 있습니다.
    - 대표 명함이 바뀌거나 로그아웃해도 이전 대표명함이 선택목록에 없지만 선택되어있음. 목록은 빈 목록.
    - 하지만, 로그아웃하면 이전 대표명함이 설정되어 있더라도 목록에 없어서 엠티뷰로 대응됨.
- 이 문제를 해결하게되면 또 이슈 만들겠습니다!
- 아마.. IntentHandler 의 메서드를 수동으로 호출하는 방향을 좀 찾아보려합니다..

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기본값 설정|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/a2edf470-bbc2-40bf-85a1-bf60fa390eab" width ="200">|

## 📮 관련 이슈
- Resolved: #538
