### PR TITLE
feat: 위젯으로 앱 접근 시 화면 트래킹 (#541)

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
+++ b/NADA-iOS-forRelease/Resouces/Tracking/Screen.swift
@@ -14,5 +14,7 @@ extension Tracking {
         static let onboarding = "A2 온보딩"
         static let login = "A3 로그인"
         static let more = "E1 설정"
+        static let myCardWidget = "F1 명함 위젯"
+        static let qrcodeWidget = "F2 QR 위젯"
     }
 }

--- a/NADA-iOS-forRelease/Sources/SceneDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/SceneDelegate.swift
@@ -8,6 +8,7 @@
 import Photos
 import UIKit
 
+import FirebaseAnalytics
 import FirebaseDynamicLinks
 import IQKeyboardManagerSwift
 import KakaoSDKAuth
@@ -25,12 +26,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let url = connectionOptions.urlContexts.first?.url {
             if url.absoluteString == qrCodeURL {
                 UserDefaults.standard.setValue(true, forKey: Const.UserDefaultsKey.openQRCodeWidget)
+                
+                Analytics.logEvent(AnalyticsEventScreenView,
+                                   parameters: [
+                                    AnalyticsParameterScreenName: Tracking.Screen.qrcodeWidget
+                                   ])
             } else if url.absoluteString.starts(with: myCardURL) {
                 guard let queryItems = URLComponents(string: url.absoluteString)?.queryItems,
                       let cardUUID = queryItems.filter({ $0.name == "cardUUID" }).first?.value else { return }
                 
                 UserDefaults.standard.setValue(true, forKey: Const.UserDefaultsKey.openMyCardWidget)
                 UserDefaults.standard.setValue(cardUUID, forKey: Const.UserDefaultsKey.widgetCardUUID)
+                
+                Analytics.logEvent(AnalyticsEventScreenView,
+                                   parameters: [
+                                    AnalyticsParameterScreenName: Tracking.Screen.myCardWidget
+                                   ])
             }
         }
         
@@ -99,6 +110,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             default:
                 break
             }
+            
+            Analytics.logEvent(AnalyticsEventScreenView,
+                               parameters: [
+                                AnalyticsParameterScreenName: Tracking.Screen.qrcodeWidget
+                               ])
         } else if url.absoluteString.starts(with: myCardURL) {
             // 내 명함 위젯.
             if UserDefaults.appGroup.string(forKey: Const.UserDefaultsKey.accessToken) != nil {
@@ -120,6 +136,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     }
                 }
             }
+            
+            Analytics.logEvent(AnalyticsEventScreenView,
+                               parameters: [
+                                AnalyticsParameterScreenName: Tracking.Screen.myCardWidget
+                               ])
         } else {
             if (AuthApi.isKakaoTalkLoginUrl(url)) {
                 _ = AuthController.handleOpenUrl(url: url)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #541

🌱 작업한 내용
- `scene(_:willConnectTo:options:)` : 앱이 씬이 추가될 때(앱 런치 시) url 체크해서 위젯에서 접근하는지 확인
- `scene(_:openURLContexts:)` : URL 을 열라고 요청할 때 위젯에서 접근하는지 확인
을 사용해서 화면 트래킹하였습니다.


## 📮 관련 이슈
- Resolved: #541