### PR TITLE
fix: 명함 라운드값 수정 (#555)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
@@ -17,7 +17,7 @@ class CompanyFrontCardCell: CardCell {
     
     private var cardData: Card?
     private var setConstraintDone = false
-    private var backgroundCornerRaidus: CGFloat?
+    private var backgroundCornerRadius: CGFloat?
     
     public var cardContext: CardContext?
     
@@ -116,7 +116,7 @@ extension CompanyFrontCardCell {
         
         linkURLStackView.alignment = .center
         
-        backgroundImageView.cornerRadius = backgroundCornerRaidus ?? 20
+        backgroundImageView.cornerRadius = backgroundCornerRadius ?? 20
     }
     func setConstraints() {
         if setConstraintDone { return }
@@ -148,7 +148,7 @@ extension CompanyFrontCardCell {
         linkURLLabel.addGestureRecognizer(linkURLTapGesture)
     }
     public func setCornerRadius(_ cornerRadius: CGFloat) {
-        backgroundCornerRaidus = cornerRadius
+        backgroundCornerRadius = cornerRadius
     }
     
     // MARK: - @objc Methods

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
@@ -116,8 +116,7 @@ extension CompanyFrontCardCell {
         
         linkURLStackView.alignment = .center
         
-        guard let backgroundCornerRaidus else { return }
-        backgroundImageView.cornerRadius = backgroundCornerRaidus
+        backgroundImageView.cornerRadius = backgroundCornerRaidus ?? 20
     }
     func setConstraints() {
         if setConstraintDone { return }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.swift
@@ -17,6 +17,7 @@ class CompanyFrontCardCell: CardCell {
     
     private var cardData: Card?
     private var setConstraintDone = false
+    private var backgroundCornerRaidus: CGFloat?
     
     public var cardContext: CardContext?
     
@@ -87,26 +88,36 @@ extension CompanyFrontCardCell {
     private func setUI() {
         titleLabel.font = .title02
         titleLabel.textColor = .white
+        
         descriptionLabel.font = .textRegular03
         descriptionLabel.textColor = .white
+        
         userNameLabel.font = .title01
         userNameLabel.textColor = .white
+        
         birthLabel.font = .textRegular03
         birthLabel.textColor = .white
+        
         mbtiLabel.font = .textRegular03
         mbtiLabel.textColor = .white
+        
         mailLabel.font = .textRegular04
         mailLabel.textColor = .white
         mailLabel.lineBreakMode = .byTruncatingTail
+        
         phoneNumberLabel.font = .textRegular04
         phoneNumberLabel.textColor = .white
         phoneNumberLabel.lineBreakMode = .byTruncatingTail
+        
         linkURLLabel.font = .textRegular04
         linkURLLabel.textColor = .white
         linkURLLabel.numberOfLines = 1
         linkURLLabel.lineBreakMode = .byTruncatingTail
         
         linkURLStackView.alignment = .center
+        
+        guard let backgroundCornerRaidus else { return }
+        backgroundImageView.cornerRadius = backgroundCornerRaidus
     }
     func setConstraints() {
         if setConstraintDone { return }
@@ -136,6 +147,9 @@ extension CompanyFrontCardCell {
         linkURLLabel.isUserInteractionEnabled = true
         let linkURLTapGesture = UITapGestureRecognizer(target: self, action: #selector(tapLinkURLLabel))
         linkURLLabel.addGestureRecognizer(linkURLTapGesture)
+    }
+    public func setCornerRadius(_ cornerRadius: CGFloat) {
+        backgroundCornerRaidus = cornerRadius
     }
     
     // MARK: - @objc Methods

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/CompanyFrontCardCell.xib
@@ -20,7 +20,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="327" height="540"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                <real key="value" value="15"/>
+                                <real key="value" value="20"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -17,6 +17,7 @@ class FanFrontCardCell: CardCell {
     
     private var cardData: Card?
     private var setConstraintDone = false
+    private var backgroundCornerRaidus: CGFloat?
     
     public var cardContext: CardContext?
     
@@ -83,24 +84,33 @@ extension FanFrontCardCell {
     private func setUI() {
         titleLabel.font = .title02
         titleLabel.textColor = .white
+        
         userNameLabel.font = .title01
         userNameLabel.textColor = .white
+        
         birthLabel.font = .textRegular03
         birthLabel.textColor = .white
+        
         snsLabel.font = .textRegular03
         snsLabel.textColor = .white
         snsLabel.lineBreakMode = .byTruncatingTail
+        
         firstURLLabel.font = .textRegular04
         firstURLLabel.textColor = .white
         firstURLLabel.numberOfLines = 1
         firstURLLabel.lineBreakMode = .byTruncatingTail
+        
         secondURLLabel.font = .textRegular04
         secondURLLabel.textColor = .white
         secondURLLabel.numberOfLines = 1
         secondURLLabel.lineBreakMode = .byTruncatingTail
         
         firstURLStackView.alignment = .center
+        
         secondURLStackView.alignment = .center
+        
+        guard let backgroundCornerRaidus else { return }
+        backgroundImageView.cornerRadius = backgroundCornerRaidus
     }
     func setConstraints() {
         if setConstraintDone { return }
@@ -134,6 +144,9 @@ extension FanFrontCardCell {
         secondURLLabel.isUserInteractionEnabled = true
         let secondURLTapGesture = UITapGestureRecognizer(target: self, action: #selector(touchSecondURLLabel))
         secondURLLabel.addGestureRecognizer(secondURLTapGesture)
+    }
+    public func setCornerRadius(_ cornerRadius: CGFloat) {
+        backgroundCornerRaidus = cornerRadius
     }
     
     // MARK: - @objc Methods

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -109,8 +109,7 @@ extension FanFrontCardCell {
         
         secondURLStackView.alignment = .center
         
-        guard let backgroundCornerRaidus else { return }
-        backgroundImageView.cornerRadius = backgroundCornerRaidus
+        backgroundImageView.cornerRadius = backgroundCornerRaidus ?? 20
     }
     func setConstraints() {
         if setConstraintDone { return }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.swift
@@ -17,7 +17,7 @@ class FanFrontCardCell: CardCell {
     
     private var cardData: Card?
     private var setConstraintDone = false
-    private var backgroundCornerRaidus: CGFloat?
+    private var backgroundCornerRadius: CGFloat?
     
     public var cardContext: CardContext?
     
@@ -109,7 +109,7 @@ extension FanFrontCardCell {
         
         secondURLStackView.alignment = .center
         
-        backgroundImageView.cornerRadius = backgroundCornerRaidus ?? 20
+        backgroundImageView.cornerRadius = backgroundCornerRadius ?? 20
     }
     func setConstraints() {
         if setConstraintDone { return }
@@ -145,7 +145,7 @@ extension FanFrontCardCell {
         secondURLLabel.addGestureRecognizer(secondURLTapGesture)
     }
     public func setCornerRadius(_ cornerRadius: CGFloat) {
-        backgroundCornerRaidus = cornerRadius
+        backgroundCornerRadius = cornerRadius
     }
     
     // MARK: - @objc Methods

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FanFrontCardCell.xib
@@ -20,7 +20,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="327" height="540"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                <real key="value" value="15"/>
+                                <real key="value" value="20"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -17,6 +17,7 @@ class FrontCardCell: CardCell {
     
     private var cardData: Card?
     private var setConstraintDone = false
+    private var backgroundCornerRadius: CGFloat?
     
     public var cardContext: CardContext?
     
@@ -89,26 +90,36 @@ extension FrontCardCell {
     private func setUI() {
         titleLabel.font = .title02
         titleLabel.textColor = .white
+        
         descriptionLabel.font = .textRegular03
         descriptionLabel.textColor = .white
+        
         userNameLabel.font = .title01
         userNameLabel.textColor = .white
+        
         birthLabel.font = .textRegular03
         birthLabel.textColor = .white
+        
         mbtiLabel.font = .textRegular03
         mbtiLabel.textColor = .white
+        
         instagramIDLabel.font = .textRegular03
         instagramIDLabel.textColor = .white
         instagramIDLabel.lineBreakMode = .byTruncatingTail
+        
         phoneNumberLabel.font = .textRegular04
         phoneNumberLabel.textColor = .white
         phoneNumberLabel.lineBreakMode = .byTruncatingTail
+        
         linkURLLabel.font = .textRegular04
         linkURLLabel.textColor = .white
         linkURLLabel.numberOfLines = 1
         linkURLLabel.lineBreakMode = .byTruncatingTail
         
         linkURLStackView.alignment = .center
+        
+        guard let backgroundCornerRadius else { return }
+        backgroundImageView.cornerRadius = backgroundCornerRadius
     }
     func setConstraints() {
         if setConstraintDone { return }
@@ -138,6 +149,9 @@ extension FrontCardCell {
         linkURLLabel.isUserInteractionEnabled = true
         let linkURLTapGesture = UITapGestureRecognizer(target: self, action: #selector(tapLinkURLLabel))
         linkURLLabel.addGestureRecognizer(linkURLTapGesture)
+    }
+    public func setCornerRadius(_ cornerRadius: CGFloat) {
+        backgroundCornerRadius = cornerRadius
     }
     
     // MARK: - @objc Methods

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.swift
@@ -118,8 +118,7 @@ extension FrontCardCell {
         
         linkURLStackView.alignment = .center
         
-        guard let backgroundCornerRadius else { return }
-        backgroundImageView.cornerRadius = backgroundCornerRadius
+        backgroundImageView.cornerRadius = backgroundCornerRadius ?? 20
     }
     func setConstraints() {
         if setConstraintDone { return }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/FrontCardCell.xib
@@ -20,7 +20,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="327" height="540"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                <real key="value" value="15"/>
+                                <real key="value" value="20"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/CardResultBottomSheetViewController.swift
@@ -149,6 +149,8 @@ extension CardResultBottomSheetViewController: UICollectionViewDataSource {
             }
             cardCell.initCellFromServer(cardData: frontCard, isShareable: false)
             cardCell.setConstraints()
+            cardCell.setCornerRadius(15)
+            
             return cardCell
         case "FAN":
             guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FanFrontCardCell.className, for: indexPath) as? FanFrontCardCell else {
@@ -156,6 +158,8 @@ extension CardResultBottomSheetViewController: UICollectionViewDataSource {
             }
             cardCell.initCellFromServer(cardData: frontCard, isShareable: false)
             cardCell.setConstraints()
+            cardCell.setCornerRadius(15)
+            
             return cardCell
         case "COMPANY":
             guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: CompanyFrontCardCell.className, for: indexPath) as? CompanyFrontCardCell else {
@@ -163,6 +167,8 @@ extension CardResultBottomSheetViewController: UICollectionViewDataSource {
             }
             cardCell.initCellFromServer(cardData: frontCard, isShareable: false)
             cardCell.setConstraints()
+            cardCell.setCornerRadius(15)
+            
             return cardCell
         default:
             return UICollectionViewCell()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -319,6 +319,8 @@ extension GroupViewController: UICollectionViewDataSource {
                 }
                 cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
                 cardCell.setConstraints()
+                cardCell.setCornerRadius(15)
+                
                 return cardCell
             case "FAN":
                 guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: FanFrontCardCell.className, for: indexPath) as? FanFrontCardCell else {
@@ -326,6 +328,8 @@ extension GroupViewController: UICollectionViewDataSource {
                 }
                 cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
                 cardCell.setConstraints()
+                cardCell.setCornerRadius(15)
+                
                 return cardCell
             case "COMPANY":
                 guard let cardCell = collectionView.dequeueReusableCell(withReuseIdentifier: CompanyFrontCardCell.className, for: indexPath) as? CompanyFrontCardCell else {
@@ -333,6 +337,8 @@ extension GroupViewController: UICollectionViewDataSource {
                 }
                 cardCell.initCellFromServer(cardData: frontCards[indexPath.row], isShareable: false)
                 cardCell.setConstraints()
+                cardCell.setCornerRadius(15)
+                
                 return cardCell
             default:
                 return UICollectionViewCell()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #555

🌱 작업한 내용
- 명함 라운드 값 수정
- 명함모음, 명함 추가 바텀시트의 경우 15로 수정
- - 많은 곳에서 사용되고 있기 때문에 기본이 20이고, 설정하고 싶은 경우에만 함수로 접근할 수 있도록 함.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함 모음|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/f96d244a-1760-4fb0-8b66-e68876e45565" width ="250">|
|명함 추가 바텀시트|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/05e4310d-2325-4c85-a362-22fa88cc5c7e" width ="250">|


## 📮 관련 이슈
- Resolved: #555
