### PR TITLE
fix: 명함 생성, 미리보기 버튼 폰트 적용 (#569)

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreation.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreation.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -19,31 +19,31 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tbX-yg-azh">
-                                <rect key="frame" x="166.66666666666666" y="60.999999999999993" width="41.666666666666657" height="20.666666666666664"/>
+                                <rect key="frame" x="166.66666666666666" y="67" width="41.666666666666657" height="20.666666666666671"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q7k-m0-xi2">
-                                <rect key="frame" x="25" y="124" width="42" height="21"/>
+                                <rect key="frame" x="25" y="130" width="42" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yP6-6Y-BPF">
-                                <rect key="frame" x="97" y="124" width="42" height="21"/>
+                                <rect key="frame" x="97" y="130" width="42" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gBB-hQ-SyS">
-                                <rect key="frame" x="20" y="148" width="52" height="2"/>
+                                <rect key="frame" x="20" y="154" width="52" height="2"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="Hm8-0C-mLG"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RJP-GW-J4W">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RJP-GW-J4W">
                                 <rect key="frame" x="24" y="724" width="327" height="54"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="54" id="5Vp-dw-6P6"/>
@@ -52,15 +52,12 @@
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="linkColor"/>
                                 </state>
-                                <buttonConfiguration key="configuration" style="plain" title="Button">
-                                    <color key="baseForegroundColor" systemColor="linkColor"/>
-                                </buttonConfiguration>
                                 <connections>
                                     <action selector="pushToCardCompletionView:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="mWh-HD-gMb"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nZD-YQ-z5l">
-                                <rect key="frame" x="25" y="59" width="54" height="34"/>
+                                <rect key="frame" x="25" y="65" width="54" height="34"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="tintColor"/>
@@ -70,10 +67,10 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wd4-Tx-rSs">
-                                <rect key="frame" x="0.0" y="162" width="375" height="550"/>
+                                <rect key="frame" x="0.0" y="168" width="375" height="544"/>
                                 <subviews>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="PLB-cM-M8s">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="550"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="544"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="RWl-ol-Bps">
                                             <size key="itemSize" width="128" height="128"/>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreationPreview.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CardCreationPreview.storyboard
@@ -48,7 +48,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="명함 만들기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V9F-GG-Wlr">
-                                        <rect key="frame" x="144" y="14" width="87" height="22"/>
+                                        <rect key="frame" x="144" y="14.666666666666671" width="87" height="21"/>
                                         <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="18"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -71,14 +71,13 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gc2-31-hRU">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gc2-31-hRU">
                                 <rect key="frame" x="24" y="724" width="327" height="54"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="54" id="smH-Df-7w1"/>
                                 </constraints>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                 <connections>
                                     <action selector="touchCompleteButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="fX7-aC-GHN"/>
                                 </connections>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CompanyCardCreation.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/CompanyCardCreation.storyboard
@@ -43,7 +43,7 @@
                                     <constraint firstAttribute="height" constant="2" id="Hm8-0C-mLG"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RJP-GW-J4W">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RJP-GW-J4W">
                                 <rect key="frame" x="24" y="724" width="327" height="54"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="54" id="5Vp-dw-6P6"/>
@@ -52,9 +52,6 @@
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="linkColor"/>
                                 </state>
-                                <buttonConfiguration key="configuration" style="plain" title="Button">
-                                    <color key="baseForegroundColor" systemColor="linkColor"/>
-                                </buttonConfiguration>
                                 <connections>
                                     <action selector="pushToCardCompletionView:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="mWh-HD-gMb"/>
                                 </connections>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/FanCardCreation.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardCreation/FanCardCreation.storyboard
@@ -43,7 +43,7 @@
                                     <constraint firstAttribute="height" constant="2" id="Hm8-0C-mLG"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RJP-GW-J4W">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RJP-GW-J4W">
                                 <rect key="frame" x="24" y="724" width="327" height="54"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="54" id="5Vp-dw-6P6"/>
@@ -52,9 +52,6 @@
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="linkColor"/>
                                 </state>
-                                <buttonConfiguration key="configuration" style="plain" title="Button">
-                                    <color key="baseForegroundColor" systemColor="linkColor"/>
-                                </buttonConfiguration>
                                 <connections>
                                     <action selector="pushToCardCompletionView:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="mWh-HD-gMb"/>
                                 </connections>

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
@@ -120,25 +120,32 @@ extension CardCreationPreviewViewController {
         attributeString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributeString.length))
         noticeLabel.attributedText = attributeString
         
-        completeButton.titleLabel?.font = .button01
         // MARK: - #available(iOS 15.0, *)
+
         if #available(iOS 15.0, *) {
             var config = UIButton.Configuration.filled()
+            var attributedString = AttributedString("완료")
+            
+            attributedString.font = .button01
             config.background.cornerRadius = 15
-            config.baseBackgroundColor = .mainColorNadaMain
+            config.attributedTitle = attributedString
             config.baseForegroundColor = .white
-            completeButton.configuration = config
             
             let configHandler: UIButton.ConfigurationUpdateHandler = { button in
                 switch button.state {
+                case .disabled:
+                    button.configuration = config
+                    button.configuration?.baseBackgroundColor = .textBox
                 default:
-                    button.configuration?.title = "생성"
+                    button.configuration = config
+                    button.configuration?.baseBackgroundColor = .mainColorNadaMain
                 }
             }
             completeButton.configurationUpdateHandler = configHandler
         } else {
             // TODO: - QA/iOS 13 테스트. selected 설정.
-            completeButton.setTitle("생성", for: .normal)
+            completeButton.titleLabel?.font = .button01
+            completeButton.setTitle("완료", for: .normal)
             completeButton.layer.cornerRadius = 15
             completeButton.setBackgroundImage(UIImage(named: "enableButtonBackground"), for: .normal)
             completeButton.setTitleColor(.white, for: .normal)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -128,36 +128,39 @@ extension CardCreationViewController {
         closeButton.setImage(UIImage(named: "iconClear"), for: .normal)
         closeButton.setTitle("", for: .normal)
         
-        completeButton.titleLabel?.font = .button01
         completeButton.isEnabled = false
         
         // MARK: - #available(iOS 15.0, *)
+
         if #available(iOS 15.0, *) {
             var config = UIButton.Configuration.filled()
+            var attributedString = AttributedString("미리보기")
+            
+            attributedString.font = .button01
             config.background.cornerRadius = 15
-            completeButton.configuration = config
+            config.attributedTitle = attributedString
+            config.baseForegroundColor = .white
 
             let configHandler: UIButton.ConfigurationUpdateHandler = { button in
                 switch button.state {
                 case .disabled:
-                    button.configuration?.title = "완료"
+                    button.configuration = config
                     button.configuration?.baseBackgroundColor = .textBox
-                    button.configuration?.baseForegroundColor = .white
                 default:
-                    button.configuration?.title = "완료"
+                    button.configuration = config
                     button.configuration?.baseBackgroundColor = .mainColorNadaMain
-                    button.configuration?.baseForegroundColor = .white
                 }
             }
             completeButton.configurationUpdateHandler = configHandler
         } else {
+            completeButton.titleLabel?.font = .button01
             completeButton.layer.cornerRadius = 15
             
-            completeButton.setTitle("완료", for: .normal)
+            completeButton.setTitle("미리보기", for: .normal)
             completeButton.setTitleColor(.white, for: .normal)
             completeButton.setBackgroundImage(UIImage(named: "enableButtonBackground"), for: .normal)
             
-            completeButton.setTitle("완료", for: .disabled)
+            completeButton.setTitle("미리보기", for: .disabled)
             completeButton.setTitleColor(.white, for: .disabled)
             completeButton.setBackgroundImage(UIImage(named: "disableButtonBackground"), for: .disabled)
         }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CompanyCardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CompanyCardCreationViewController.swift
@@ -128,36 +128,39 @@ extension CompanyCardCreationViewController {
         closeButton.setImage(UIImage(named: "iconClear"), for: .normal)
         closeButton.setTitle("", for: .normal)
         
-        completeButton.titleLabel?.font = .button01
         completeButton.isEnabled = false
         
         // MARK: - #available(iOS 15.0, *)
+
         if #available(iOS 15.0, *) {
             var config = UIButton.Configuration.filled()
+            var attributedString = AttributedString("미리보기")
+            
+            attributedString.font = .button01
             config.background.cornerRadius = 15
-            completeButton.configuration = config
+            config.attributedTitle = attributedString
+            config.baseForegroundColor = .white
 
             let configHandler: UIButton.ConfigurationUpdateHandler = { button in
                 switch button.state {
                 case .disabled:
-                    button.configuration?.title = "완료"
+                    button.configuration = config
                     button.configuration?.baseBackgroundColor = .textBox
-                    button.configuration?.baseForegroundColor = .white
                 default:
-                    button.configuration?.title = "완료"
+                    button.configuration = config
                     button.configuration?.baseBackgroundColor = .mainColorNadaMain
-                    button.configuration?.baseForegroundColor = .white
                 }
             }
             completeButton.configurationUpdateHandler = configHandler
         } else {
+            completeButton.titleLabel?.font = .button01
             completeButton.layer.cornerRadius = 15
             
-            completeButton.setTitle("완료", for: .normal)
+            completeButton.setTitle("미리보기", for: .normal)
             completeButton.setTitleColor(.white, for: .normal)
             completeButton.setBackgroundImage(UIImage(named: "enableButtonBackground"), for: .normal)
             
-            completeButton.setTitle("완료", for: .disabled)
+            completeButton.setTitle("미리보기", for: .disabled)
             completeButton.setTitleColor(.white, for: .disabled)
             completeButton.setBackgroundImage(UIImage(named: "disableButtonBackground"), for: .disabled)
         }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/FanCardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/FanCardCreationViewController.swift
@@ -128,36 +128,39 @@ extension FanCardCreationViewController {
         closeButton.setImage(UIImage(named: "iconClear"), for: .normal)
         closeButton.setTitle("", for: .normal)
         
-        completeButton.titleLabel?.font = .button01
         completeButton.isEnabled = false
         
         // MARK: - #available(iOS 15.0, *)
+
         if #available(iOS 15.0, *) {
             var config = UIButton.Configuration.filled()
+            var attributedString = AttributedString("미리보기")
+            
+            attributedString.font = .button01
             config.background.cornerRadius = 15
-            completeButton.configuration = config
+            config.attributedTitle = attributedString
+            config.baseForegroundColor = .white
 
             let configHandler: UIButton.ConfigurationUpdateHandler = { button in
                 switch button.state {
                 case .disabled:
-                    button.configuration?.title = "완료"
+                    button.configuration = config
                     button.configuration?.baseBackgroundColor = .textBox
-                    button.configuration?.baseForegroundColor = .white
                 default:
-                    button.configuration?.title = "완료"
+                    button.configuration = config
                     button.configuration?.baseBackgroundColor = .mainColorNadaMain
-                    button.configuration?.baseForegroundColor = .white
                 }
             }
             completeButton.configurationUpdateHandler = configHandler
         } else {
+            completeButton.titleLabel?.font = .button01
             completeButton.layer.cornerRadius = 15
             
-            completeButton.setTitle("완료", for: .normal)
+            completeButton.setTitle("미리보기", for: .normal)
             completeButton.setTitleColor(.white, for: .normal)
             completeButton.setBackgroundImage(UIImage(named: "enableButtonBackground"), for: .normal)
             
-            completeButton.setTitle("완료", for: .disabled)
+            completeButton.setTitle("미리보기", for: .disabled)
             completeButton.setTitleColor(.white, for: .disabled)
             completeButton.setBackgroundImage(UIImage(named: "disableButtonBackground"), for: .disabled)
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #569

🌱 작업한 내용
- 명함 생성, 미리보기 버튼 폰트 미적용된거 확인 후 수정하였습니다.
- UIButton 에 커스텀 폰트를 반영하기 위해서 System 타입의 Default 스타일로 설정.

<img width="269" alt="스크린샷 2023-05-28 오후 11 45 16" src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/3daddc94-f98a-44a3-b716-53a5c77d0462">

- UIButton.Configuration 을 적용할때 configurationUpdateHandler 에서 텍스트를 적용해주었는데 configuration 설정 이후에 작동하여 덮어씌어짐.
- configuration 을 사용한다면 configuration 이 제일 우선순위가 약해서 덮어씌어지는 것을 조심해야함.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|미리보기|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/95f0a89c-273e-4a33-b482-050a32187882" width ="200">|
|미리보기|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/7d2c1dee-9af9-48f8-b6c6-5cf9f1d09979" width ="200">|
|완료|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/86b3ffbd-ef32-419d-a1ba-327bda9a3e2d" width ="200">|


## 📮 관련 이슈
- Resolved: #569
