### PR TITLE
feat: fastfile 수정 (#579)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,cocoapods,xcode,swift
+fastlane/key.json

--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -2387,7 +2387,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "YJC.NADA-iOS-forRelease";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development YJC.NADA-iOS-forRelease";
@@ -2417,7 +2417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "YJC.NADA-iOS-forRelease";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore YJC.NADA-iOS-forRelease";

--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -2387,7 +2387,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "YJC.NADA-iOS-forRelease";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development YJC.NADA-iOS-forRelease";
@@ -2417,7 +2417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "YJC.NADA-iOS-forRelease";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore YJC.NADA-iOS-forRelease";

--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -2387,7 +2387,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "YJC.NADA-iOS-forRelease";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development YJC.NADA-iOS-forRelease";
@@ -2417,7 +2417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "YJC.NADA-iOS-forRelease";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore YJC.NADA-iOS-forRelease";

--- a/NADA-iOS-forRelease/Info.plist
+++ b/NADA-iOS-forRelease/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>2.3.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,7 +50,7 @@ platform :ios do
     if options[:version]
       increment_version_number(
         version_number: options[:version],
-        xcodeproj: "NADA-iOS-forRelease.xcworkspace"
+        xcodeproj: "NADA-iOS-forRelease.xcodeproj"
       )
     else
       version = get_version_number(
@@ -72,6 +72,63 @@ platform :ios do
     )
   end
 
+  # beta
+  desc "Push a new beta build to the TestFlight"
+  lane :beta do |options|
+    increment_build_number(xcodeproj: "NADA-iOS-forRelease.xcodeproj")
+
+    build_app(
+      workspace: "NADA-iOS-forRelease.xcworkspace",
+      scheme: "NADA-iOS-forRelease (Beta)",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: {
+          "YJC.NADA-iOS-forRelease" => "match AppStore YJC.NADA-iOS-forRelease",
+          "YJC.NADA-iOS-forRelease.Widgets" => "match AppStore YJC.NADA-iOS-forRelease.Widgets",
+          "YJC.NADA-iOS-forRelease.IntentsExtension" => "match AppStore YJC.NADA-iOS-forRelease.IntentsExtension",
+          "YJC.NADA-iOS-forRelease.IntentsExtensionUI" => "match AppStore YJC.NADA-iOS-forRelease.IntentsExtensionUI"
+        }
+      }
+    )
+
+    # changelog 사용 시 반영, 미사용시 빈값.
+    if options[:changelog]
+      upload_to_testflight(
+        distribute_external: false, # default
+        changelog: "changelog"
+      )
+    else
+      upload_to_testflight(
+        distribute_external: false, # default
+        changelog: ""
+      )
+    end
+
+    # version 사용 시 반영, 미사용 시 현재 프로젝트 버전 사용.
+    if options[:version]
+      increment_version_number(
+        version_number: options[:version],
+        xcodeproj: "NADA-iOS-forRelease.xcodeproj"
+      )
+    else
+      version = get_version_number(
+                  target: "NADA-iOS-forRelease"
+                )
+    end
+
+    build = get_build_number
+
+    slack(
+      username: "fastlane",
+      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/f997e95e-3c09-432b-aa35-9c67ea381e0d",
+      message: "성공적으로 TestFlight 에 등록되었습니다!🔥",
+      success: true, # default
+      slack_url: "https://hooks.slack.com/services/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",
+      payload: {
+	"Version": version + "(" + build + ")"
+      }
+    )
+  end
 
   # install
   desc "Add certificates and provisioning profiles on a new machine"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,8 +61,8 @@ platform :ios do
     build = get_build_number
 
     slack(
-      username: "fastlane",
-      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/f997e95e-3c09-432b-aa35-9c67ea381e0d",
+      username: "약한녀석의 말은 듣지 않는 워그레이몬🦖",
+      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/0c947bbc-9406-465a-b918-d154a26f7320",
       message: "성공적으로 앱을 등록했습니다!💫",
       success: true, # default
       slack_url: "https://hooks.slack.com/services/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",
@@ -119,8 +119,8 @@ platform :ios do
     build = get_build_number
 
     slack(
-      username: "fastlane",
-      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/f997e95e-3c09-432b-aa35-9c67ea381e0d",
+      username: "약한녀석의 말은 듣지 않는 워그레이몬🦖",
+      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/0c947bbc-9406-465a-b918-d154a26f7320",
       message: "성공적으로 TestFlight 에 등록되었습니다!🔥",
       success: true, # default
       slack_url: "https://hooks.slack.com/services/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",
@@ -149,8 +149,8 @@ platform :ios do
     build = get_build_number 
 
     slack(
-      username: "fastlane",
-      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/f997e95e-3c09-432b-aa35-9c67ea381e0d",
+      username: "약한녀석의 말은 듣지 않는 워그레이몬🦖",
+      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/0c947bbc-9406-465a-b918-d154a26f7320",
       message: "에러 발생!!! 발생!!🚨 : #{exception}",
       success: false,
       slack_url: "https://hooks.slack.com/services/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",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,11 +16,62 @@
 default_platform(:ios)
 
 platform :ios do
+
+  # release
   desc "Push a new release build to the App Store"
-  lane :release do
+  lane :release do |options|
+
     increment_build_number(xcodeproj: "NADA-iOS-forRelease.xcodeproj")
-    build_app(workspace: "NADA-iOS-forRelease.xcworkspace", scheme: "NADA-iOS-forRelease")
-    upload_to_app_store
+
+    build_app(
+      workspace: "NADA-iOS-forRelease.xcworkspace",
+      scheme: "NADA-iOS-forRelease (Release)",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: {
+          "YJC.NADA-iOS-forRelease" => "match AppStore YJC.NADA-iOS-forRelease",
+          "YJC.NADA-iOS-forRelease.Widgets" => "match AppStore YJC.NADA-iOS-forRelease.Widgets",
+          "YJC.NADA-iOS-forRelease.IntentsExtension" => "match AppStore YJC.NADA-iOS-forRelease.IntentsExtension",
+          "YJC.NADA-iOS-forRelease.IntentsExtensionUI" => "match AppStore YJC.NADA-iOS-forRelease.IntentsExtensionUI"
+        }
+      }
+    )
+
+    upload_to_app_store(
+      skip_metadata: false, #default
+      skip_screenshots: true,
+      submit_for_review: true,
+      automatic_release: false,
+      force: true,
+      precheck_include_in_app_purchases: false,
+      submission_information: { add_id_info_uses_idfa: false }
+    )
+
+    if options[:version]
+      increment_version_number(
+        version_number: options[:version],
+        xcodeproj: "NADA-iOS-forRelease.xcworkspace"
+      )
+    else
+      version = get_version_number(
+                  target: "NADA-iOS-forRelease"
+                )
+    end
+
+    build = get_build_number
+
+    slack(
+      username: "fastlane",
+      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/f997e95e-3c09-432b-aa35-9c67ea381e0d",
+      message: "성공적으로 앱을 등록했습니다!💫",
+      success: true, # default
+      slack_url: "https://hooks.slack.com/services/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",
+      payload: {
+	"Version": version + "(" + build + ")"
+      }
+    )
+  end
+
 
   # install
   desc "Add certificates and provisioning profiles on a new machine"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,7 +97,7 @@ platform :ios do
       upload_to_testflight(
         api_key_path: "fastlane/key.json",
         distribute_external: false, # default
-        changelog: "changelog"
+        changelog: options[:changelog]
       )
     else
       upload_to_testflight(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,6 +53,7 @@ platform :ios do
         version_number: options[:version],
         xcodeproj: "NADA-iOS-forRelease.xcodeproj"
       )
+      version = options[:version]
     else
       version = get_version_number(
                   target: "NADA-iOS-forRelease"
@@ -113,6 +114,7 @@ platform :ios do
         version_number: options[:version],
         xcodeproj: "NADA-iOS-forRelease.xcodeproj"
       )
+      version = options[:version]
     else
       version = get_version_number(
                   target: "NADA-iOS-forRelease"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,17 @@ platform :ios do
     build_app(workspace: "NADA-iOS-forRelease.xcworkspace", scheme: "NADA-iOS-forRelease")
     upload_to_app_store
 
+  # install
+  desc "Add certificates and provisioning profiles on a new machine"
+  lane :install do
+    match(type: "appstore",
+          app_identifier:["YJC.NADA-iOS-forRelease", "YJC.NADA-iOS-forRelease.Widgets", "YJC.NADA-iOS-forRelease.IntentsExtension", "YJC.NADA-iOS-forRelease.IntentsExtensionUI"],
+          readonly: true)
+    match(type: "development",
+          app_identifier:["YJC.NADA-iOS-forRelease", "YJC.NADA-iOS-forRelease.Widgets", "YJC.NADA-iOS-forRelease.IntentsExtension", "YJC.NADA-iOS-forRelease.IntentsExtensionUI"],
+          readonly: true)
+  end
+
   # error
   error do |lane, exception, options|
     version = get_version_number(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,5 +21,23 @@ platform :ios do
     increment_build_number(xcodeproj: "NADA-iOS-forRelease.xcodeproj")
     build_app(workspace: "NADA-iOS-forRelease.xcworkspace", scheme: "NADA-iOS-forRelease")
     upload_to_app_store
+
+  # error
+  error do |lane, exception, options|
+    version = get_version_number(
+                target: "NADA-iOS-forRelease"
+              )
+    build = get_build_number 
+
+    slack(
+      username: "fastlane",
+      icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/f997e95e-3c09-432b-aa35-9c67ea381e0d",
+      message: "에러 발생!!! 발생!!🚨 : #{exception}",
+      success: false,
+      slack_url: "https://hooks.slack.com/services/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",
+      payload: {
+	"Version": version + "(" + build + ")"
+      }
+    )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,6 +38,7 @@ platform :ios do
     )
 
     upload_to_app_store(
+      api_key_path: "fastlane/key.json",
       skip_metadata: false, #default
       skip_screenshots: true,
       submit_for_review: true,
@@ -94,11 +95,13 @@ platform :ios do
     # changelog 사용 시 반영, 미사용시 빈값.
     if options[:changelog]
       upload_to_testflight(
+        api_key_path: "fastlane/key.json",
         distribute_external: false, # default
         changelog: "changelog"
       )
     else
       upload_to_testflight(
+        api_key_path: "fastlane/key.json",
         distribute_external: false, # default
         changelog: ""
       )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -66,7 +66,7 @@ platform :ios do
       icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/0c947bbc-9406-465a-b918-d154a26f7320",
       message: "성공적으로 앱을 등록했습니다!💫",
       success: true, # default
-      slack_url: "https://hooks.slack.com/services/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",
+      slack_url: "https://hooks.slack.com/services/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",
       payload: {
 	"Version": version + "(" + build + ")"
       }
@@ -126,7 +126,7 @@ platform :ios do
       icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/0c947bbc-9406-465a-b918-d154a26f7320",
       message: "성공적으로 TestFlight 에 등록되었습니다!🔥",
       success: true, # default
-      slack_url: "https://hooks.slack.com/services/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",
+      slack_url: "https://hooks.slack.com/services/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",
       payload: {
 	"Version": version + "(" + build + ")"
       }
@@ -156,7 +156,7 @@ platform :ios do
       icon_url: "https://github.com/hyun99999/algorithm-Swift/assets/69136340/0c947bbc-9406-465a-b918-d154a26f7320",
       message: "에러 발생!!! 발생!!🚨 : #{exception}",
       success: false,
-      slack_url: "https://hooks.slack.com/services/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",
+      slack_url: "https://hooks.slack.com/services/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",
       payload: {
 	"Version": version + "(" + build + ")"
       }

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,40 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios release
+
+```sh
+[bundle exec] fastlane ios release
+```
+
+Push a new release build to the App Store
+
+### ios install
+
+```sh
+[bundle exec] fastlane ios install
+```
+
+Add certificates and provisioning profiles on a new machine
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #579

🌱 작업한 내용
### testflight
- multiple targets 을 대응.
- 빌드 넘버 증가.
- 명령어 입력 시 파라미터를 전달하여 버전 설정 및 테스트 메모 설정.
- 외부 테스트가 아닌 내부 테스트만 진행.
- slack 연동.

### release
- multiple targets 을 대응.
- 빌드 넘버 증가.
- 명령어 입력 시 파라미터를 전달하여 버전 설정.
- slack 연동.

### 🚨 참고 사항
> match 방식의 fastfile 을 작성한 내용입니당
> https://gyuios.tistory.com/287

- 스크린샷 다운로드 : fastlane deliver download_screenshots
- 메타데이터 다운로드 : fastlane deliver download_metadata
명령어로 다운받아서 push 해주면 다음 릴리즈부터 사용할 수 있을 것 같심더! 스크린샷과 메타데이터 양식을 사용해야하기 때문이죵


- lane 의 다음 명령어를 통해 테스트 메모 작성되는데 여러줄 작성할때는 fastfile 에서 직접 수정하면 되겠습니당. else 의 ""에 넣으면 됩니당
```ruby
    if options[:changelog]
      upload_to_testflight(
        distribute_external: false, # default
        changelog: "changelog"
      )
    else
      upload_to_testflight(
        distribute_external: false, # default
        changelog: ""
      )
    end
```

- 다음과 같이 터미널에서 명령어 사용하면 됩니당
```ruby
fastlane beta version:"2.2.0" changelog:"테스트 메모"

fastlane beta # version 그대로, changelog 빈값 넘길때

fastlane release version:"2.2.0"

fastlane release # version 그대로
```

## 📮 관련 이슈
- Resolved: #579
