### PR TITLE
bug: 명함 생성 시 새로 만든 명함으로 스크롤 되지 않는 버그 해결 (#586)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -73,6 +73,7 @@ class FrontViewController: UIViewController {
                 }
             }
         }
+        self.isAfterCreation = false
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -164,7 +165,6 @@ extension FrontViewController {
         
         cardListPageFetchWithAPI(pageNumber: pageNumber, pageSize: pageSize) {
             _ = self.cardSwiper.scrollToCard(at: 1, animated: false)
-            self.isAfterCreation = false
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #586

🌱 작업한 내용
생성 전에 기본/직장/덕질 을 고르는 단계가 추가되면서(push) 이전에는present 였기 때문에 viewWillAppear 미호출되다가 현재는 네비게이션 뷰컨의 라이프 사이클에 따라서 viewWillAppear 가 호출되게 되었습니다.
그래서 이전에

`명함 생성 -> 노티 & isAfterCreation true-> dismiss -> 두번째 명함(갓 생성한 명함) & isAfterCreation false 로 변경`

동작한 구조가 다음과 같이 변경되었습니다.(왜인지 모르겠지만 viewWillAppear 가 호출되지 않기에 viewWillAppear 에 조건문을 달지 않아도 되었을 텐데.. 일단 이렇게 구현되어 있었음)

`명함 생성 -> 노티 & isAfterCreation true -> dismiss -> pop -> 두번째 명함으로 이동 & isAfterCreation 변수 false 로 변경 -> viewWillAppear 호출하여 다시 첫번째 명함으로 스크롤`

**그래서 명함을 생성하면 두 번째 명함으로 이동 -> 로딩뷰 -> 명함 목록 다시 조회하기 때문에 첫번째 명함부터 등장
하는 현상이 생겼습니다.**

그래서 isAfterCreation 변수를 재할당하는 코드의 순서를 변경하여서 해결했습니다.
**즉, viewWillAppear 에서 명함 생성을 판단하고 그 후에 isAfterCreartion 변수를 false 로 수정.**


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|버그|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/b4c8dbec-6e16-4241-aca2-1794d762039c" width ="250">|
|해결|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/df445ea1-24ab-400b-896b-6a4a0cd8f836" width ="250">|


## 📮 관련 이슈
- Resolved: #586
