### PR TITLE
refactor: 중첩 클로저에서 [weak self] 사용 개선 (#589)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Home/VC/HomeViewController.swift
@@ -197,7 +197,7 @@ extension HomeViewController {
     private func checkUpdateVersionAndSetting() {
         updateUserInfoFetchWithAPI { [weak self] checkUpdateNote in
             if !checkUpdateNote {
-                self?.updateNoteFetchWithAPI { [weak self] updateNote in
+                self?.updateNoteFetchWithAPI { updateNote in
                     if self?.checkUpdateAvailable(updateNote.latestVersion) ?? false {
                         self?.presentToUpdateVC(with: updateNote)
                         UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.dynamicLinkCardUUID)
@@ -256,7 +256,7 @@ extension HomeViewController {
     
     private func checkDynamicLink(_ dynamicLinkCardUUID: String) {
         self.cardDetailFetchWithAPI(cardUUID: dynamicLinkCardUUID) { [weak self] cardDataModel in
-            self?.cardAddInGroupWithAPI(cardUUID: dynamicLinkCardUUID) { [weak self] in
+            self?.cardAddInGroupWithAPI(cardUUID: dynamicLinkCardUUID) {
                 UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.dynamicLinkCardUUID)
                 self?.presentToCardDetailVC(cardDataModel: cardDataModel)
             }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/TabBar/TabBarViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/TabBar/TabBarViewController.swift
@@ -64,7 +64,7 @@ extension TabBarViewController {
     
     private func checkDynamicLink(_ dynamicLinkCardUUID: String) {
         self.cardDetailFetchWithAPI(cardUUID: dynamicLinkCardUUID) { [weak self] cardDataModel in
-            self?.cardAddInGroupWithAPI(cardUUID: dynamicLinkCardUUID) { [weak self] in
+            self?.cardAddInGroupWithAPI(cardUUID: dynamicLinkCardUUID) {
                 self?.presentToCardDetailVC(cardDataModel: cardDataModel)
             }
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #589

🌱 작업한 내용
- 중첩 클로저에서 다음과 같은 상황에서 inner closure 에 [weak self] 캡처리스트는 사용하지 않아도 reference count 가 올라가지 않기 때문에 코드 개선.

```swift
self.doSomething { [weak self] in  ✅
// guard let self = self else { return }
// 를 사용하면 강한 참조이기 때문에 [weak self] 사용해줘야 함.
    self?.doSomethingElse { [weak self] in  ✅ 불필요

    }
}
```

## 📮 관련 이슈
- Resolved: #589
