### PR TITLE
feat: 명함 수정 API 추가 (#598)

### DIFF
--- a/NADA-iOS-forRelease/Sources/NetworkService/Card/CardAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Card/CardAPI.swift
@@ -30,8 +30,8 @@ public class CardAPI {
         }
     }
     
-    func cardCreation(request: CardCreationRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
-        cardProvider.request(.cardCreation(request: request)) { (result) in
+    func cardCreation(request: CardCreationRequest, type: CreationType = .create, cardUUID: String? = nil, completion: @escaping (NetworkResult<Any>) -> Void) {
+        cardProvider.request(.cardCreation(request: request, type: type, cardUUID: cardUUID)) { (result) in
             switch result {
             case .success(let response):
                 let statusCode = response.statusCode

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationPreviewViewController.swift
@@ -21,6 +21,7 @@ class CardCreationPreviewViewController: UIViewController {
     private var isFront = true
     private var isShareable = false
     private var creationType: CreationType = .create
+    private var cardUUID: String?
     
     lazy var loadingBgView: UIView = {
         let bgView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height))
@@ -79,8 +80,7 @@ class CardCreationPreviewViewController: UIViewController {
                 case .create:
                     self.cardCreationWithAPI(request: cardCreationRequest)
                 case .modify:
-                    // FIXME: - 명함 수정 API 로 수정.
-                    self.cardModifyWithAPI(request: cardCreationRequest)
+                    self.cardModifyWithAPI(request: cardCreationRequest, cardUUID: cardUUID)
                 }
             }
         }
@@ -249,6 +249,9 @@ extension CardCreationPreviewViewController {
     public func setCreationType(_ creationType: CreationType) {
         self.creationType = creationType
     }
+    public func setCardUUID(_ cardUUID: String) {
+        self.cardUUID = cardUUID
+    }
 
     // MARK: - @objc Methods
     
@@ -329,9 +332,8 @@ extension CardCreationPreviewViewController {
             }
         }
     }
-    private func cardModifyWithAPI(request: CardCreationRequest) {
-        // FIXME: - 명함 생성 API 로 교체.
-        CardAPI.shared.cardCreation(request: request) { response in
+    private func cardModifyWithAPI(request: CardCreationRequest, cardUUID: String?) {
+        CardAPI.shared.cardCreation(request: request, type: .modify, cardUUID: cardUUID) { response in
             switch response {
             case .success:
                 print("cardModifyWithAPI - success")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CardCreationViewController.swift
@@ -104,6 +104,9 @@ class CardCreationViewController: UIViewController {
         nextVC.tasteInfo = tasteInfo
         nextVC.cardType = cardType
         nextVC.setCreationType(creationType)
+        if let cardUUID = preCardDataModel?.cardUUID {
+            nextVC.setCardUUID(cardUUID)
+        }
         
         navigationController?.pushViewController(nextVC, animated: true)
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CompanyCardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CompanyCardCreationViewController.swift
@@ -103,6 +103,9 @@ class CompanyCardCreationViewController: UIViewController {
         nextVC.tasteInfo = tasteInfo
         nextVC.cardType = cardType
         nextVC.setCreationType(creationType)
+        if let cardUUID = preCardDataModel?.cardUUID {
+            nextVC.setCardUUID(cardUUID)
+        }
         
         navigationController?.pushViewController(nextVC, animated: true)
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CompanyCardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/CompanyCardCreationViewController.swift
@@ -415,7 +415,7 @@ extension CompanyCardCreationViewController: UICollectionViewDataSource {
                 }
                 backCreationCell.backCardCreationDelegate = self
                 if let tasteInfo {
-                    backCreationCell.tasteInfo = tasteInfo.map { $0.tasteName }
+                    backCreationCell.setTasteInfo(tasteInfo.map { $0.tasteName })
                 }
                 backCreationCell.cardType = cardType
                 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/FanCardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/FanCardCreationViewController.swift
@@ -103,6 +103,9 @@ class FanCardCreationViewController: UIViewController {
         nextVC.tasteInfo = tasteInfo
         nextVC.cardType = cardType
         nextVC.setCreationType(creationType)
+        if let cardUUID = preCardDataModel?.cardUUID {
+            nextVC.setCardUUID(cardUUID)
+        }
         
         navigationController?.pushViewController(nextVC, animated: true)
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/FanCardCreationViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardCreation/VC/FanCardCreationViewController.swift
@@ -409,7 +409,7 @@ extension FanCardCreationViewController: UICollectionViewDataSource {
                 }
                 backCreationCell.backCardCreationDelegate = self
                 if let tasteInfo {
-                    backCreationCell.tasteInfo = tasteInfo.map { $0.tasteName }
+                    backCreationCell.setTasteInfo(tasteInfo.map { $0.tasteName })
                 }
                 backCreationCell.cardType = cardType
                 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #598

🌱 작업한 내용
- 명함 수정 API 적용.
- 명함 미리보기 뷰까지 cardUUID 를 전달하여서 명함 수정 API 에 사용.
- 명함 수정(creationType 이 modify)일 때,  HTTP method 를 put 으로 변경.

### 🚨 참고사항
- 이전 PR 에서 set 함수를 적용하지 않아서 에러가 존재했었습니당. 
- 수정은 4c60af03e2883bf7c0b1e02256ee22e181437a84 커밋에서 확인하실 수 있습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|명함 수정|<img src = "https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/9b65c5c7-562c-4d92-a4cf-74c08f32aa4f" width ="250">|

## 📮 관련 이슈
- Resolved: #598
