### PR TITLE
fix: 태그 보내기 UI 변경 (#633)

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -26,5 +26,5 @@ extension Notification.Name {
     static let presentMail = Notification.Name("presentMail")
     static let presentDynamicLink = Notification.Name("presentDynamicLink")
     static let backToHome = Notification.Name("backToHome")
-    static let presentToTagSheet = Notification.Name("presentToTagSheet")
+    static let presentToReceivedTagSheet = Notification.Name("presentToTagSheet")
 }

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -33,7 +33,7 @@ class BackCardCell: CardCell {
     
     // MARK: - Functions
     @IBAction func touchTagButton(_ sender: Any) {
-        NotificationCenter.default.post(name: .presentToTagSheet, object: cardUUID)
+        NotificationCenter.default.post(name: .presentToReceivedTagSheet, object: cardUUID)
     }
     
     static func nib() -> UINib {

--- a/NADA-iOS-forRelease/Sources/Model/CustomDetent.swift
+++ b/NADA-iOS-forRelease/Sources/Model/CustomDetent.swift
@@ -16,11 +16,11 @@ struct CustomDetent {
         return 572 - safeAreaBottom
     }
     
-    static let editTagDetent = UISheetPresentationController.Detent.custom(identifier: .init("editTagDetent")) { _ in
-        return 304 - safeAreaBottom
-    }
+//    static let editTagDetent = UISheetPresentationController.Detent.custom(identifier: .init("editTagDetent")) { _ in
+//        return 304 - safeAreaBottom
+//    }
     
     static let sendTagDetent = UISheetPresentationController.Detent.custom(identifier: .init("sendTagDetent")) { _ in
-        return 389 - safeAreaBottom
+        return 388 - safeAreaBottom
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Main/FrontViewController.swift
@@ -116,7 +116,7 @@ extension FrontViewController {
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(didRecievePresentCardShare(_:)), name: .presentCardShare, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(setCreationReloadMainCardSwiper), name: .creationReloadMainCardSwiper, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(presentToTagSheet(_:)), name: .presentToTagSheet, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(presentToReceivedTagSheet(_:)), name: .presentToReceivedTagSheet, object: nil)
     }
     
     private func setActivityIndicator() {
@@ -170,7 +170,7 @@ extension FrontViewController {
     }
     
     @objc
-    private func presentToTagSheet(_ notification: Notification) {
+    private func presentToReceivedTagSheet(_ notification: Notification) {
         if let cardUUID = notification.object as? String {
             let tagSheet = FetchTagSheetVC()
             

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -210,31 +210,49 @@ extension SendTagSheetVC {
         subtitleLabel.textColor = .mainColorButtonText
         adjectiveTextFiled.becomeFirstResponder()
         
+        colorView.snp.updateConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(41)
+        }
+        
         UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseIn, animations: { [weak self] in
-            [self?.sendTagLabel, self?.sendButton, self?.backButton].forEach { $0?.alpha = 0 }
+            [self?.cardNameLabel, self?.sendTagLabel, self?.sendButton, self?.backButton].forEach { $0?.alpha = 0 }
+            
+            self?.view.layoutIfNeeded()
         }, completion: { [weak self] _ in
+            self?.cardNameLabel.isHidden = true
+            self?.sendTagLabel.isHidden = true
             self?.sendButton.isHidden = true
             self?.backButton.isHidden = true
             
             UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseIn) {
-                self?.sendTagLabel.isHidden = true
                 self?.subtitleLabel.isHidden = false
                 self?.subtitleLabel.alpha = 1
                 self?.collectionView.isHidden = false
                 self?.collectionView.alpha = 1
+                self?.nextButton.isHidden = false
+                self?.nextButton.alpha = 1
             }
         })
     }
     private func setSendUIWithAnimation() {
+        colorView.snp.updateConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(20)
+        }
+        
         UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseIn, animations: { [weak self] in
-            [self?.subtitleLabel, self?.collectionView].forEach { $0?.alpha = 0 }
+            [self?.subtitleLabel, self?.collectionView, self?.nextButton].forEach { $0?.alpha = 0 }
+            
+            self?.view.layoutIfNeeded()
         }, completion: { [weak self] _ in
             self?.subtitleLabel.isHidden = true
             self?.collectionView.isHidden = true
+            self?.nextButton.isHidden = true
             
             UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseIn) {
                 self?.sendTagLabel.isHidden = false
                 self?.sendTagLabel.alpha = 1
+                self?.cardNameLabel.isHidden = false
+                self?.cardNameLabel.alpha = 1
                 self?.backButton.isHidden = false
                 self?.backButton.alpha = 1
                 self?.sendButton.isHidden = false
@@ -244,24 +262,21 @@ extension SendTagSheetVC {
     }
     private func setCompletedUIWithAnimation() {
         UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseIn, animations: { [weak self] in
-            [self?.sendTagLabel, self?.backButton, self?.sendButton, self?.colorView].forEach { $0?.alpha = 0 }
+            [self?.backButton, self?.sendButton, self?.colorView, self?.sendTagLabel, self?.cardNameLabel].forEach { $0?.alpha = 0 }
         }, completion: { [weak self] _ in
             self?.backButton.isHidden = true
             self?.sendButton.isHidden = true
             self?.colorView.isHidden = true
             
-            let attributeString = NSMutableAttributedString(string: "ID \(self?.cardUUID ?? "") 명함에 태그를 보냈어요!")
-            attributeString.addAttribute(.font, value: UIFont.textBold01, range: NSRange(location: 0, length: 2))
-            attributeString.addAttribute(.font, value: UIFont.textRegular03, range: NSRange(location: 2, length: attributeString.length - 2))
-            
-            self?.sendTagLabel.attributedText = attributeString
+            self?.sendTagLabel.text = "명함에 태그를 보냈어요!"
             
             UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseIn) {
-                self?.sendTagLabel.alpha = 1.0
                 self?.checkImageView.isHidden = false
                 self?.checkImageView.alpha = 1.0
                 self?.completeButton.isHidden = false
                 self?.completeButton.alpha = 1.0
+                self?.sendTagLabel.alpha = 1.0
+                self?.cardNameLabel.alpha = 1.0
             }
         })
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -81,10 +81,10 @@ class SendTagSheetVC: UIViewController {
     private let nextButton = UIButton().then {
         $0.setTitle("다음", for: .normal)
         $0.backgroundColor = .textBox
-        $0.titleLabel?.textColor = .quaternary
+        $0.setTitleColor(.quaternary, for: .normal)
         $0.titleLabel?.font = .button01
         $0.layer.cornerRadius = 15
-        $0.isEnabled = false
+        $0.isUserInteractionEnabled = false
     }
     private var cardNameLabel = UILabel().then {
         $0.textColor = .mainColorNadaMain
@@ -191,6 +191,16 @@ extension SendTagSheetVC {
             .distinctUntilChanged()
             .bind(with: self) { owner, text in
                 owner.countTextFieldText(text, owner.adjectiveTextFiled)
+                
+                if !text.isEmpty && !(owner.nounTextFiled.text ?? "").isEmpty {
+                    owner.nextButton.isUserInteractionEnabled = true
+                    owner.nextButton.backgroundColor = .mainColorNadaMain
+                    owner.nextButton.setTitleColor(.white, for: .normal)
+                } else {
+                    owner.nextButton.isUserInteractionEnabled = true
+                    owner.nextButton.backgroundColor = .textBox
+                    owner.nextButton.setTitleColor(.quaternary, for: .normal)
+                }
             }.disposed(by: disposeBag)
         
         nounTextFiled.rx.text
@@ -198,6 +208,16 @@ extension SendTagSheetVC {
             .distinctUntilChanged()
             .bind(with: self) { owner, text in
                 owner.countTextFieldText(text, owner.nounTextFiled)
+                
+                if !(owner.adjectiveTextFiled.text ?? "").isEmpty && !text.isEmpty {
+                    owner.nextButton.isUserInteractionEnabled = true
+                    owner.nextButton.backgroundColor = .mainColorNadaMain
+                    owner.nextButton.setTitleColor(.white, for: .normal)
+                } else {
+                    owner.nextButton.isUserInteractionEnabled = true
+                    owner.nextButton.backgroundColor = .textBox
+                    owner.nextButton.setTitleColor(.quaternary, for: .normal)
+                }
             }.disposed(by: disposeBag)
     }
     private func setDelegate() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -196,7 +196,7 @@ extension SendTagSheetVC {
             .bind(with: self) { owner, text in
                 owner.countTextFieldText(text, owner.adjectiveTextFiled)
                 
-                if !text.isEmpty && !(owner.nounTextFiled.text ?? "").isEmpty {
+                if !text.isEmpty && owner.nounTextFiled.hasText {
                     owner.nextButton.isUserInteractionEnabled = true
                     owner.nextButton.backgroundColor = .mainColorNadaMain
                     owner.nextButton.setTitleColor(.white, for: .normal)
@@ -213,7 +213,7 @@ extension SendTagSheetVC {
             .bind(with: self) { owner, text in
                 owner.countTextFieldText(text, owner.nounTextFiled)
                 
-                if !(owner.adjectiveTextFiled.text ?? "").isEmpty && !text.isEmpty {
+                if !text.isEmpty && owner.adjectiveTextFiled.hasText {
                     owner.nextButton.isUserInteractionEnabled = true
                     owner.nextButton.backgroundColor = .mainColorNadaMain
                     owner.nextButton.setTitleColor(.white, for: .normal)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -168,6 +168,10 @@ extension SendTagSheetVC {
         [sendTagLabel, backButton, sendButton, checkImageView, completeButton].forEach { $0.isHidden = true }
     }
     private func bind() {
+        nextButton.rx.tap.bind { [weak self] in
+            self?.checkTag()
+        }.disposed(by: disposeBag)
+        
         backButton.rx.tap.bind { [weak self] in
             self?.adjectiveTextFiled.isUserInteractionEnabled = true
             self?.nounTextFiled.isUserInteractionEnabled = true
@@ -305,6 +309,21 @@ extension SendTagSheetVC {
             let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
             let newString = String(text[text.startIndex..<maxIndex])
             textField.text = newString
+        }
+    }
+    private func checkTag() {
+        if let adjectiveText = adjectiveTextFiled.text, let nounText = nounTextFiled.text,
+           !adjectiveText.isEmpty, !nounText.isEmpty {
+            if let items = collectionView.indexPathsForSelectedItems?.map({ index in index.item }) {
+                creationTagRequest = .init(adjective: adjectiveText, cardUUID: cardUUID ?? "", icon: tags[items[0]].icon, noun: nounText)
+                
+                tagFilteringWithAPI(request: CreationTagRequest(adjective: adjectiveText,
+                                                                cardUUID: cardUUID ?? "",
+                                                                icon: tags[items[0]].icon,
+                                                                noun: nounText)) { [weak self] in
+                    self?.setSendUIWithAnimation()
+                }
+            }
         }
     }
     public func setCardUUID(_ cardUUID: String) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -204,9 +204,6 @@ extension SendTagSheetVC {
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.register(SendTagCVC.self, forCellWithReuseIdentifier: "SendTagCVC")
-        
-        adjectiveTextFiled.delegate = self
-        nounTextFiled.delegate = self
     }
     private func setEditUIWithAnimation() {
         subtitleLabel.text = "명함을 자유롭게 표현해 보세요"
@@ -454,30 +451,5 @@ extension SendTagSheetVC: UICollectionViewDataSource {
                       tags[indexPath.item].db)
         
         return cell
-    }
-}
-
-// MARK: - UITextFieldDelegate
-
-extension SendTagSheetVC: UITextFieldDelegate {
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if let adjectiveText = adjectiveTextFiled.text, let nounText = nounTextFiled.text,
-           !adjectiveText.isEmpty, !nounText.isEmpty {
-            if let items = collectionView.indexPathsForSelectedItems?.map({ index in index.item }) {
-                creationTagRequest = .init(adjective: adjectiveText, cardUUID: cardUUID ?? "", icon: tags[items[0]].icon, noun: nounText)
-
-                tagFilteringWithAPI(request: CreationTagRequest(adjective: adjectiveText,
-                                                                cardUUID: cardUUID ?? "",
-                                                                icon: tags[items[0]].icon,
-                                                                noun: nounText)) { [weak self] in
-                    self?.setSendUIWithAnimation()
-                }
-            }
-        } else {
-            subtitleLabel.text = "형용사, 명사 모두를 입력해 주세요."
-            subtitleLabel.textColor = .stateColorError
-        }
-        
-        return false
     }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -22,9 +22,16 @@ class SendTagSheetVC: UIViewController {
     private var tags: [Tag] = []
     private var keyboardOn: Bool = false
     private var creationTagRequest: CreationTagRequest?
+    private var mode: Mode = .edit
     
     private let maxLength: Int = 7
     private let disposeBag = DisposeBag()
+    
+    private enum Mode {
+        case edit
+        case send
+        case completed
+    }
 
     // MARK: - Components
     
@@ -294,6 +301,10 @@ extension SendTagSheetVC {
             switch networkResult {
             case .success:
                 print("tagCreationWithAPI - success")
+                
+                DispatchQueue.main.async {
+                    self?.mode = .completed
+                }
                 
                 completion()
             case .requestErr:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -78,13 +78,25 @@ class SendTagSheetVC: UIViewController {
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout).then {
         $0.showsHorizontalScrollIndicator = false
     }
+    private let nextButton = UIButton().then {
+        $0.setTitle("다음", for: .normal)
+        $0.backgroundColor = .textBox
+        $0.titleLabel?.textColor = .quaternary
+        $0.titleLabel?.font = .button01
+        $0.layer.cornerRadius = 15
+        $0.isEnabled = false
+    }
+    private var cardNameLabel = UILabel().then {
+        $0.textColor = .mainColorNadaMain
+        $0.font = .textBold01
+        $0.isHidden = true
+        $0.alpha = 0
+    }
     private lazy var sendTagLabel = UILabel().then {
-        let attributeString = NSMutableAttributedString(string: "ID \(cardUUID ?? "") 명함에 태그를 보낼까요?")
-        attributeString.addAttribute(.font, value: UIFont.textBold01, range: NSRange(location: 0, length: 2))
-        attributeString.addAttribute(.font, value: UIFont.textRegular03, range: NSRange(location: 2, length: attributeString.length - 2))
-        
-        $0.attributedText = attributeString
-        $0.textColor = .secondary
+        $0.text = "명함에 태그를 보낼까요?"
+        $0.font = .textRegular04
+        $0.textColor = .primary
+        $0.isHidden = true
         $0.alpha = 0
     }
     private let sendButton = UIButton().then {
@@ -93,6 +105,7 @@ class SendTagSheetVC: UIViewController {
         $0.setTitle("보내기", for: .normal)
         $0.titleLabel?.font = .button01
         $0.layer.cornerRadius = 15
+        $0.isHidden = true
         $0.alpha = 0
     }
     private let backButton = UIButton().then {
@@ -101,6 +114,7 @@ class SendTagSheetVC: UIViewController {
         $0.setTitle("뒤로가기", for: .normal)
         $0.titleLabel?.font = .button01
         $0.layer.cornerRadius = 15
+        $0.isHidden = true
         $0.alpha = 0
     }
     private let completeButton = UIButton().then {
@@ -109,6 +123,7 @@ class SendTagSheetVC: UIViewController {
         $0.setTitle("완료", for: .normal)
         $0.titleLabel?.font = .button01
         $0.layer.cornerRadius = 15
+        $0.isHidden = true
         $0.alpha = 0
     }
     private let checkImageView = UIImageView().then {
@@ -147,6 +162,8 @@ extension SendTagSheetVC {
         collectionView.backgroundColor = .background
         
         IQKeyboardManager.shared.shouldResignOnTouchOutside = false
+        
+        cardNameLabel.text = cardUUID
         
         [sendTagLabel, backButton, sendButton, checkImageView, completeButton].forEach { $0.isHidden = true }
     }
@@ -327,7 +344,7 @@ extension SendTagSheetVC {
 
 extension SendTagSheetVC {
     private func setLayout() {
-        view.addSubviews([grabber, titleLabel, subtitleLabel, colorView, collectionView, sendTagLabel, backButton, sendButton, checkImageView, completeButton])
+        view.addSubviews([grabber, titleLabel, subtitleLabel, colorView, collectionView, nextButton, cardNameLabel, sendTagLabel, backButton, sendButton, checkImageView, completeButton])
         
         grabber.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(12)
@@ -342,7 +359,7 @@ extension SendTagSheetVC {
             make.centerX.equalToSuperview()
         }
         colorView.snp.makeConstraints { make in
-            make.top.equalTo(subtitleLabel.snp.bottom).offset(14)
+            make.top.equalTo(titleLabel.snp.bottom).offset(41)
             make.height.equalTo(132)
             make.left.right.equalToSuperview().inset(41)
         }
@@ -351,28 +368,37 @@ extension SendTagSheetVC {
             make.left.right.equalToSuperview().inset(39)
             make.height.equalTo(32)
         }
+        nextButton.snp.makeConstraints { make in
+            make.top.equalTo(collectionView.snp.bottom).offset(22)
+            make.left.right.equalToSuperview().inset(24)
+            make.height.equalTo(54)
+        }
+        cardNameLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(170)
+            make.centerX.equalToSuperview()
+        }
         sendTagLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(191)
+            make.top.equalTo(titleLabel.snp.bottom).offset(194)
             make.centerX.equalToSuperview()
         }
         backButton.snp.makeConstraints { make in
-            make.top.equalTo(sendTagLabel.snp.bottom).offset(20)
+            make.top.equalTo(sendTagLabel.snp.bottom).offset(18)
             make.left.equalToSuperview().inset(24)
             make.right.equalTo(view.snp.centerX).inset(3.5)
             make.height.equalTo(54)
         }
         sendButton.snp.makeConstraints { make in
-            make.top.equalTo(sendTagLabel.snp.bottom).offset(20)
+            make.top.equalTo(sendTagLabel.snp.bottom).offset(18)
             make.right.equalToSuperview().inset(24)
             make.left.equalTo(view.snp.centerX).offset(3.5)
             make.height.equalTo(54)
         }
         checkImageView.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(45)
+            make.top.equalTo(titleLabel.snp.bottom).offset(20)
             make.centerX.equalToSuperview()
         }
         completeButton.snp.makeConstraints { make in
-            make.top.equalTo(sendTagLabel.snp.bottom).offset(20)
+            make.top.equalTo(sendTagLabel.snp.bottom).offset(18)
             make.right.left.equalToSuperview().inset(24)
             make.height.equalTo(54)
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #633

🌱 작업한 내용
- 태그 보내기 UI 변경하였습니다.
    - 다음버튼이 생기고, 바텀시트 높이가 동일해졌습니다. 애니메이션을 수정하였습니다.
    - 키보드 완료버튼으로 변경하였습니다. 완료 버튼을 통해서 키보드가 내려갈 수 있게되었습니다.
- CustomDetent 도 태그 보내기 한개로 통일하였습니다.
- 받은 태그 뷰 관련해서 notification 네이밍을 수정하였습니다.
- mode 변수는 커밋과정에서 누락되어서 지금 추가합니다 ㅜ (한꺼번에 작업을 많이하고 쌓아뒀다가 커밋하면 이런 점이 아쉬운거 같습니다. 그렇다고 커밋해버리면 수정된 코드에 대한 표시가 Xcode 에 나타나지 않아서 약간 불편도 하구용 ㅎㅎ)
- text field 를 subscribe 하게되면 입력전에도 이벤트가 발생합니다. 그래서 `skip(1)` 과 같이 사용도하는데 저는 다음과 같이 구현하였습니다.

```swift
// text field 로 부터 옵셔널 바인딩 된 text 를 얻을 수 있음.
// 명사, 형용사 텍스트필드의 값을 조회하는데 좀 더 좋은 코드가 있지 않을까 고민해봤는데 요렇게 진행했어요..
// 아마도 textField delegate 를 사용했다면 한번에 작업할 수는 있었지 않았나 싶습니당
// 그래도 Rx 사용하려고 노력하였어용
if !text.isEmpty && !(owner.nounTextFiled.text ?? "").isEmpty {
    // 버튼 활성화
} else {
    // 버튼 비활성화
}
```

## 🚨 참고사항 
- #637 
- 뷰와 관련하여 해당 오류가 있어서 진행할 예정입니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|다음 버튼|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/e6b3de90-e046-4fdf-af38-9f6fbb2d061d" width="200">|

## 📮 관련 이슈
- Resolved: #633
