### PR TITLE
feat: 태그 필터링 API 구현 (#622)

### DIFF
--- a/NADA-iOS-forRelease/Sources/NetworkService/Tag/TagAPI.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Tag/TagAPI.swift
@@ -89,4 +89,23 @@ public class TagAPI: BasicAPI {
             return Disposables.create()
         }
     }
+    
+    public func tagFiltering(query: String) -> Single<NetworkResult2<GenericResponse<Bool>>> {
+        return Single<NetworkResult2<GenericResponse<Bool>>>.create { [weak self] single in
+            self?.tagProvider.request(.tagFiltering(query: query)) { result in
+                switch result {
+                case .success(let response):
+                    let networkResult = self?.judgeStatus(response: response, type: Bool.self)
+                    if let networkResult {
+                        single(.success(networkResult))
+                        return
+                    }
+                case .failure(let error):
+                    single(.failure(error))
+                    return
+                }
+            }
+            return Disposables.create()
+        }
+    }
 }

--- a/NADA-iOS-forRelease/Sources/NetworkService/Tag/TagService.swift
+++ b/NADA-iOS-forRelease/Sources/NetworkService/Tag/TagService.swift
@@ -14,6 +14,7 @@ enum TagService {
     case tagFetch
     case receivedTagFetch(cardUUID: String)
     case tagDelete(request: [TagDeletionRequest])
+    case tagFiltering(query: String)
 }
 
 extension TagService: TargetType {
@@ -31,6 +32,8 @@ extension TagService: TargetType {
             return "/v1/card/tag/card/\(cardUUID)"
         case .tagDelete:
             return "/v1/card/tag/delete"
+        case .tagFiltering:
+            return "/v1/slang"
         }
     }
     
@@ -38,7 +41,7 @@ extension TagService: TargetType {
         switch self {
         case .tagCreation, .tagDelete:
             return .post
-        case .tagFetch, .receivedTagFetch:
+        case .tagFetch, .receivedTagFetch, .tagFiltering:
             return .get
         }
     }
@@ -49,6 +52,8 @@ extension TagService: TargetType {
             return .requestJSONEncodable(request)
         case .tagDelete(let request):
             return .requestJSONEncodable(request)
+        case .tagFiltering(let query):
+            return .requestParameters(parameters: ["text": query], encoding: URLEncoding.queryString)
         case .tagFetch, .receivedTagFetch:
             return .requestPlain
         }
@@ -58,7 +63,7 @@ extension TagService: TargetType {
         switch self {
         case .tagCreation, .tagDelete:
             return Const.Header.basicHeader()
-        case .tagFetch, .receivedTagFetch:
+        case .tagFetch, .receivedTagFetch, .tagFiltering:
             return Const.Header.bearerHeader()
         }
     }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -317,11 +317,27 @@ extension SendTagSheetVC {
             if let items = collectionView.indexPathsForSelectedItems?.map({ index in index.item }) {
                 creationTagRequest = .init(adjective: adjectiveText, cardUUID: cardUUID ?? "", icon: tags[items[0]].icon, noun: nounText)
                 
-                tagFilteringWithAPI(request: CreationTagRequest(adjective: adjectiveText,
-                                                                cardUUID: cardUUID ?? "",
-                                                                icon: tags[items[0]].icon,
-                                                                noun: nounText)) { [weak self] in
-                    self?.setSendUIWithAnimation()
+                tagFilteringWithAPI(text: adjectiveText) { [weak self] in
+                    self?.tagFilteringWithAPI(text: nounText) {
+                        DispatchQueue.main.async {
+                            self?.mode = .send
+                            self?.adjectiveTextFiled.resignFirstResponder()
+                            self?.nounTextFiled.resignFirstResponder()
+                            self?.adjectiveTextFiled.isUserInteractionEnabled = false
+                            self?.nounTextFiled.isUserInteractionEnabled = false
+                            
+                            self?.setSendUIWithAnimation()
+                            
+                            // TODO: - Detent 높이 수정.
+                            if #available(iOS 16.0, *) {
+                                self?.sheetPresentationController?.animateChanges {
+    //                                self?.sheetPresentationController?.invalidateDetents()
+    //                                self?.sheetPresentationController?.selectedDetentIdentifier = .init("sendTagDetent")
+    //                                self?.sheetPresentationController?.selectedDetentIdentifier = .large
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -362,7 +362,35 @@ extension SendTagSheetVC {
             print("tagFetchWithAPI - error: \(error)")
         }).disposed(by: disposeBag)
     }
-    private func tagFilteringWithAPI(request: CreationTagRequest, completion: @escaping () -> Void) {
+    private func tagFilteringWithAPI(text: String, completion: @escaping () -> Void) {
+        TagAPI.shared.tagFiltering(query: text).subscribe(onSuccess: { [weak self] networkResult in
+            switch networkResult {
+            case .success(let response):
+                print("tagFilteringWithAPI - success")
+                
+                if let isSlang = response.data {
+                    if isSlang {
+                        DispatchQueue.main.async {
+                            self?.subtitleLabel.text = "욕설, 비속어가 포함되어 있어 전송할 수 없습니다."
+                            self?.subtitleLabel.textColor = .stateColorError
+                        }
+                    } else {
+                        completion()
+                    }
+                }
+            case .requestErr:
+                print("tagFilteringWithAPI - requestErr")
+            case .pathErr:
+                print("tagFilteringWithAPI - pathErr")
+            case .serverErr:
+                print("tagFilteringWithAPI - serverErr")
+            case .networkFail:
+                print("tagFilteringWithAPI - networkFail")
+            }
+        }, onFailure: { error in
+            print("tagFilteringWithAPI - error: \(error)")
+        })
+        .disposed(by: disposeBag)
     }
     private func tagCreationWithAPI(request: CreationTagRequest, completion: @escaping () -> Void) {
         TagAPI.shared.tagCreation(request: request).subscribe(onSuccess: { [weak self] networkResult in


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #622

🌱 작업한 내용
- 태그 필터링 API 연결하였습니다.
- 관련해서 로직도 구현하였습니다.
    - 텍스트 필드 상호작용을 막고, 보내기 모드의 애니메이션을 설정하였습니다.
    - 🚨 detent 높이 조절하는 부분은 TODO 주석으로 두었습니다. 언젠가.. 다시 돌아온다.. 크흑..
    - (현재는 바텀시트 높이가 고정된 상태이고, 이후에 변경 가능하면 다시금 이슈 만들겠다고 전달해두었습니다)

이제 끝이 조금씩 보이는군요!! 화이팅입니다

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|비속어 필터|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/22b87e3b-f0fa-45ee-bf62-275b68532ac4" width ="200">|
|태그 생성|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/3c2b698e-a131-4982-9e83-c87d3c38daf0" width ="200">|


## 📮 관련 이슈
- Resolved: #622
