### PR TITLE
feat: 명함 뒷면 블러 뷰 추가 (#652)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -149,6 +149,7 @@ extension BackCardCell {
                 visualEffectView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
             }
             visualEffectView.layer.cornerRadius = 35 / 2
+            visualEffectView.layer.masksToBounds = true
         }
         
         for index in 0..<tasteLabels.count {

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -18,6 +18,7 @@ class BackCardCell: CardCell {
     
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var backgroundImageView: UIImageView!
+    @IBOutlet weak var bgView: UIView!
     @IBOutlet weak var tasteTitleLabel: UILabel!
     @IBOutlet var leftTasteViews: [UIView]!
     @IBOutlet var rightTasteViews: [UIView]!
@@ -83,12 +84,13 @@ extension BackCardCell {
         let cardTasteInfo: [CardTasteInfo] = cardTasteInfo.sorted { $0.sortOrder > $1.sortOrder }
         
         for index in 0..<tasteViews.count where !cardTasteInfo[index].isChoose {
-            let blurEffect = UIBlurEffect(style: .light)
+            let blurEffect = UIBlurEffect(style: .systemMaterialLight)
             let visualEffectView = UIVisualEffectView(frame: tasteViews[index].frame)
             
             tasteViews[index].backgroundColor = .clear
             visualEffectView.effect = blurEffect
-            backgroundImageView.addSubview(visualEffectView)
+            bgView.addSubview(visualEffectView)
+            // FIXME: - 둥글기 설정을 위해서 view 에 추가. 그러면 backgroundImageView blur 안됨.
 //            tasteViews[index].addSubview(visualEffectView)
 //            tasteViews[index].layer.masksToBounds = true
             
@@ -130,12 +132,12 @@ extension BackCardCell {
         let cardTasteInfo: [CardTasteInfo] = cardTasteInfo.sorted { $0.sortOrder > $1.sortOrder }
         
         for index in 0..<tasteViews.count where !cardTasteInfo[index].isChoose {
-            let blurEffect = UIBlurEffect(style: .light)
+            let blurEffect = UIBlurEffect(style: .systemMaterialLight)
             let visualEffectView = UIVisualEffectView(frame: tasteViews[index].frame)
             
             tasteViews[index].backgroundColor = .clear
             visualEffectView.effect = blurEffect
-            backgroundImageView.addSubview(visualEffectView)
+            bgView.addSubview(visualEffectView)
             // FIXME: - 둥글기 설정을 위해서 view 에 추가. 그러면 backgroundImageView blur 안됨.
 //            tasteViews[index].addSubview(visualEffectView)
 //            tasteViews[index].layer.masksToBounds = true

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -73,6 +73,10 @@ extension BackCardCell {
             $0.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
             $0.layer.cornerRadius = 35 / 2
         }
+        
+        tasteViews.forEach {
+            $0.backgroundColor = .white
+        }
     }
     
     /// 명함 미리보기 시 사용.

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -19,7 +19,9 @@ class BackCardCell: CardCell {
     // MARK: - @IBOutlet Properties
     @IBOutlet weak var backgroundImageView: UIImageView!
     @IBOutlet weak var tasteTitleLabel: UILabel!
-    @IBOutlet var tasteImageViews: [UIImageView]!
+    @IBOutlet var leftTasteViews: [UIView]!
+    @IBOutlet var rightTasteViews: [UIView]!
+    @IBOutlet var tasteViews: [UIView]!
     @IBOutlet var tasteLabels: [UILabel]!
     @IBOutlet weak var tmiTitleLabel: UILabel!
     @IBOutlet weak var tmiLabel: UILabel!
@@ -60,6 +62,16 @@ extension BackCardCell {
         tmiLabel.font = .textRegular04
         tmiLabel.textColor = .white
         tmiLabel.numberOfLines = 0
+        
+        leftTasteViews.forEach {
+            $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+            $0.layer.cornerRadius = 35 / 2
+        }
+        
+        rightTasteViews.forEach {
+            $0.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
+            $0.layer.cornerRadius = 35 / 2
+        }
     }
     
     /// 명함 미리보기 시 사용.
@@ -70,12 +82,23 @@ extension BackCardCell {
         
         let cardTasteInfo: [CardTasteInfo] = cardTasteInfo.sorted { $0.sortOrder > $1.sortOrder }
         
-        for index in stride(from: 0, to: cardTasteInfo.count, by: 2) {
-            if cardTasteInfo[index].isChoose {
-                tasteImageViews[index / 2].image = UIImage(named: "imgBalanceLeft")
+        for index in 0..<tasteViews.count where !cardTasteInfo[index].isChoose {
+            let blurEffect = UIBlurEffect(style: .light)
+            let visualEffectView = UIVisualEffectView(frame: tasteViews[index].frame)
+            
+            tasteViews[index].backgroundColor = .clear
+            visualEffectView.effect = blurEffect
+            backgroundImageView.addSubview(visualEffectView)
+//            tasteViews[index].addSubview(visualEffectView)
+//            tasteViews[index].layer.masksToBounds = true
+            
+            // FIXME: - 둥글기 적용 안됨.
+            if index % 2 == 0 {
+                visualEffectView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
             } else {
-                tasteImageViews[index / 2].image = UIImage(named: "imgBalanceRight")
+                visualEffectView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
             }
+            visualEffectView.layer.cornerRadius = 35 / 2
         }
         
         for index in 0..<tasteLabels.count {
@@ -106,12 +129,24 @@ extension BackCardCell {
         
         let cardTasteInfo: [CardTasteInfo] = cardTasteInfo.sorted { $0.sortOrder > $1.sortOrder }
         
-        for index in stride(from: 0, to: cardTasteInfo.count, by: 2) {
-            if cardTasteInfo[index].isChoose {
-                tasteImageViews[index / 2].image = UIImage(named: "imgBalanceLeft")
+        for index in 0..<tasteViews.count where !cardTasteInfo[index].isChoose {
+            let blurEffect = UIBlurEffect(style: .light)
+            let visualEffectView = UIVisualEffectView(frame: tasteViews[index].frame)
+            
+            tasteViews[index].backgroundColor = .clear
+            visualEffectView.effect = blurEffect
+            backgroundImageView.addSubview(visualEffectView)
+            // FIXME: - 둥글기 설정을 위해서 view 에 추가. 그러면 backgroundImageView blur 안됨.
+//            tasteViews[index].addSubview(visualEffectView)
+//            tasteViews[index].layer.masksToBounds = true
+            
+            // FIXME: - 둥글기 적용 안됨.
+            if index % 2 == 0 {
+                visualEffectView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
             } else {
-                tasteImageViews[index / 2].image = UIImage(named: "imgBalanceRight")
+                visualEffectView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
             }
+            visualEffectView.layer.cornerRadius = 35 / 2
         }
         
         for index in 0..<tasteLabels.count {

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -89,18 +89,16 @@ extension BackCardCell {
             
             tasteViews[index].backgroundColor = .clear
             visualEffectView.effect = blurEffect
-            bgView.addSubview(visualEffectView)
-            // FIXME: - 둥글기 설정을 위해서 view 에 추가. 그러면 backgroundImageView blur 안됨.
-//            tasteViews[index].addSubview(visualEffectView)
-//            tasteViews[index].layer.masksToBounds = true
-            
-            // FIXME: - 둥글기 적용 안됨.
+
             if index % 2 == 0 {
                 visualEffectView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
             } else {
                 visualEffectView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
             }
             visualEffectView.layer.cornerRadius = 35 / 2
+            visualEffectView.layer.masksToBounds = true
+            
+            bgView.addSubview(visualEffectView)
         }
         
         for index in 0..<tasteLabels.count {
@@ -137,12 +135,7 @@ extension BackCardCell {
             
             tasteViews[index].backgroundColor = .clear
             visualEffectView.effect = blurEffect
-            bgView.addSubview(visualEffectView)
-            // FIXME: - 둥글기 설정을 위해서 view 에 추가. 그러면 backgroundImageView blur 안됨.
-//            tasteViews[index].addSubview(visualEffectView)
-//            tasteViews[index].layer.masksToBounds = true
-            
-            // FIXME: - 둥글기 적용 안됨.
+
             if index % 2 == 0 {
                 visualEffectView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
             } else {
@@ -150,6 +143,8 @@ extension BackCardCell {
             }
             visualEffectView.layer.cornerRadius = 35 / 2
             visualEffectView.layer.masksToBounds = true
+            
+            bgView.addSubview(visualEffectView)
         }
         
         for index in 0..<tasteLabels.count {

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -102,7 +102,7 @@ extension BackCardCell {
             visualEffectView.layer.cornerRadius = 35 / 2
             visualEffectView.layer.masksToBounds = true
             
-            bgView.addSubview(visualEffectView)
+            backgroundImageView.addSubview(visualEffectView)
         }
         
         for index in 0..<tasteLabels.count {
@@ -148,7 +148,7 @@ extension BackCardCell {
             visualEffectView.layer.cornerRadius = 35 / 2
             visualEffectView.layer.masksToBounds = true
             
-            bgView.addSubview(visualEffectView)
+            backgroundImageView.addSubview(visualEffectView)
         }
         
         for index in 0..<tasteLabels.count {

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.swift
@@ -88,7 +88,7 @@ extension BackCardCell {
         let cardTasteInfo: [CardTasteInfo] = cardTasteInfo.sorted { $0.sortOrder > $1.sortOrder }
         
         for index in 0..<tasteViews.count where !cardTasteInfo[index].isChoose {
-            let blurEffect = UIBlurEffect(style: .systemMaterialLight)
+            let blurEffect = UIBlurEffect(style: .extraLight)
             let visualEffectView = UIVisualEffectView(frame: tasteViews[index].frame)
             
             tasteViews[index].backgroundColor = .clear
@@ -134,7 +134,7 @@ extension BackCardCell {
         let cardTasteInfo: [CardTasteInfo] = cardTasteInfo.sorted { $0.sortOrder > $1.sortOrder }
         
         for index in 0..<tasteViews.count where !cardTasteInfo[index].isChoose {
-            let blurEffect = UIBlurEffect(style: .systemMaterialLight)
+            let blurEffect = UIBlurEffect(style: .extraLight)
             let visualEffectView = UIVisualEffectView(frame: tasteViews[index].frame)
             
             tasteViews[index].backgroundColor = .clear

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
@@ -248,6 +248,7 @@
             </userDefinedRuntimeAttributes>
             <connections>
                 <outlet property="backgroundImageView" destination="Rmd-7u-oYx" id="Ci4-HW-97h"/>
+                <outlet property="bgView" destination="Q9H-oG-tzn" id="J1Q-uy-j1j"/>
                 <outlet property="tagButton" destination="aNM-Fl-RCk" id="ua1-4D-XLB"/>
                 <outlet property="tasteTitleLabel" destination="dHb-jJ-jng" id="s2A-b9-Osl"/>
                 <outlet property="tmiLabel" destination="Ch6-5U-VOL" id="soW-Sy-5Zm"/>

--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/BackCardCell.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -48,6 +49,44 @@
                             <constraint firstAttribute="height" constant="1" id="Qid-DD-84g"/>
                         </constraints>
                     </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BKt-1V-zZY">
+                        <rect key="frame" x="24" y="95" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="35" id="sSI-7u-N5a"/>
+                        </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XpY-HU-vVz">
+                        <rect key="frame" x="163.5" y="95" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="35" id="1fS-bb-D11"/>
+                        </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5to-Xm-Fpj">
+                        <rect key="frame" x="24" y="146" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2gv-GI-seP">
+                        <rect key="frame" x="163.5" y="146" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="udh-YW-SO6">
+                        <rect key="frame" x="24" y="197" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Bk-Fb-sH2">
+                        <rect key="frame" x="163.5" y="197" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Up-ei-zjX">
+                        <rect key="frame" x="24" y="248" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7fh-gH-hH3">
+                        <rect key="frame" x="163.5" y="248" width="139.5" height="35"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bNI-yG-96K">
                         <rect key="frame" x="24" y="371.5" width="279" height="1"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -55,30 +94,6 @@
                             <constraint firstAttribute="height" constant="1" id="6Db-Js-vCb"/>
                         </constraints>
                     </view>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sLy-tM-Foc">
-                        <rect key="frame" x="24" y="95" width="279" height="35"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="35" id="Ycf-5Q-4Nf"/>
-                        </constraints>
-                    </imageView>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Sfm-fL-vo0">
-                        <rect key="frame" x="24" y="146" width="279" height="35"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="35" id="osE-xJ-O13"/>
-                        </constraints>
-                    </imageView>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Z3d-Jw-0bl">
-                        <rect key="frame" x="24" y="197" width="279" height="35"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="35" id="iQB-Su-UFF"/>
-                        </constraints>
-                    </imageView>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Bo-yc-zB1">
-                        <rect key="frame" x="24" y="248" width="279" height="35"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="35" id="c3k-g5-uGj"/>
-                        </constraints>
-                    </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="나의 취향" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dHb-jJ-jng">
                         <rect key="frame" x="24" y="50" width="67" height="22"/>
                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
@@ -98,49 +113,49 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yWc-gu-ca5">
-                        <rect key="frame" x="36" y="102" width="42" height="21"/>
+                        <rect key="frame" x="36" y="102" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0VZ-Iq-YfG">
-                        <rect key="frame" x="249" y="102" width="42" height="21"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0VZ-Iq-YfG">
+                        <rect key="frame" x="163.5" y="102" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="trU-Am-jlp">
-                        <rect key="frame" x="36" y="153" width="42" height="21"/>
+                        <rect key="frame" x="36" y="153" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJI-Zc-w2j">
-                        <rect key="frame" x="249" y="153" width="42" height="21"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJI-Zc-w2j">
+                        <rect key="frame" x="163.5" y="153" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="19t-Fx-dQ8">
-                        <rect key="frame" x="36" y="204" width="42" height="21"/>
+                        <rect key="frame" x="36" y="204" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EUO-lM-Tml">
-                        <rect key="frame" x="249" y="204" width="42" height="21"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EUO-lM-Tml">
+                        <rect key="frame" x="163.5" y="204" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6T0-dr-P6W">
-                        <rect key="frame" x="36" y="255" width="42" height="21"/>
+                        <rect key="frame" x="36" y="255" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aNc-su-6SN">
-                        <rect key="frame" x="249" y="255" width="42" height="21"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aNc-su-6SN">
+                        <rect key="frame" x="163.5" y="255" width="127.5" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -148,57 +163,83 @@
                 </subviews>
             </view>
             <constraints>
+                <constraint firstItem="cJI-Zc-w2j" firstAttribute="centerY" secondItem="trU-Am-jlp" secondAttribute="centerY" id="0fy-vq-XTN"/>
                 <constraint firstAttribute="trailing" secondItem="Rmd-7u-oYx" secondAttribute="trailing" id="0jt-23-iuI"/>
-                <constraint firstItem="sLy-tM-Foc" firstAttribute="top" secondItem="FfP-9G-1a3" secondAttribute="bottom" constant="19.5" id="0qQ-GA-Jqc"/>
                 <constraint firstItem="aNM-Fl-RCk" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="16" id="0wf-Nl-5GA"/>
-                <constraint firstItem="0VZ-Iq-YfG" firstAttribute="centerY" secondItem="sLy-tM-Foc" secondAttribute="centerY" id="2l1-Uh-a1X"/>
-                <constraint firstItem="Z3d-Jw-0bl" firstAttribute="leading" secondItem="sLy-tM-Foc" secondAttribute="leading" id="3yS-Lv-c0f"/>
-                <constraint firstItem="cJI-Zc-w2j" firstAttribute="centerY" secondItem="Sfm-fL-vo0" secondAttribute="centerY" id="4Ik-if-OEk"/>
+                <constraint firstItem="aNc-su-6SN" firstAttribute="leading" secondItem="2Up-ei-zjX" secondAttribute="trailing" id="2uY-V2-Rdi"/>
+                <constraint firstItem="7Bk-Fb-sH2" firstAttribute="height" secondItem="2gv-GI-seP" secondAttribute="height" id="3vb-jz-huD"/>
+                <constraint firstItem="trU-Am-jlp" firstAttribute="top" secondItem="5to-Xm-Fpj" secondAttribute="top" constant="7" id="5V1-he-fm9"/>
                 <constraint firstAttribute="bottom" secondItem="Rmd-7u-oYx" secondAttribute="bottom" id="6sP-l0-YJZ"/>
                 <constraint firstAttribute="trailing" secondItem="bNI-yG-96K" secondAttribute="trailing" constant="24" id="7eM-YI-3Qt"/>
+                <constraint firstItem="7Bk-Fb-sH2" firstAttribute="trailing" secondItem="2gv-GI-seP" secondAttribute="trailing" id="7hI-Fm-tCK"/>
                 <constraint firstItem="Q9H-oG-tzn" firstAttribute="leading" secondItem="Rmd-7u-oYx" secondAttribute="leading" id="7x9-tr-J5n"/>
-                <constraint firstItem="Z3d-Jw-0bl" firstAttribute="top" secondItem="Sfm-fL-vo0" secondAttribute="bottom" constant="16" id="8qH-Jg-J7V"/>
                 <constraint firstItem="FfP-9G-1a3" firstAttribute="top" secondItem="dHb-jJ-jng" secondAttribute="bottom" constant="2.5" id="9Bq-4m-Efc"/>
+                <constraint firstItem="EUO-lM-Tml" firstAttribute="leading" secondItem="udh-YW-SO6" secondAttribute="trailing" id="9C6-U0-uST"/>
+                <constraint firstItem="7fh-gH-hH3" firstAttribute="leading" secondItem="6T0-dr-P6W" secondAttribute="trailing" id="9W1-7E-5G0"/>
+                <constraint firstItem="udh-YW-SO6" firstAttribute="leading" secondItem="5to-Xm-Fpj" secondAttribute="leading" id="9oa-qa-ckM"/>
                 <constraint firstItem="trU-Am-jlp" firstAttribute="leading" secondItem="yWc-gu-ca5" secondAttribute="leading" id="9yw-5u-T00"/>
+                <constraint firstItem="XT5-iW-6kG" firstAttribute="top" secondItem="2Up-ei-zjX" secondAttribute="bottom" constant="63" id="AhI-aZ-Y52"/>
+                <constraint firstItem="udh-YW-SO6" firstAttribute="height" secondItem="5to-Xm-Fpj" secondAttribute="height" id="AsT-ap-G3e"/>
+                <constraint firstItem="XpY-HU-vVz" firstAttribute="top" secondItem="FfP-9G-1a3" secondAttribute="bottom" constant="19.5" id="CS4-nz-BB8"/>
                 <constraint firstItem="dHb-jJ-jng" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="24" id="EYG-Vx-bQ6"/>
+                <constraint firstItem="BKt-1V-zZY" firstAttribute="trailing" secondItem="gTV-IL-0wX" secondAttribute="centerX" id="Eis-Nl-yHN"/>
                 <constraint firstItem="Q9H-oG-tzn" firstAttribute="bottom" secondItem="Rmd-7u-oYx" secondAttribute="bottom" id="GEn-g5-aCr"/>
+                <constraint firstItem="7fh-gH-hH3" firstAttribute="height" secondItem="7Bk-Fb-sH2" secondAttribute="height" id="GIk-zM-fCY"/>
                 <constraint firstItem="Rmd-7u-oYx" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="GZC-tY-5Ql"/>
                 <constraint firstItem="EUO-lM-Tml" firstAttribute="trailing" secondItem="0VZ-Iq-YfG" secondAttribute="trailing" id="Ged-YL-iLB"/>
+                <constraint firstItem="2Up-ei-zjX" firstAttribute="trailing" secondItem="udh-YW-SO6" secondAttribute="trailing" id="IAa-if-kc8"/>
+                <constraint firstItem="2gv-GI-seP" firstAttribute="trailing" secondItem="XpY-HU-vVz" secondAttribute="trailing" id="Ij3-FL-GOW"/>
+                <constraint firstItem="udh-YW-SO6" firstAttribute="trailing" secondItem="5to-Xm-Fpj" secondAttribute="trailing" id="Iod-RG-HDW"/>
                 <constraint firstAttribute="trailing" secondItem="aNM-Fl-RCk" secondAttribute="trailing" constant="24" id="Itj-02-GFe"/>
+                <constraint firstItem="yWc-gu-ca5" firstAttribute="top" secondItem="BKt-1V-zZY" secondAttribute="top" constant="7" id="JGI-Bi-dFK"/>
+                <constraint firstItem="2gv-GI-seP" firstAttribute="height" secondItem="XpY-HU-vVz" secondAttribute="height" id="JIP-u4-qpW"/>
                 <constraint firstItem="6T0-dr-P6W" firstAttribute="leading" secondItem="yWc-gu-ca5" secondAttribute="leading" id="JMR-rX-vVC"/>
                 <constraint firstItem="FfP-9G-1a3" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="24" id="JZc-Zj-0OC"/>
-                <constraint firstItem="trU-Am-jlp" firstAttribute="centerY" secondItem="Sfm-fL-vo0" secondAttribute="centerY" id="JjA-np-XJG"/>
+                <constraint firstItem="yWc-gu-ca5" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="36" id="JtU-1V-o5V"/>
                 <constraint firstItem="bNI-yG-96K" firstAttribute="top" secondItem="XT5-iW-6kG" secondAttribute="bottom" constant="3.5" id="Kaa-x2-BOP"/>
+                <constraint firstItem="7fh-gH-hH3" firstAttribute="leading" secondItem="7Bk-Fb-sH2" secondAttribute="leading" id="LNH-3C-xe2"/>
+                <constraint firstAttribute="trailing" secondItem="0VZ-Iq-YfG" secondAttribute="trailing" constant="36" id="Nah-Z6-2kR"/>
                 <constraint firstItem="aNc-su-6SN" firstAttribute="trailing" secondItem="0VZ-Iq-YfG" secondAttribute="trailing" id="Nyw-zl-nns"/>
-                <constraint firstItem="0VZ-Iq-YfG" firstAttribute="trailing" secondItem="sLy-tM-Foc" secondAttribute="trailing" constant="-12" id="Tk3-aq-AiS"/>
+                <constraint firstItem="0VZ-Iq-YfG" firstAttribute="leading" secondItem="BKt-1V-zZY" secondAttribute="trailing" id="OXt-2F-uHQ"/>
+                <constraint firstItem="udh-YW-SO6" firstAttribute="top" secondItem="5to-Xm-Fpj" secondAttribute="bottom" constant="16" id="ObQ-Wm-9qh"/>
+                <constraint firstItem="2Up-ei-zjX" firstAttribute="height" secondItem="udh-YW-SO6" secondAttribute="height" id="Ok8-R4-yJi"/>
+                <constraint firstItem="cJI-Zc-w2j" firstAttribute="leading" secondItem="5to-Xm-Fpj" secondAttribute="trailing" id="PcL-GD-t7d"/>
+                <constraint firstItem="5to-Xm-Fpj" firstAttribute="top" secondItem="BKt-1V-zZY" secondAttribute="bottom" constant="16" id="SqF-og-rGL"/>
+                <constraint firstItem="7Bk-Fb-sH2" firstAttribute="leading" secondItem="2gv-GI-seP" secondAttribute="leading" id="SqQ-kh-vBp"/>
+                <constraint firstItem="2gv-GI-seP" firstAttribute="top" secondItem="XpY-HU-vVz" secondAttribute="bottom" constant="16" id="Tmc-QM-vQE"/>
+                <constraint firstItem="2gv-GI-seP" firstAttribute="leading" secondItem="trU-Am-jlp" secondAttribute="trailing" id="UWo-ek-sjm"/>
+                <constraint firstItem="EUO-lM-Tml" firstAttribute="centerY" secondItem="19t-Fx-dQ8" secondAttribute="centerY" id="UYK-V5-w9t"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ch6-5U-VOL" secondAttribute="trailing" constant="24" id="VvQ-c1-IEH"/>
+                <constraint firstItem="BKt-1V-zZY" firstAttribute="top" secondItem="FfP-9G-1a3" secondAttribute="bottom" constant="19.5" id="XgF-oN-Zfd"/>
                 <constraint firstItem="XT5-iW-6kG" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="24" id="Y36-eF-FL8"/>
-                <constraint firstItem="19t-Fx-dQ8" firstAttribute="centerY" secondItem="Z3d-Jw-0bl" secondAttribute="centerY" id="Y3l-pu-rSB"/>
                 <constraint firstItem="bNI-yG-96K" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="24" id="YH6-4Z-GcG"/>
+                <constraint firstItem="7Bk-Fb-sH2" firstAttribute="leading" secondItem="19t-Fx-dQ8" secondAttribute="trailing" id="ZG6-pi-omg"/>
+                <constraint firstItem="aNc-su-6SN" firstAttribute="centerY" secondItem="6T0-dr-P6W" secondAttribute="centerY" id="ZKh-Ze-3Dq"/>
                 <constraint firstItem="dHb-jJ-jng" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="50" id="ZLX-Il-oq0"/>
                 <constraint firstAttribute="trailing" secondItem="FfP-9G-1a3" secondAttribute="trailing" constant="24" id="Zh6-xa-VD9"/>
-                <constraint firstItem="5Bo-yc-zB1" firstAttribute="leading" secondItem="sLy-tM-Foc" secondAttribute="leading" id="aKZ-4f-bRM"/>
-                <constraint firstItem="Sfm-fL-vo0" firstAttribute="trailing" secondItem="sLy-tM-Foc" secondAttribute="trailing" id="asD-N1-UD3"/>
                 <constraint firstItem="Rmd-7u-oYx" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="b9D-mv-wWz"/>
                 <constraint firstItem="Ch6-5U-VOL" firstAttribute="top" secondItem="XT5-iW-6kG" secondAttribute="bottom" constant="16" id="eZ8-Sh-fET"/>
-                <constraint firstItem="Z3d-Jw-0bl" firstAttribute="trailing" secondItem="sLy-tM-Foc" secondAttribute="trailing" id="gxf-5Y-0Ez"/>
+                <constraint firstItem="5to-Xm-Fpj" firstAttribute="height" secondItem="BKt-1V-zZY" secondAttribute="height" id="f4r-4n-j0Y"/>
+                <constraint firstItem="XpY-HU-vVz" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="centerX" id="ftu-Cp-5Th"/>
+                <constraint firstItem="6T0-dr-P6W" firstAttribute="top" secondItem="2Up-ei-zjX" secondAttribute="top" constant="7" id="gmy-DJ-R4N"/>
+                <constraint firstItem="2Up-ei-zjX" firstAttribute="leading" secondItem="udh-YW-SO6" secondAttribute="leading" id="gtn-SX-NRY"/>
+                <constraint firstItem="7fh-gH-hH3" firstAttribute="top" secondItem="7Bk-Fb-sH2" secondAttribute="bottom" constant="16" id="h7T-ta-r77"/>
                 <constraint firstItem="cJI-Zc-w2j" firstAttribute="trailing" secondItem="0VZ-Iq-YfG" secondAttribute="trailing" id="hSc-91-MBM"/>
                 <constraint firstItem="19t-Fx-dQ8" firstAttribute="leading" secondItem="yWc-gu-ca5" secondAttribute="leading" id="jGL-LA-UtE"/>
+                <constraint firstItem="19t-Fx-dQ8" firstAttribute="top" secondItem="udh-YW-SO6" secondAttribute="top" constant="7" id="k3W-vF-SAu"/>
                 <constraint firstItem="Ch6-5U-VOL" firstAttribute="leading" secondItem="XT5-iW-6kG" secondAttribute="leading" id="k4x-2l-IzD"/>
-                <constraint firstItem="yWc-gu-ca5" firstAttribute="centerY" secondItem="sLy-tM-Foc" secondAttribute="centerY" id="kea-TJ-d10"/>
-                <constraint firstItem="XT5-iW-6kG" firstAttribute="top" secondItem="5Bo-yc-zB1" secondAttribute="bottom" constant="63" id="o4m-Db-HKw"/>
+                <constraint firstAttribute="trailing" secondItem="XpY-HU-vVz" secondAttribute="trailing" constant="24" id="lXd-ja-X6l"/>
+                <constraint firstItem="XpY-HU-vVz" firstAttribute="leading" secondItem="yWc-gu-ca5" secondAttribute="trailing" id="mSm-Js-h1i"/>
+                <constraint firstItem="5to-Xm-Fpj" firstAttribute="trailing" secondItem="BKt-1V-zZY" secondAttribute="trailing" id="njy-Sy-E5J"/>
+                <constraint firstItem="0VZ-Iq-YfG" firstAttribute="top" secondItem="FfP-9G-1a3" secondAttribute="bottom" constant="26.5" id="nkA-2a-oxW"/>
                 <constraint firstItem="Q9H-oG-tzn" firstAttribute="trailing" secondItem="Rmd-7u-oYx" secondAttribute="trailing" id="oBY-hd-ry4"/>
                 <constraint firstItem="Q9H-oG-tzn" firstAttribute="top" secondItem="Rmd-7u-oYx" secondAttribute="top" id="oMo-GV-3Jn"/>
-                <constraint firstItem="EUO-lM-Tml" firstAttribute="centerY" secondItem="Z3d-Jw-0bl" secondAttribute="centerY" id="rQU-jD-pze"/>
-                <constraint firstItem="aNc-su-6SN" firstAttribute="centerY" secondItem="5Bo-yc-zB1" secondAttribute="centerY" id="s9L-2Y-7F3"/>
-                <constraint firstItem="Sfm-fL-vo0" firstAttribute="leading" secondItem="sLy-tM-Foc" secondAttribute="leading" id="sCJ-I0-BiO"/>
-                <constraint firstItem="Sfm-fL-vo0" firstAttribute="top" secondItem="sLy-tM-Foc" secondAttribute="bottom" constant="16" id="sUC-vx-Knc"/>
-                <constraint firstItem="5Bo-yc-zB1" firstAttribute="trailing" secondItem="sLy-tM-Foc" secondAttribute="trailing" id="tea-0m-xv9"/>
-                <constraint firstItem="sLy-tM-Foc" firstAttribute="trailing" secondItem="FfP-9G-1a3" secondAttribute="trailing" id="uPF-Uu-eOa"/>
-                <constraint firstItem="5Bo-yc-zB1" firstAttribute="top" secondItem="Z3d-Jw-0bl" secondAttribute="bottom" constant="16" id="v44-xR-hy4"/>
-                <constraint firstItem="yWc-gu-ca5" firstAttribute="leading" secondItem="sLy-tM-Foc" secondAttribute="leading" constant="12" id="vgT-ka-S97"/>
-                <constraint firstItem="sLy-tM-Foc" firstAttribute="leading" secondItem="FfP-9G-1a3" secondAttribute="leading" id="wCX-42-FQN"/>
-                <constraint firstItem="6T0-dr-P6W" firstAttribute="centerY" secondItem="5Bo-yc-zB1" secondAttribute="centerY" id="xTO-WH-sTR"/>
+                <constraint firstItem="2Up-ei-zjX" firstAttribute="top" secondItem="udh-YW-SO6" secondAttribute="bottom" constant="16" id="r1A-3h-BJz"/>
+                <constraint firstItem="7Bk-Fb-sH2" firstAttribute="top" secondItem="2gv-GI-seP" secondAttribute="bottom" constant="16" id="syX-cN-wb6"/>
+                <constraint firstItem="7fh-gH-hH3" firstAttribute="trailing" secondItem="7Bk-Fb-sH2" secondAttribute="trailing" id="t1e-AF-P44"/>
+                <constraint firstItem="2gv-GI-seP" firstAttribute="leading" secondItem="XpY-HU-vVz" secondAttribute="leading" id="uk5-jn-c8c"/>
+                <constraint firstItem="5to-Xm-Fpj" firstAttribute="leading" secondItem="BKt-1V-zZY" secondAttribute="leading" id="wWh-tX-Rqt"/>
+                <constraint firstItem="BKt-1V-zZY" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="24" id="ykM-On-vK9"/>
             </constraints>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -211,10 +252,6 @@
                 <outlet property="tasteTitleLabel" destination="dHb-jJ-jng" id="s2A-b9-Osl"/>
                 <outlet property="tmiLabel" destination="Ch6-5U-VOL" id="soW-Sy-5Zm"/>
                 <outlet property="tmiTitleLabel" destination="XT5-iW-6kG" id="75E-sq-FUS"/>
-                <outletCollection property="tasteImageViews" destination="sLy-tM-Foc" collectionClass="NSMutableArray" id="wWT-4v-WF2"/>
-                <outletCollection property="tasteImageViews" destination="Sfm-fL-vo0" collectionClass="NSMutableArray" id="9C9-Xg-zNB"/>
-                <outletCollection property="tasteImageViews" destination="Z3d-Jw-0bl" collectionClass="NSMutableArray" id="tu4-hh-EOf"/>
-                <outletCollection property="tasteImageViews" destination="5Bo-yc-zB1" collectionClass="NSMutableArray" id="vo8-mJ-tBE"/>
                 <outletCollection property="tasteLabels" destination="yWc-gu-ca5" collectionClass="NSMutableArray" id="lS0-OD-xZb"/>
                 <outletCollection property="tasteLabels" destination="0VZ-Iq-YfG" collectionClass="NSMutableArray" id="zFn-pM-PNt"/>
                 <outletCollection property="tasteLabels" destination="trU-Am-jlp" collectionClass="NSMutableArray" id="2KS-Qx-ZMy"/>
@@ -223,11 +260,30 @@
                 <outletCollection property="tasteLabels" destination="EUO-lM-Tml" collectionClass="NSMutableArray" id="708-XX-pbC"/>
                 <outletCollection property="tasteLabels" destination="6T0-dr-P6W" collectionClass="NSMutableArray" id="ug6-Kc-Nud"/>
                 <outletCollection property="tasteLabels" destination="aNc-su-6SN" collectionClass="NSMutableArray" id="eYa-9t-O5s"/>
+                <outletCollection property="leftTasteViews" destination="2Up-ei-zjX" collectionClass="NSMutableArray" id="dLe-db-Yep"/>
+                <outletCollection property="leftTasteViews" destination="udh-YW-SO6" collectionClass="NSMutableArray" id="1Y1-17-PbN"/>
+                <outletCollection property="leftTasteViews" destination="5to-Xm-Fpj" collectionClass="NSMutableArray" id="6fE-Cb-Gge"/>
+                <outletCollection property="leftTasteViews" destination="BKt-1V-zZY" collectionClass="NSMutableArray" id="6ff-GZ-CuV"/>
+                <outletCollection property="rightTasteViews" destination="XpY-HU-vVz" collectionClass="NSMutableArray" id="BJr-FJ-yAp"/>
+                <outletCollection property="rightTasteViews" destination="2gv-GI-seP" collectionClass="NSMutableArray" id="h4l-XT-y4k"/>
+                <outletCollection property="rightTasteViews" destination="7Bk-Fb-sH2" collectionClass="NSMutableArray" id="KPG-YO-q3X"/>
+                <outletCollection property="rightTasteViews" destination="7fh-gH-hH3" collectionClass="NSMutableArray" id="fkL-mg-gYq"/>
+                <outletCollection property="tasteViews" destination="BKt-1V-zZY" collectionClass="NSMutableArray" id="l0l-Cb-r0t"/>
+                <outletCollection property="tasteViews" destination="XpY-HU-vVz" collectionClass="NSMutableArray" id="GTf-be-qu5"/>
+                <outletCollection property="tasteViews" destination="5to-Xm-Fpj" collectionClass="NSMutableArray" id="HXd-Jd-HaE"/>
+                <outletCollection property="tasteViews" destination="2gv-GI-seP" collectionClass="NSMutableArray" id="oEV-MA-aap"/>
+                <outletCollection property="tasteViews" destination="udh-YW-SO6" collectionClass="NSMutableArray" id="GNA-TH-4ay"/>
+                <outletCollection property="tasteViews" destination="7Bk-Fb-sH2" collectionClass="NSMutableArray" id="evH-wf-UhU"/>
+                <outletCollection property="tasteViews" destination="2Up-ei-zjX" collectionClass="NSMutableArray" id="I8Q-cw-aDF"/>
+                <outletCollection property="tasteViews" destination="7fh-gH-hH3" collectionClass="NSMutableArray" id="SAv-Sc-rbN"/>
             </connections>
             <point key="canvasLocation" x="131.15942028985509" y="79.6875"/>
         </collectionViewCell>
     </objects>
     <resources>
         <image name="iconTag" width="24" height="24"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #652

🌱 작업한 내용
- 명함 뒷면의 선택되지 않은 취향을 블러처리해보려 했습니다.

<img width="400" alt="스크린샷 2023-11-02 오전 10 43 58" src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/ec4e0679-cfaa-4a97-b2fe-cd266cd977d8">

- 🚨그러나 ㅜㅜ 스크린샷처럼 blur 를 bgView(image view 위 alpha 값을 가진 view)에 추가해야하는데 그렇게 되면 corner radius 가 조절되지 않았습니다.(fixme 주석 추가)
- maskToBounds 를 사용해서 둥글기를 조절하기 위해 UIView 를 만들어서 얹으면 해당 뷰의 색상 조절에 영향을 받아서 안되더라구요 clear 하면 안보이고..~혹시 방법이 있으시면 알려주세용!😭~
- (https://ikyle.me/blog/2022/uiblureffectstyle) 에서 일반 배경일때와 검정 배경일때 적절히 비슷한 blur 효과를 찾아보았습니다.

<img width="600" alt="스크린샷 2023-11-02 오전 11 00 26" src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/c5719c70-1e60-4ccf-94e3-237a4a165c65">

> ~보류 태그 붙여두었고, PR 은 머지 없이 닫아두고 이슈만 열어두겠습니다.~

bgView 의 뷰 계층은 다음과 같습니다.

<img width="400" alt="스크린샷 2023-11-02 오전 10 57 03" src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/93c83fed-f62a-4b4c-8a60-1ee32935d482">

라고 할뻔... `make uiblureffect corner radius` 검색하니까 바로나옴 ㅋ 이래서 사람이 영어를..

`visualEffectView.layer.masksToBounds = true` 을 추가했습니다! blur effect 가 전체적으로 적용되고 이를 가지는 view 의 layer 를 적용해야 하나봅니다.
트러블 슈팅 과정은 남겨두겠습니다.

## 📮 관련 이슈
- Resolved: #652
