### PR TITLE
feat: 명함 생성 뷰내에서는 입력하던 태그 저장 (#655)

### DIFF
--- a/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
+++ b/NADA-iOS-forRelease/Resouces/Constants/Notification.swift
@@ -28,4 +28,5 @@ extension Notification.Name {
     static let backToHome = Notification.Name("backToHome")
     static let presentToReceivedTagSheet = Notification.Name("presentToTagSheet")
     static let completeSendTag = Notification.Name("completeSendTag")
+    static let sendEditingTags = Notification.Name("sendEditingTags")
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -78,13 +78,13 @@ class CardDetailViewController: UIViewController {
     @IBOutlet weak var tagCollectionView: UICollectionView!
     
     public var cardDataModel: Card?
-    private var isShareable: Bool = false
+    public var status: Status = .group
+    public var serverGroups: [String]?
+    public var groupName: String?
+    public var cardType: String = ""
     
+    private var isShareable: Bool = false
     private var isFront = true
-    var status: Status = .group
-    var serverGroups: [String]?
-    var groupName: String?
-    var cardType: String = ""
     private var receivedTags: [ReceivedTag]?
     private let disposeBag = DisposeBag()
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -86,6 +86,9 @@ class CardDetailViewController: UIViewController {
     private var isShareable: Bool = false
     private var isFront = true
     private var receivedTags: [ReceivedTag]?
+    private var editingAdjectiveTagText: String?
+    private var editingNounTagText: String?
+    
     private let disposeBag = DisposeBag()
     
     override func viewDidLoad() {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -60,7 +60,7 @@ class CardDetailViewController: UIViewController {
         }
         
         tagSheet.setCardDataModel(cardDataModel)
-        tagSheet.setEditingTag(adjectiveText: editingAdjectiveTagText, nounText: editingNounTagText)
+        tagSheet.setEditingTag(adjectiveText: editingAdjectiveTagText, nounText: editingNounTagText, item: editingItem)
         tagSheet.modalPresentationStyle = .pageSheet
         
         present(tagSheet, animated: true)
@@ -89,6 +89,7 @@ class CardDetailViewController: UIViewController {
     private var receivedTags: [ReceivedTag]?
     private var editingAdjectiveTagText: String?
     private var editingNounTagText: String?
+    private var editingItem: Int = 0
     
     private let disposeBag = DisposeBag()
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -254,6 +254,7 @@ extension CardDetailViewController {
     }
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(reloadReceivedTags), name: .completeSendTag, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setEditingTags), name: .sendEditingTags, object: nil)
     }
     
     // MARK: - @objc Methods

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -291,6 +291,22 @@ extension CardDetailViewController {
     private func reloadReceivedTags() {
         receivedTagFetchWithAPI(cardUUID: cardDataModel?.cardUUID ?? "")
     }
+    @objc
+    private func setEditingTags(_ notification: Notification) {
+        guard let tags = notification.object as? [String: Any] else { return }
+        
+        if let text = tags["editingAdjectiveTagText"] as? String {
+            editingAdjectiveTagText = text
+        }
+        
+        if let text = tags["editingNounTagText"] as? String {
+            editingNounTagText = text
+        }
+        
+        if let item = tags["selectedItem"] as? Int {
+            editingItem = item
+        }
+    }
 }
 
 // MARK: - Network

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -60,6 +60,7 @@ class CardDetailViewController: UIViewController {
             }
         }
         tagSheet.setCardDataModel(cardDataModel)
+        tagSheet.setEditingTag(adjectiveText: editingAdjectiveTagText, nounText: editingNounTagText)
         tagSheet.modalPresentationStyle = .pageSheet
         
         present(tagSheet, animated: true)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -89,7 +89,7 @@ class CardDetailViewController: UIViewController {
     private var receivedTags: [ReceivedTag]?
     private var editingAdjectiveTagText: String?
     private var editingNounTagText: String?
-    private var editingItem: Int = 0
+    private var editingItem: Int?
     
     private let disposeBag = DisposeBag()
     

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -48,7 +48,6 @@ class CardDetailViewController: UIViewController {
         let tagSheet = SendTagSheetVC()
         
         if #available(iOS 16.0, *) {
-            
             if let sheet = tagSheet.sheetPresentationController {
                 sheet.detents = [CustomDetent.sendTagDetent]
                 sheet.preferredCornerRadius = 30
@@ -59,6 +58,7 @@ class CardDetailViewController: UIViewController {
                 sheet.preferredCornerRadius = 30
             }
         }
+        
         tagSheet.setCardDataModel(cardDataModel)
         tagSheet.setEditingTag(adjectiveText: editingAdjectiveTagText, nounText: editingNounTagText)
         tagSheet.modalPresentationStyle = .pageSheet

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -23,6 +23,8 @@ class SendTagSheetVC: UIViewController {
     private var keyboardOn: Bool = false
     private var creationTagRequest: CreationTagRequest?
     private var mode: Mode = .edit
+    private var editingAjectiveTagText: String?
+    private var editingNounTagText: String?
     
     private let maxLength: Int = 7
     private let disposeBag = DisposeBag()

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -367,7 +367,7 @@ extension SendTagSheetVC {
     public func setCardDataModel(_ cardDataModel: Card?) {
         self.cardDataModel = cardDataModel
     }
-    public func setEditingTag(adjectiveText: String?, nounText: String?, item: Int) {
+    public func setEditingTag(adjectiveText: String?, nounText: String?, item: Int?) {
         adjectiveTextField.text = adjectiveText
         nounTextField.text = nounText
         selectedItem = item

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -153,11 +153,6 @@ class SendTagSheetVC: UIViewController {
             adjectiveTextField.becomeFirstResponder()
             keyboardOn = true
         }
-        
-        if let selectedItem {
-            collectionView.selectItem(at: IndexPath(item: selectedItem, section: 0), animated: false, scrollPosition: .left)
-            collectionView(collectionView, didSelectItemAt: IndexPath(item: selectedItem, section: 0))
-        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -388,8 +383,8 @@ extension SendTagSheetVC {
                     DispatchQueue.main.async {
                         self?.collectionView.reloadData()
                         
-                        self?.collectionView.selectItem(at: IndexPath(item: 0, section: 0), animated: false, scrollPosition: .left)
-                        self?.collectionView(self?.collectionView ?? UICollectionView(), didSelectItemAt: IndexPath(item: 0, section: 0))
+                        self?.collectionView.selectItem(at: IndexPath(item: self?.selectedItem ?? 0, section: 0), animated: false, scrollPosition: .left)
+                        self?.collectionView(self?.collectionView ?? UICollectionView(), didSelectItemAt: IndexPath(item: self?.selectedItem ?? 0, section: 0))
                     }
                 }
             case .requestErr:

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -347,6 +347,15 @@ extension SendTagSheetVC {
     public func setCardDataModel(_ cardDataModel: Card?) {
         self.cardDataModel = cardDataModel
     }
+    public func setEditingTag(adjectiveText: String?, nounText: String?) {
+        if let adjectiveText {
+            adjectiveTextFiled.text = adjectiveText
+        }
+        
+        if let nounText {
+            nounTextFiled.text = nounText
+        }
+    }
 }
 
 // MARK: - Network

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -367,14 +367,10 @@ extension SendTagSheetVC {
     public func setCardDataModel(_ cardDataModel: Card?) {
         self.cardDataModel = cardDataModel
     }
-    public func setEditingTag(adjectiveText: String?, nounText: String?) {
-        if let adjectiveText {
-            adjectiveTextFiled.text = adjectiveText
-        }
-        
-        if let nounText {
-            nounTextFiled.text = nounText
-        }
+    public func setEditingTag(adjectiveText: String?, nounText: String?, item: Int) {
+        adjectiveTextField.text = adjectiveText
+        nounTextField.text = nounText
+        selectedItem = item
     }
 }
 

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -25,6 +25,7 @@ class SendTagSheetVC: UIViewController {
     private var mode: Mode = .edit
     private var editingAdjectiveTagText: String?
     private var editingNounTagText: String?
+    private var selectedItem: Int?
     
     private let maxLength: Int = 7
     private let disposeBag = DisposeBag()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #655

🌱 작업한 내용
- 명함 생성 뷰내에서는 입력하던 태그를 저장하도록 하였습니다.
- notification center 를 사용해서 형용사, 명사, 선택된 셀의 item index 를 전달하였습니다.
- 저장된 셀이 선택되는 시기는 태그 서버 통신이 끝나면서 reloadData() 하기 때문에 이후에 지정하였습니다.
- 저장된 셀의 인덱스가 없다면 0으로 설정하였습니다.(기본이 되는 설정)
- 이 외에도 오타가 보여서 수정했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|태그 미리 지정|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/4ab9a4ec-ff25-45c8-a2b2-846deaddde50" width ="250">|

## 📮 관련 이슈
- Resolved: #655
