### PR TITLE
bug: 일부 경우 명함을 돌렸을 때 여전히 앞면인 경우 해결 (#658)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CardCell/MainCardCell.swift
@@ -35,6 +35,7 @@ class MainCardCell: CardCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
+        isFront = true
         contentView.subviews.forEach { $0.removeFromSuperview() }
         contentView.frame = CGRect(x: 0, y: 0, width: Size.cellWidth, height: Size.cellHeight)
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #658

🌱 작업한 내용
- 초창기부터 언급되어 왔던 일부 경우 명함을 돌렸을 때 여전히 앞면인 뇬석을 잡았습ㄴ디ㅏ..!!!
- 해당 이슈는 뒷면으로 돌리고 다른 탭에 갔다가 다시금 돌아왔을 때 `isFront` 가 여전히 뒷면으로 되어있는거 같더라구요
- 이전에는 `isFront` flag 로 사용되는 값을 사용해서 뒷면을 보여줄지 앞면을 보여줄지 정했었습니다. 그래서 prepareForReuse 에서 이걸 초기화해주면 될까 싶어서했는데 됐네여!
- 스크린샷으로 비교해주시면 될 것 같아용

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|as is|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/07382cea-0d1c-4ab6-aaeb-d8ff23fa2b88" width ="200">|
|to be|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/c464b8f5-1338-407f-b5fb-f89c49325994" width ="200">|


## 📮 관련 이슈
- Resolved: #658
