### PR TITLE
fix: 태그 보내기 뷰 툴바 삭제, IQKeyboardManger 재활성화하기 (#669)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -151,7 +151,6 @@ class SendTagSheetVC: UIViewController {
         
         IQKeyboardManager.shared.enable = false
         IQKeyboardManager.shared.shouldResignOnTouchOutside = false
-        IQKeyboardManager.shared.enableAutoToolbar = true
     }
     
     override func viewIsAppearing(_ animated: Bool) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -162,6 +162,12 @@ class SendTagSheetVC: UIViewController {
         }
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        IQKeyboardManager.shared.enable = true
+    }
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #669

🌱 작업한 내용
- 태그 보내기 뷰에 툴바를 설정해봤는데 다음 버튼과 겹쳐보여 없애기로 하였습니다.

<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/1e544eb5-b7e7-47f9-8855-6bb785ae5ae7" width ="150">

- IQKeyboardManger 를 재활성화하지 않아서 바텀시트가 올라오지 않았습니다.
    - viewWillDisappear 에서 활성화해주었는데 적용되지 않았습니다;; 그래서 어쩔 수 없이 viewDidAppear 에서 호출해주었습니다.
    - viewWillAppear 에서 비활성화, viewDidAppear 에서 활성화 해주었고 다른 IQKeyboardManager 를 사용하는 바텀시트에서도 제대로 활성화된채로 적용되었습니다.

## 📮 관련 이슈
- Resolved: #669
