### PR TITLE
feat: 명함 상세 풀 투 리프레시 기능 (#671)

### DIFF
--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -167,6 +167,9 @@ extension CardDetailViewController {
         let dimmedTap = UITapGestureRecognizer(target: self, action: #selector(helpDimmedViewTapped))
         helpDimmedView.addGestureRecognizer(dimmedTap)
         helpDimmedView.isUserInteractionEnabled = true
+        
+        scrollView.refreshControl = UIRefreshControl()
+        scrollView.refreshControl?.addTarget(self, action: #selector(pullToRefresh(_:)), for: .valueChanged)
     }
     private func setLayout() {
         helpView.addSubview(helpTextView)
@@ -361,6 +364,10 @@ extension CardDetailViewController {
             editingItem = item
         }
     }
+    @objc
+    private func pullToRefresh(_ sender: Any) {
+        receivedTagFetchWithAPI(cardUUID: cardDataModel?.cardUUID ?? "")
+    }
 }
 
 // MARK: - Network
@@ -421,6 +428,7 @@ extension CardDetailViewController {
                 if let data = response.data {
                     owner.receivedTags = data
                     owner.tagCollectionView.reloadData()
+                    owner.scrollView.refreshControl?.endRefreshing()
                     owner.scrollView.layoutIfNeeded()
                     if data.isEmpty {
                         self.emptyView.isHidden = false

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -170,6 +170,7 @@ extension CardDetailViewController {
         
         scrollView.refreshControl = UIRefreshControl()
         scrollView.refreshControl?.addTarget(self, action: #selector(pullToRefresh(_:)), for: .valueChanged)
+        scrollView.refreshControl?.tintColor = .mainColorNadaMain
     }
     private func setLayout() {
         helpView.addSubview(helpTextView)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -427,16 +427,17 @@ extension CardDetailViewController {
                 
                 if let data = response.data {
                     owner.receivedTags = data
-                    owner.tagCollectionView.reloadData()
-                    owner.scrollView.refreshControl?.endRefreshing()
-                    owner.scrollView.layoutIfNeeded()
                     if data.isEmpty {
                         self.emptyView.isHidden = false
                     } else {
                         self.emptyView.isHidden = true
                     }
-//                    self.backView.layoutIfNeeded()
-//                    self.scrollView.updateContentSize()
+                }
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    owner.tagCollectionView.reloadData()
+                    owner.scrollView.refreshControl?.endRefreshing()
+                    owner.scrollView.layoutIfNeeded()
                 }
             case .requestErr:
                 print("receivedTagFetchWithAPI - requestErr")


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#671

🌱 작업한 내용
- 명함 상세뷰 풀 투 리프레시 기능을 구현했습니다
- refreshControl을 나다 색으로 바꿔봤답니다..? 근데 이상하면 다시 회색으로 돌리는 걸로...

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![ezgif com-video-to-gif (5)](https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69078056/75fc2791-3158-4f8e-9a6b-e212e6d5c1e0)|


## 📮 관련 이슈
- Resolved: #671 
