### PR TITLE
fix: 스크롤 뷰 dynamic height 고치기 (#673)

### DIFF
--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		7705CF402752C844005195DF /* CardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7705CF3F2752C844005195DF /* CardView.xib */; };
 		770E58862778A78900498C2E /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770E58852778A78900498C2E /* Status.swift */; };
 		7713E8482752E2A900724C8B /* SelectGroupBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7713E8472752E2A900724C8B /* SelectGroupBottomSheetViewController.swift */; };
+		7727B60E2B05F966005847BC /* safeAreaInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7727B60D2B05F966005847BC /* safeAreaInset.swift */; };
 		7734D5AA27719520004360E4 /* CardShareBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7734D5A927719520004360E4 /* CardShareBottomSheetViewController.swift */; };
 		7734D5B427778EFB004360E4 /* HarmonyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7734D5B327778EFB004360E4 /* HarmonyResponse.swift */; };
 		7734D5B627779EF0004360E4 /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7734D5B527779EF0004360E4 /* QRCodeView.swift */; };
@@ -371,6 +372,7 @@
 		7705CF3F2752C844005195DF /* CardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CardView.xib; sourceTree = "<group>"; };
 		770E58852778A78900498C2E /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
 		7713E8472752E2A900724C8B /* SelectGroupBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectGroupBottomSheetViewController.swift; sourceTree = "<group>"; };
+		7727B60D2B05F966005847BC /* safeAreaInset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = safeAreaInset.swift; sourceTree = "<group>"; };
 		7734D5A927719520004360E4 /* CardShareBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardShareBottomSheetViewController.swift; sourceTree = "<group>"; };
 		7734D5B327778EFB004360E4 /* HarmonyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarmonyResponse.swift; sourceTree = "<group>"; };
 		7734D5B527779EF0004360E4 /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
@@ -919,6 +921,7 @@
 				77A4D5EA29AE20CB00367B7C /* makeVibrate.swift */,
 				77A4D60729BD74BC00367B7C /* getClassName.swift */,
 				77A4D60929C09D2900367B7C /* calculateTime.swift */,
+				7727B60D2B05F966005847BC /* safeAreaInset.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2092,6 +2095,7 @@
 				F8915A22275728F20013D609 /* SelectBirthBottomViewController.swift in Sources */,
 				F8FC438626C01CDD0033E151 /* AppDelegate.swift in Sources */,
 				F8915A23275728F20013D609 /* SelectMBTIBottomViewController.swift in Sources */,
+				7727B60E2B05F966005847BC /* safeAreaInset.swift in Sources */,
 				393E3345275F69EE00965BBF /* SplashViewController.swift in Sources */,
 				F8C83FB8272F9E3F0009DF0D /* UtilAPI.swift in Sources */,
 				77A196C729F661DC000DEF49 /* NearbyAPI.swift in Sources */,

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
@@ -138,7 +138,7 @@
                                             </button>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="yy9-XM-5Du">
                                                 <rect key="frame" x="24" y="783.66666666666652" width="327" height="716.33333333333348"/>
-                                                <color key="backgroundColor" name="AccentColor"/>
+                                                <color key="backgroundColor" name="background"/>
                                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="PqA-Jt-42i">
                                                     <size key="itemSize" width="128" height="128"/>
                                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -168,7 +168,7 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" name="harmonyGreen"/>
+                                        <color key="backgroundColor" name="background"/>
                                         <constraints>
                                             <constraint firstAttribute="bottom" secondItem="yy9-XM-5Du" secondAttribute="bottom" id="8Ui-ah-S5t"/>
                                             <constraint firstItem="0P6-1k-dQm" firstAttribute="top" secondItem="lcZ-YD-xcC" secondAttribute="top" constant="20" id="9PO-Qa-LgX"/>
@@ -242,17 +242,11 @@
         <image name="icnInformation" width="16" height="16"/>
         <image name="iconArrow" width="24" height="24"/>
         <image name="iconOption" width="24" height="24"/>
-        <namedColor name="AccentColor">
-            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <namedColor name="background">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="card">
             <color red="0.96470588235294119" green="0.96862745098039216" blue="0.97647058823529409" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="harmonyGreen">
-            <color red="0.43137254901960786" green="0.94117647058823528" blue="0.65098039215686276" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="primary">
             <color red="0.074509803921568626" green="0.078431372549019607" blue="0.086274509803921567" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -68,7 +68,7 @@
                                 <rect key="frame" x="0.0" y="100" width="375" height="1366"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lcZ-YD-xcC">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1200"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1500"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0P6-1k-dQm">
                                                 <rect key="frame" x="24" y="20" width="327" height="540"/>
@@ -102,6 +102,9 @@
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3LS-7h-1h3">
                                                 <rect key="frame" x="24" y="624" width="327" height="54"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="54" id="FBx-Ob-CVd"/>
+                                                </constraints>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 <state key="normal" image="btnMainMatch"/>
                                                 <connections>
@@ -134,7 +137,7 @@
                                                 </connections>
                                             </button>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="yy9-XM-5Du">
-                                                <rect key="frame" x="24" y="783.66666666666663" width="327" height="416.33333333333337"/>
+                                                <rect key="frame" x="24" y="783.66666666666652" width="327" height="716.33333333333348"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
                                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="PqA-Jt-42i">
                                                     <size key="itemSize" width="128" height="128"/>
@@ -180,7 +183,7 @@
                                             <constraint firstItem="yy9-XM-5Du" firstAttribute="leading" secondItem="lcZ-YD-xcC" secondAttribute="leading" constant="24" id="axu-B2-QuU"/>
                                             <constraint firstItem="9XU-CD-Avs" firstAttribute="leading" secondItem="lcZ-YD-xcC" secondAttribute="leading" constant="24" id="eAg-su-QVd"/>
                                             <constraint firstItem="vSp-1W-l8j" firstAttribute="leading" secondItem="lcZ-YD-xcC" secondAttribute="leading" id="giK-4V-h0G"/>
-                                            <constraint firstAttribute="height" priority="250" constant="1200" id="hZH-rn-2XI"/>
+                                            <constraint firstAttribute="height" constant="1500" id="hZH-rn-2XI"/>
                                             <constraint firstAttribute="trailing" secondItem="vSp-1W-l8j" secondAttribute="trailing" id="mvv-0B-Nm0"/>
                                             <constraint firstItem="HBn-DL-xMI" firstAttribute="top" secondItem="vSp-1W-l8j" secondAttribute="bottom" constant="31" id="nR9-VO-NB7"/>
                                             <constraint firstItem="9XU-CD-Avs" firstAttribute="top" secondItem="vSp-1W-l8j" secondAttribute="bottom" constant="30" id="oOH-rF-IiA"/>
@@ -218,6 +221,7 @@
                     <connections>
                         <outlet property="backButton" destination="ppy-17-v7q" id="mdc-dd-yGB"/>
                         <outlet property="backView" destination="lcZ-YD-xcC" id="SMc-KV-3jH"/>
+                        <outlet property="backViewHeight" destination="hZH-rn-2XI" id="Bs7-zZ-rLa"/>
                         <outlet property="cardView" destination="0P6-1k-dQm" id="qGN-9y-K4Y"/>
                         <outlet property="idLabel" destination="J0e-kR-6Zc" id="4il-d0-UMv"/>
                         <outlet property="idStackView" destination="yM7-jk-cSi" id="W9m-Jo-mDr"/>

--- a/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
+++ b/NADA-iOS-forRelease/Resouces/Storyboards/CardDetail/CardDetail.storyboard
@@ -139,7 +139,7 @@
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="yy9-XM-5Du">
                                                 <rect key="frame" x="24" y="783.66666666666652" width="327" height="716.33333333333348"/>
                                                 <color key="backgroundColor" name="AccentColor"/>
-                                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="PqA-Jt-42i">
+                                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="PqA-Jt-42i">
                                                     <size key="itemSize" width="128" height="128"/>
                                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>

--- a/NADA-iOS-forRelease/Resouces/Utils/safeAreaInset.swift
+++ b/NADA-iOS-forRelease/Resouces/Utils/safeAreaInset.swift
@@ -1,0 +1,40 @@
+//
+//  safeAreaInset.swift
+//  NADA-iOS-forRelease
+//
+//  Created by Yi Joon Choi on 11/16/23.
+//
+
+import Foundation
+import UIKit
+
+public let STATUS_HEIGHT = UIApplication.shared.statusBarFrame.size.height   // 상태바 높이
+
+/**
+ # safeAreaTopInset
+ - Note: 현재 디바이스의 safeAreaTopInset값 반환
+ */
+func safeAreaTopInset() -> CGFloat {
+    if #available(iOS 11.0, *) {
+        let window = UIApplication.shared.keyWindow
+        let topPadding = window?.safeAreaInsets.top
+        return topPadding ?? STATUS_HEIGHT
+    } else {
+        return STATUS_HEIGHT
+    }
+}
+
+/**
+ # safeAreaBottomInset
+ - Note: 현재 디바이스의 safeAreaBottomInset값 반환
+ */
+func safeAreaBottomInset() -> CGFloat {
+    if #available(iOS 11.0, *) {
+        let window = UIApplication.shared.keyWindow
+        let bottomPadding = window?.safeAreaInsets.bottom
+        return bottomPadding ??  0.0
+    } else {
+        return 0.0
+    }
+}
+

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -97,7 +97,6 @@ class CardDetailViewController: UIViewController {
     private let emptyView = UIImageView(image: UIImage(named: "imgSendTagEmpty")).then {
         $0.isHidden = true
         $0.contentMode = .scaleAspectFit
-        $0.backgroundColor = .systemPink
     }
     
     public var cardDataModel: Card?
@@ -431,10 +430,9 @@ extension CardDetailViewController {
                         owner.backViewHeight.constant = CGFloat(790 + 281)
                     } else {
                         self.emptyView.isHidden = true
-                        owner.backViewHeight.constant = CGFloat(790 + (data.count * 60) + 21)
+                        owner.backViewHeight.constant = CGFloat(790 + (data.count * 60) + 20)
                     }
                     owner.backView.layoutIfNeeded()
-                    owner.scrollView.layoutIfNeeded()
                 }
             case .requestErr:
                 print("receivedTagFetchWithAPI - requestErr")

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -430,7 +430,7 @@ extension CardDetailViewController {
                         owner.backViewHeight.constant = CGFloat(790 + 281)
                     } else {
                         self.emptyView.isHidden = true
-                        owner.backViewHeight.constant = CGFloat(790 + (data.count * 60) + 20)
+                        owner.backViewHeight.constant = CGFloat(845 + (data.count * 60)) - safeAreaBottomInset()
                     }
                     owner.backView.layoutIfNeeded()
                 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/CardDetail/CardDetailViewController.swift
@@ -79,6 +79,7 @@ class CardDetailViewController: UIViewController {
     @IBOutlet weak var receiveTitleLabel: UILabel!
     @IBOutlet weak var sendButton: UIButton!
     @IBOutlet weak var tagCollectionView: UICollectionView!
+    @IBOutlet weak var backViewHeight: NSLayoutConstraint!
     
     private var helpDimmedView = UIView().then {
         $0.backgroundColor = .black.withAlphaComponent(0.4)
@@ -96,6 +97,7 @@ class CardDetailViewController: UIViewController {
     private let emptyView = UIImageView(image: UIImage(named: "imgSendTagEmpty")).then {
         $0.isHidden = true
         $0.contentMode = .scaleAspectFit
+        $0.backgroundColor = .systemPink
     }
     
     public var cardDataModel: Card?
@@ -171,7 +173,7 @@ extension CardDetailViewController {
     private func setLayout() {
         helpView.addSubview(helpTextView)
         helpDimmedView.addSubview(helpView)
-        view.addSubviews([helpDimmedView, emptyView])
+        backView.addSubviews([helpDimmedView, emptyView])
         
         helpDimmedView.snp.makeConstraints { make in
             make.top.leading.trailing.bottom.equalTo(view)
@@ -187,7 +189,10 @@ extension CardDetailViewController {
             make.leading.equalToSuperview().inset(10)
         }
         emptyView.snp.makeConstraints { make in
-            make.top.leading.trailing.bottom.equalTo(tagCollectionView)
+            make.centerX.equalToSuperview()
+            make.top.equalTo(receiveTitleLabel.snp.bottom).offset(37)
+            make.leading.equalToSuperview().inset(105)
+            make.bottom.equalToSuperview().inset(20)
         }
     }
     
@@ -421,14 +426,15 @@ extension CardDetailViewController {
                 if let data = response.data {
                     owner.receivedTags = data
                     owner.tagCollectionView.reloadData()
-                    owner.scrollView.layoutIfNeeded()
                     if data.isEmpty {
                         self.emptyView.isHidden = false
+                        owner.backViewHeight.constant = CGFloat(790 + 281)
                     } else {
                         self.emptyView.isHidden = true
+                        owner.backViewHeight.constant = CGFloat(790 + (data.count * 60) + 21)
                     }
-//                    self.backView.layoutIfNeeded()
-//                    self.scrollView.updateContentSize()
+                    owner.backView.layoutIfNeeded()
+                    owner.scrollView.layoutIfNeeded()
                 }
             case .requestErr:
                 print("receivedTagFetchWithAPI - requestErr")
@@ -483,7 +489,7 @@ extension CardDetailViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         
-        return UIEdgeInsets(top: 0, left: 0, bottom: 55, right: 0)
+        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
 }
 
@@ -517,25 +523,4 @@ extension CardDetailViewController: UICollectionViewDataSource {
 
 extension CardDetailViewController: UICollectionViewDelegate {
     
-}
-
-extension UIScrollView {
-    func updateContentSize() {
-        let unionCalculatedTotalRect = recursiveUnionInDepthFor(view: self)
-        
-        // 계산된 크기로 컨텐츠 사이즈 설정
-        self.contentSize = CGSize(width: self.frame.width, height: unionCalculatedTotalRect.height)
-    }
-    
-    private func recursiveUnionInDepthFor(view: UIView) -> CGRect {
-        var totalRect: CGRect = .zero
-        
-        // 모든 자식 View의 컨트롤의 크기를 재귀적으로 호출하며 최종 영역의 크기를 설정
-        for subView in view.subviews {
-            totalRect = totalRect.union(recursiveUnionInDepthFor(view: subView))
-        }
-        
-        // 최종 계산 영역의 크기를 반환
-        return totalRect.union(view.frame)
-    }
 }

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -290,8 +290,9 @@ extension GroupViewController: UICollectionViewDelegate {
                 if isInfiniteScroll {
                     isInfiniteScroll = false
                     offset += 1
+                    print("🔥offset: ", offset)
                     cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: offset,
-                                                                                          pageSize: 10,
+                                                                                          pageSize: 12,
                                                                                           groupName: serverGroups?[self.selectedRow] ?? "")) {
                         self.isInfiniteScroll = true
                     }
@@ -379,9 +380,8 @@ extension GroupViewController: UICollectionViewDataSource {
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.cardListInGroupWithAPI(cardListInGroupRequest:
-                                                CardListInGroupRequest(pageNo: 1, pageSize: 10, groupName: self.groupName)) {
+                                                CardListInGroupRequest(pageNo: 1, pageSize: 6, groupName: self.groupName))
                     self.isInfiniteScroll = true
-                }
             }
         case cardsCollectionView:
             Analytics.logEvent(Tracking.Event.touchGroupCard + String(indexPath.row+1), parameters: nil)

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Group/GroupViewController.swift
@@ -28,8 +28,8 @@ class GroupViewController: UIViewController {
     // 네비게이션 바
     @IBAction func presentToAddWithIdView(_ sender: Any) {
         let nextVC = AddWithIdBottomSheetViewController()
-                    .setTitle("ID로 명함 추가")
-                    .setHeight(184)
+            .setTitle("ID로 명함 추가")
+            .setHeight(184)
         nextVC.modalPresentationStyle = .overFullScreen
         self.present(nextVC, animated: false, completion: nil)
     }
@@ -38,10 +38,10 @@ class GroupViewController: UIViewController {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .denied:
             makeOKCancelAlert(title: "카메라 권한이 허용되어 있지 않아요.",
-                        message: "QR코드 인식을 위해 카메라 권한이 필요합니다. 앱 설정으로 이동해 허용해 주세요.",
-                        okAction: { _ in UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)},
-                        cancelAction: nil,
-                        completion: nil)
+                              message: "QR코드 인식을 위해 카메라 권한이 필요합니다. 앱 설정으로 이동해 허용해 주세요.",
+                              okAction: { _ in UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)},
+                              cancelAction: nil,
+                              completion: nil)
         case .authorized:
             guard let nextVC = UIStoryboard.init(name: Const.Storyboard.Name.qrScan, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.qrScanViewController) as? QRScanViewController else { return }
             nextVC.modalPresentationStyle = .overFullScreen
@@ -147,7 +147,7 @@ extension GroupViewController {
         groupCollectionView.dataSource = self
         cardsCollectionView.delegate = self
         cardsCollectionView.dataSource = self
-         
+        
         groupCollectionView.register(GroupCollectionViewCell.nib(), forCellWithReuseIdentifier: Const.Xib.groupCollectionViewCell)
         cardsCollectionView.register(FrontCardCell.nib(), forCellWithReuseIdentifier: FrontCardCell.className)
         cardsCollectionView.register(FanFrontCardCell.nib(), forCellWithReuseIdentifier: FanFrontCardCell.className)
@@ -203,12 +203,11 @@ extension GroupViewController {
                     self.serverGroups = group
                     self.groupCollectionView.reloadData()
                     print("selectedRow: ", self.selectedRow)
-                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: 1, pageSize: 6, groupName: self.groupName)) {
-                        if self.frontCards?.count != 0 {
-                            self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
-                        }
-                        self.isInfiniteScroll = true
+                    self.cardListInGroupWithAPI(cardListInGroupRequest: CardListInGroupRequest(pageNo: 1, pageSize: 6, groupName: self.groupName)) 
+                    if self.frontCards?.count != 0 {
+                        self.cardsCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
                     }
+                    self.isInfiniteScroll = true
                 }
                 print("groupListFetchWithAPI - success")
             case .requestErr(let message):
@@ -266,7 +265,7 @@ extension GroupViewController {
                     nextVC.cardDataModel = card
                     nextVC.groupName = self.groupName
                     nextVC.serverGroups = self.serverGroups
-//                    nextVC.cardType = card.cardType 
+                    //                    nextVC.cardType = card.cardType 
                     self.navigationController?.pushViewController(nextVC, animated: true)
                 }
             case .requestErr(let message):
@@ -381,7 +380,7 @@ extension GroupViewController: UICollectionViewDataSource {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.cardListInGroupWithAPI(cardListInGroupRequest:
                                                 CardListInGroupRequest(pageNo: 1, pageSize: 6, groupName: self.groupName))
-                    self.isInfiniteScroll = true
+                self.isInfiniteScroll = true
             }
         case cardsCollectionView:
             Analytics.logEvent(Tracking.Event.touchGroupCard + String(indexPath.row+1), parameters: nil)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#673

🌱 작업한 내용
- 네.. 결국 방정식을 만들었어요
- 방정식을 만들 때 애먹은 내용 -> 컬렉션뷰 셀의 사이즈를 맞게 입력했는데도 자꾸 태그가 잘리는 거 있죠.. 그래서 뭐가 문제인가 봤더니 제가 estimated Size를 auto로 하고 있더라고요... none으로 설정해야 flowLayout에서 설정한 셀의 사이즈가 나온다!
- #671 이슈랑 겹친 부분에서 수정한 내용이 있어서 PR 차례 차례 합치고 충돌 해결하고 머지 하겠습니당!

- 아 그리고 이 이슈에서 group 뷰컨 무한 스크롤 이슈도 고쳤습니다!
- completion이 제대로 행해지지 않아서 infiniteScroll이 true로 바뀌지 못하고 있었어요... 그래서 한번 무한스크롤이 먹으면 그 다음엔 안먹혔던...

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|왔다 태그|<img src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69078056/22c8149f-d034-4a07-9af0-1d0ccb926585" width ="250">|


## 📮 관련 이슈
- Resolved: #673 
