### PR TITLE
fix: 밸런스 게임 GA 수정 (#682)

### DIFF
--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
@@ -180,11 +180,35 @@ extension BackCardCreationCollectionViewCell: UICollectionViewDelegate {
         
         switch cardType {
         case .basic:
-            Analytics.logEvent(Tracking.Event.touchBasicTasteInfo + (tasteInfo?[indexPath.item] ?? ""), parameters: nil)
+            if collectionView == firstTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchBasicTasteInfo + (tasteInfo?[indexPath.item] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == secondTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchBasicTasteInfo + (tasteInfo?[indexPath.item + 2] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == thirdTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchBasicTasteInfo + (tasteInfo?[indexPath.item + 4] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == fourthTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchBasicTasteInfo + (tasteInfo?[indexPath.item + 6] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            }
         case .company:
-            Analytics.logEvent(Tracking.Event.touchCompanyTasteInfo + (tasteInfo?[indexPath.item] ?? ""), parameters: nil)
+            if collectionView == firstTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchCompanyTasteInfo + (tasteInfo?[indexPath.item] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == secondTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchCompanyTasteInfo + (tasteInfo?[indexPath.item + 2] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == thirdTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchCompanyTasteInfo + (tasteInfo?[indexPath.item + 4] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == fourthTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchCompanyTasteInfo + (tasteInfo?[indexPath.item + 6] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            }
         case .fan:
-            Analytics.logEvent(Tracking.Event.touchFanTasteInfo + (tasteInfo?[indexPath.item] ?? ""), parameters: nil)
+            if collectionView == firstTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchFanTasteInfo + (tasteInfo?[indexPath.item] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == secondTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchFanTasteInfo + (tasteInfo?[indexPath.item + 2] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == thirdTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchFanTasteInfo + (tasteInfo?[indexPath.item + 4] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            } else if collectionView == fourthTasteCollectionView {
+                Analytics.logEvent(Tracking.Event.touchFanTasteInfo + (tasteInfo?[indexPath.item + 6] ?? "").replacingOccurrences(of: " ", with: "_"), parameters: nil)
+            }
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #682

🌱 작업한 내용
- 서버에서 내려주는 띄어쓰기 포함하는 밸런스 선택지는 트래킹 전송이 안되서 문자를 대체하였습니다.
`빵 먹기` -> `빵_먹기`

## 📮 관련 이슈
- Resolved: #682
