### PR TITLE
chore: Required reason API 를 사용하는 SDK 사용 이유 명시는 애플 정책에 대응 (#696)

### DIFF
--- a/NADA-iOS-forRelease.xcodeproj/project.pbxproj
+++ b/NADA-iOS-forRelease.xcodeproj/project.pbxproj
@@ -1689,6 +1689,7 @@
 				F8FC43BD26C0244D0033E151 /* ShellScript */,
 				F838B673298E5C5400D84340 /* Embed Foundation Extensions */,
 				3DFB37457B9A5C839910082B /* [CP] Embed Pods Frameworks */,
+				A4510748121788FC05B629DB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1885,6 +1886,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A4510748121788FC05B629DB /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NADA-iOS-forRelease/Pods-NADA-iOS-forRelease-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8FC43BD26C0244D0033E151 /* ShellScript */ = {

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/BackCardCreationCollectionViewCell.swift
@@ -59,7 +59,7 @@ class BackCardCreationCollectionViewCell: UICollectionViewCell {
 
 extension BackCardCreationCollectionViewCell {
     private func setUI() {
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
+        IQKeyboardManager.shared.resignOnTouchOutside = true
         
         initCollectionViewList()
         

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/CompanyFrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/CompanyFrontCardCreationCollectionViewCell.swift
@@ -71,7 +71,7 @@ class CompanyFrontCardCreationCollectionViewCell: UICollectionViewCell {
 
 extension CompanyFrontCardCreationCollectionViewCell {
     private func setUI() {
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
+        IQKeyboardManager.shared.resignOnTouchOutside = true
         
         initUITextFieldList()
         backgroundSettingCollectionView.showsHorizontalScrollIndicator = false

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FanFrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FanFrontCardCreationCollectionViewCell.swift
@@ -91,7 +91,7 @@ class FanFrontCardCreationCollectionViewCell: UICollectionViewCell {
 
 extension FanFrontCardCreationCollectionViewCell {
     private func setUI() {
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
+        IQKeyboardManager.shared.resignOnTouchOutside = true
         
         initUITextFieldList()
         backgroundSettingCollectionView.showsHorizontalScrollIndicator = false

--- a/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
+++ b/NADA-iOS-forRelease/Sources/Cells/CreationCard/FrontCardCreationCollectionViewCell.swift
@@ -71,7 +71,7 @@ class FrontCardCreationCollectionViewCell: UICollectionViewCell {
 
 extension FrontCardCreationCollectionViewCell {
     private func setUI() {
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
+        IQKeyboardManager.shared.resignOnTouchOutside = true
         
         initUITextFieldList()
         backgroundSettingCollectionView.showsHorizontalScrollIndicator = false

--- a/NADA-iOS-forRelease/Sources/SceneDelegate.swift
+++ b/NADA-iOS-forRelease/Sources/SceneDelegate.swift
@@ -54,7 +54,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         IQKeyboardManager.shared.enable = true
         IQKeyboardManager.shared.enableAutoToolbar = false
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = true
+        IQKeyboardManager.shared.resignOnTouchOutside = true
         
         let isDark = defaults.bool(forKey: Const.UserDefaultsKey.darkModeState)
         

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddGroupBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddGroupBottomSheetViewController.swift
@@ -50,7 +50,7 @@ class AddGroupBottomSheetViewController: CommonBottomSheetViewController, UIText
         
         setupUI()
         addGroupTextField.delegate = self
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = false
+        IQKeyboardManager.shared.resignOnTouchOutside = false
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/AddWithIdBottomSheetViewController.swift
@@ -47,7 +47,7 @@ class AddWithIdBottomSheetViewController: CommonBottomSheetViewController, UITex
 
         setupUI()
         addWithIdTextField.delegate = self
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = false
+        IQKeyboardManager.shared.resignOnTouchOutside = false
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/BottomSheet/GroupNameEditBottomSheetViewController.swift
@@ -38,7 +38,7 @@ class GroupNameEditBottomSheetViewController: CommonBottomSheetViewController, U
         
         setupUI()
         addGroupTextField.delegate = self
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = false
+        IQKeyboardManager.shared.resignOnTouchOutside = false
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
+++ b/NADA-iOS-forRelease/Sources/ViewControllers/Tag/SendTagSheetVC.swift
@@ -152,7 +152,7 @@ class SendTagSheetVC: UIViewController {
         super.viewWillAppear(animated)
         
         IQKeyboardManager.shared.enable = false
-        IQKeyboardManager.shared.shouldResignOnTouchOutside = false
+        IQKeyboardManager.shared.resignOnTouchOutside = false
     }
     
     override func viewIsAppearing(_ animated: Bool) {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,135 +1,143 @@
 PODS:
-  - Alamofire (5.8.1)
-  - Firebase/Analytics (10.17.0):
+  - Alamofire (5.9.1)
+  - Firebase/Analytics (10.24.0):
     - Firebase/Core
-  - Firebase/Core (10.17.0):
+  - Firebase/Core (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.17.0)
-  - Firebase/CoreOnly (10.17.0):
-    - FirebaseCore (= 10.17.0)
-  - Firebase/DynamicLinks (10.17.0):
+    - FirebaseAnalytics (~> 10.24.0)
+  - Firebase/CoreOnly (10.24.0):
+    - FirebaseCore (= 10.24.0)
+  - Firebase/DynamicLinks (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.17.0)
-  - Firebase/Messaging (10.17.0):
+    - FirebaseDynamicLinks (~> 10.24.0)
+  - Firebase/Messaging (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.17.0)
-  - FirebaseAnalytics (10.17.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.17.0)
+    - FirebaseMessaging (~> 10.24.0)
+  - FirebaseAnalytics (10.24.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.24.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.17.0):
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseAnalytics/AdIdSupport (10.24.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.17.0)
+    - GoogleAppMeasurement (= 10.24.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (10.17.0):
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseCore (10.24.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.17.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreInternal (10.24.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseDynamicLinks (10.17.0):
+  - FirebaseDynamicLinks (10.24.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseInstallations (10.17.0):
+  - FirebaseInstallations (10.24.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.17.0):
+  - FirebaseMessaging (10.24.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleDataTransport (~> 9.2)
+    - GoogleDataTransport (~> 9.3)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FlexLayout (2.0.03)
-  - Google-Mobile-Ads-SDK (10.12.0):
-    - GoogleAppMeasurement (< 11.0, >= 7.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FlexLayout (2.0.07)
+  - Google-Mobile-Ads-SDK (11.3.0):
     - GoogleUserMessagingPlatform (>= 1.1)
-  - GoogleAppMeasurement (10.17.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.17.0)
+  - GoogleAppMeasurement (10.24.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.24.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.17.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.17.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (10.24.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.24.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.17.0):
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.24.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleDataTransport (9.2.5):
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUserMessagingPlatform (2.1.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.6):
+  - GoogleUserMessagingPlatform (2.3.0)
+  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.6):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (7.13.0):
+    - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.6):
+  - GoogleUtilities/Logger (7.13.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.11.6):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/MethodSwizzler (7.13.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.11.6):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.6)"
-  - GoogleUtilities/Reachability (7.11.6):
+  - "GoogleUtilities/NSData+zlib (7.13.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.0)
+  - GoogleUtilities/Reachability (7.13.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.11.6):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
-  - IQKeyboardManagerSwift (6.5.16)
-  - KakaoSDKAuth (2.18.2):
-    - KakaoSDKCommon (= 2.18.2)
-  - KakaoSDKCommon (2.18.2):
-    - KakaoSDKCommon/Common (= 2.18.2)
-    - KakaoSDKCommon/Network (= 2.18.2)
-  - KakaoSDKCommon/Common (2.18.2)
-  - KakaoSDKCommon/Network (2.18.2):
-    - Alamofire (~> 5.1)
-    - KakaoSDKCommon/Common (= 2.18.2)
-  - KakaoSDKUser (2.18.2):
-    - KakaoSDKAuth (= 2.18.2)
-  - Kingfisher (7.10.0)
-  - lottie-ios (4.3.3)
+    - GoogleUtilities/Privacy
+  - IQKeyboardManagerSwift (7.0.2)
+  - KakaoSDKAuth (2.22.0):
+    - KakaoSDKCommon (= 2.22.0)
+  - KakaoSDKCommon (2.22.0):
+    - KakaoSDKCommon/Common (= 2.22.0)
+    - KakaoSDKCommon/Network (= 2.22.0)
+  - KakaoSDKCommon/Common (2.22.0)
+  - KakaoSDKCommon/Network (2.22.0):
+    - Alamofire (~> 5.9.0)
+    - KakaoSDKCommon/Common (= 2.22.0)
+  - KakaoSDKUser (2.22.0):
+    - KakaoSDKAuth (= 2.22.0)
+  - Kingfisher (7.11.0)
+  - lottie-ios (4.4.2)
   - Moya/Core (15.0.0):
     - Alamofire (~> 5.0)
   - Moya/RxSwift (15.0.0):
     - Moya/Core
     - RxSwift (~> 6.0)
-  - nanopb (2.30909.1):
-    - nanopb/decode (= 2.30909.1)
-    - nanopb/encode (= 2.30909.1)
-  - nanopb/decode (2.30909.1)
-  - nanopb/encode (2.30909.1)
+  - nanopb (2.30910.0):
+    - nanopb/decode (= 2.30910.0)
+    - nanopb/encode (= 2.30910.0)
+  - nanopb/decode (2.30910.0)
+  - nanopb/encode (2.30910.0)
   - NVActivityIndicatorView (5.1.1):
     - NVActivityIndicatorView/Base (= 5.1.1)
   - NVActivityIndicatorView/Base (5.1.1)
   - PinLayout (1.10.5)
-  - PromisesObjC (2.3.1)
+  - PromisesObjC (2.4.0)
   - PryntTrimmerView (4.0.2)
   - RxAlamofire (6.1.1):
     - RxAlamofire/Core (= 6.1.1)
@@ -146,9 +154,9 @@ PODS:
     - RxSwift (= 6.6.0)
   - RxSwift (6.6.0)
   - SkeletonView (1.30.4)
-  - SnapKit (5.6.0)
+  - SnapKit (5.7.1)
   - SteviaLayout (5.1.2)
-  - SwiftLint (0.53.0)
+  - SwiftLint (0.54.0)
   - Then (3.0.0)
   - VerticalCardSwiper (2.3.1)
   - YPImagePicker (5.2.2):
@@ -223,31 +231,31 @@ SPEC REPOS:
     - YPImagePicker
 
 SPEC CHECKSUMS:
-  Alamofire: 3ca42e259043ee0dc5c0cdd76c4bc568b8e42af7
-  Firebase: f4ac0b02927af9253ae094d23deecf0890da7374
-  FirebaseAnalytics: b9284f9fff10157a843e0422e908711f7bf3b9f2
-  FirebaseCore: 534544dd98cabcf4bf8598d88ec683b02319a528
-  FirebaseCoreInternal: 2cf9202e226e3f78d2bf6d56c472686b935bfb7f
-  FirebaseDynamicLinks: 66878206d55d4aba6e63744f57151a80d76e472e
-  FirebaseInstallations: 9387bf15abfc69a714f54e54f74a251264fdb79b
-  FirebaseMessaging: 1367b28c0c83a63072af4a711328fcc2e6899902
-  FlexLayout: 30999df7d5e5b8878af1f9691313a92edad91e17
-  Google-Mobile-Ads-SDK: 976fdf273815674eed30b8aafffedb3c25b055e4
-  GoogleAppMeasurement: 4dcddfc7f102825c1c4e6422cb35567b101881a7
-  GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
-  GoogleUserMessagingPlatform: dce302b8f1b84d6e945812ee7a15c3f65a102cbf
-  GoogleUtilities: 202e7a9f5128accd11160fb9c19612de1911aa19
-  IQKeyboardManagerSwift: 12d89768845bb77b55cc092ecc2b1f9370f06b76
-  KakaoSDKAuth: 3daf72ec463876e0fe6d0d37c7d6b0b2729169f1
-  KakaoSDKCommon: 516f68bc6b223ed502c34a362d6ecc9145e0dcc0
-  KakaoSDKUser: 5b0826033381d314f550dd90fbf70d3612044ad6
-  Kingfisher: a18f05d3b6d37d8650ee4a3e61d57a28fc6207f6
-  lottie-ios: 25e7b2675dad5c3ddad369ac9baab03560c5bfdd
+  Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
+  Firebase: 91fefd38712feb9186ea8996af6cbdef41473442
+  FirebaseAnalytics: b5efc493eb0f40ec560b04a472e3e1a15d39ca13
+  FirebaseCore: 11dc8a16dfb7c5e3c3f45ba0e191a33ac4f50894
+  FirebaseCoreInternal: bcb5acffd4ea05e12a783ecf835f2210ce3dc6af
+  FirebaseDynamicLinks: 96e59750f0c383258c35f5b20e3c18e14b57933a
+  FirebaseInstallations: 8f581fca6478a50705d2bd2abd66d306e0f5736e
+  FirebaseMessaging: 4d52717dd820707cc4eadec5eb981b4832ec8d5d
+  FlexLayout: a1facfeac0e0b397a74cfb1d83d1ba93b98f7c52
+  Google-Mobile-Ads-SDK: 301a16c461c331ba34ff4dab40a22ab7c147af61
+  GoogleAppMeasurement: f3abf08495ef2cba7829f15318c373b8d9226491
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
+  GoogleUserMessagingPlatform: b1ad7bb1ee3ce64749d4fec24f667b36e45c396c
+  GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
+  IQKeyboardManagerSwift: d338c11a896e9f29603443700c4567e32f830c22
+  KakaoSDKAuth: 569b377eda622d93d4575240b8031cd658163eef
+  KakaoSDKCommon: d57127c339fc79e73aa8b236a4c77211c29924f1
+  KakaoSDKUser: 043bcd7e91454ebf3bf64f150c430e6f65f0a08d
+  Kingfisher: b9c985d864d43515f404f1ef4a8ce7d802ace3ac
+  lottie-ios: 4445b0bdb583c7a5325529f62246d311ee85fcd0
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
-  nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
+  nanopb: 438bc412db1928dac798aa6fd75726007be04262
   NVActivityIndicatorView: 1f6c5687f1171810aa27a3296814dc2d7dec3667
   PinLayout: f6c2b63a5a5b24864064e1d15c67de41b4e74748
-  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PryntTrimmerView: 6a43cc90df5d99addeabd33d4ba09b1365322130
   RxAlamofire: beb75a1c452d0de225651db4903f5d29d034a620
   RxCocoa: 44a80de90e25b739b5aeaae3c8c371a32e3343cc
@@ -255,9 +263,9 @@ SPEC CHECKSUMS:
   RxRelay: 45eaa5db8ee4fb50e5ebd57deec0159e97fa51e6
   RxSwift: a4b44f7d24599f674deebd1818eab82e58410632
   SkeletonView: 5a050f6411e697abd4cda0a8d767013399dccd69
-  SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
+  SnapKit: d612e99e678a2d3b95bf60b0705ed0a35c03484a
   SteviaLayout: 05424e528d643657d39ce72c786e4adf13cfc5f2
-  SwiftLint: 5ce4d6a8ff83f1b5fd5ad5dbf30965d35af65e44
+  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   Then: 844265ae87834bbe1147d91d5d41a404da2ec27d
   VerticalCardSwiper: 68df635b354500f86934ea044ade37a264c044c6
   YPImagePicker: afc81b3cffab05a6e7261c5daf80dc31b4e917b4


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #696

🌱 작업한 내용
- sdk 업데이트
- pod update
- IQKeyboardManager renamed 된 메서드 반영하였습니다!

### 🚨 참고사항
- Required reason API 를 사용하는 SDK 는 Privacy Manifest 에 API 사용 이유를 명시하도록 하는 정책에 대응

<img width="600" alt="스크린샷 2024-04-13 오후 12 53 55" src="https://github.com/TeamNADA/NADA-iOS-ForRelease/assets/69136340/e236e2fe-887b-40fc-89e8-cd8de31b5ac3">



## 📮 관련 이슈
- Resolved: #696
